### PR TITLE
fix for ckd groups 

### DIFF
--- a/analysis/preprocess/preprocess_data.R
+++ b/analysis/preprocess/preprocess_data.R
@@ -80,7 +80,7 @@ df <- df %>%
 
 # specifically format sub_bin_ckd as a factor
 
-df$sub_bin_ckd = factor(df$sub_bin_ckd, levels = c(TRUE, FALSE), labels = c("gen","ckd_hist"))
+df$sub_bin_ckd = factor(df$sub_bin_ckd, levels = c(TRUE, FALSE), labels = c("ckd_hist","gen"))
 
 # Overwrite vaccination information for dummy data and vax cohort only --
 


### PR DESCRIPTION
fixed issue with populations being divided into the flipped categories - treated it as a 0/1 due to old version of code, and therefore the T/F labels were backwards.