### PR TITLE
Add in Stata models, update to v5

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -10,7 +10,7 @@ library(dplyr)
 # Specify defaults -------------------------------------------------------------
 
 defaults_list <- list(
-  version = "3.0",
+  version = "5.0",
   expectations = list(population_size = 5000L)
 )
 

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -10,8 +10,7 @@ library(dplyr)
 # Specify defaults -------------------------------------------------------------
 
 defaults_list <- list(
-  version = "5.0",
-  expectations = list(population_size = 5000L)
+  version = "5.0"
 )
 
 active_analyses <- read_rds("lib/active_analyses.rds")
@@ -84,6 +83,8 @@ stata_models <- unique(c(
 
 stata <- active_analyses[active_analyses$name %in% stata_models, ]
 
+not_stata_models <- setdiff(active_analyses$name, stata_models)
+not_stata <- active_analyses[!active_analyses$name %in% stata_models, ]
 
 # Create generic action function -----------------------------------------------
 
@@ -424,7 +425,11 @@ make_model_output <- function(subgroup) {
       run = "r:v2 analysis/make_output/make_model_output.R",
       arguments = c(subgroup),
       needs = as.list(c(
-        paste0(
+        if(
+          length(not_stata_models) > 0 &&
+                 any(str_detect(not_stata$analysis, subgroup))
+                 ){
+          paste0(
           "cox_ipw-",
           setdiff(
             active_analyses$name[str_detect(
@@ -433,7 +438,11 @@ make_model_output <- function(subgroup) {
             )],
             c(stata$name, excluded_models)
           )
-        ),
+          )
+          } else {
+          character(0)
+        }
+        ,
         if (
           length(stata_models) > 0 &&
           any(str_detect(stata$analysis, subgroup))

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -42,7 +42,7 @@ describe <- FALSE # This prints descriptive files for each dataset in the pipeli
 
 # List of models excluded from model output generation
 
-#excluded_models <- c()
+excluded_models <- c()
 
 # List of models that should run in Stata due to convergence issue
 
@@ -74,13 +74,15 @@ stata_models <- unique(c(
     "cohort_vax-sub_ethnicity_black_preex_FALSE-ckd",
     "cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd",
     "cohort_unvax-sub_sex_male_preex_FALSE-ckd",
-    #selected by examination of outputs
+    #selected by manual examination of outputs
     "cohort_unvax-main_preex_TRUE-esrd",
     "cohort_unvax-sub_age_18_39_preex_FALSE-ckd",
     "cohort_unvax-sub_age_40_59_preex_FALSE-ckd",
     "cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd"
   )
 )
+
+stata <- active_analyses[active_analyses$name %in% stata_models, ]
 
 
 # Create generic action function -----------------------------------------------
@@ -278,6 +280,49 @@ apply_model_function <- function(
   )
 }
 
+# Create function to make Stata models -----------------------------------------
+
+apply_stata_model_function <- function(
+    name,
+    cohort,
+    analysis,
+    ipw,
+    strata,
+    covariate_sex,
+    covariate_age,
+    covariate_other,
+    cox_start,
+    cox_stop,
+    study_start,
+    study_stop,
+    cut_points,
+    controls_per_case,
+    total_event_threshold,
+    episode_event_threshold,
+    covariate_threshold,
+    age_spline
+) {
+  splice(
+    action(
+      name = glue("ready-{name}"),
+      run = glue(
+        "cox-ipw:v0.0.37 --df_input=model/model_input-{name}.rds --ipw={ipw} --exposure=exp_date --outcome=out_date --strata={strata} --covariate_sex={covariate_sex} --covariate_age={covariate_age} --covariate_other={covariate_other} --cox_start={cox_start} --cox_stop={cox_stop} --study_start={study_start} --study_stop={study_stop} --cut_points={cut_points} --controls_per_case={controls_per_case} --total_event_threshold={total_event_threshold} --episode_event_threshold={episode_event_threshold} --covariate_threshold={covariate_threshold} --age_spline={age_spline} --save_analysis_ready=model/ready-{name}.dta --run_analysis=FALSE --df_output=model/model_output-{name}.csv"
+      ),
+      needs = list(glue("make_model_input-{name}")),
+      highly_sensitive = list(ready = glue("output/model/ready-{name}.dta"))
+    ),
+    action(
+      name = glue("stata_cox_ipw-{name}"),
+      run = "stata-mp:latest analysis/model/cox_model.do",
+      arguments = c(name, cut_points, study_start),
+      needs = c(as.list(glue("ready-{name}"))),
+      moderately_sensitive = list(
+        model_output = glue("output/model/stata_model_output-{name}.csv")
+      )
+    )
+  )
+}
+
 # Create function to make Table 2 ----------------------------------------------
 
 table2 <- function(cohort, subgroup) {
@@ -366,7 +411,8 @@ venn <- function(cohort, analyses = "") {
   )
 }
 
-# Create funtion for making model outputs --------------------------------------
+
+# Create function for making model outputs --------------------------------------
 
 make_model_output <- function(subgroup) {
   splice(
@@ -380,11 +426,31 @@ make_model_output <- function(subgroup) {
       needs = as.list(c(
         paste0(
           "cox_ipw-",
-          active_analyses$name[
-            !(active_analyses$name %in% excluded_models) &
-              str_detect(active_analyses$analysis, subgroup)
-          ]
-        )
+          setdiff(
+            active_analyses$name[str_detect(
+              active_analyses$analysis,
+              subgroup
+            )],
+            c(stata$name, excluded_models)
+          )
+        ),
+        if (
+          length(stata_models) > 0 &&
+          any(str_detect(stata$analysis, subgroup))
+        ) {
+          paste0(
+            "stata_cox_ipw-",
+            setdiff(
+              stata$name[str_detect(
+                stata$analysis,
+                subgroup
+              )],
+              excluded_models
+            )
+          )
+        } else {
+          character(0)
+        }
       )),
       moderately_sensitive = list(
         model_output = glue("output/make_output/model_output-{subgroup}.csv"),
@@ -523,14 +589,14 @@ actions_list <- splice(
     )
   ),
   
-  ## Run models ----------------------------------------------------------------
+## Run models ----------------------------------------------------------------
   comment("Run models"),
   
   splice(
     unlist(
       lapply(
         1:nrow(active_analyses),
-        function(x)
+        function(x) {
           apply_model_function(
             name = active_analyses$name[x],
             cohort = active_analyses$cohort[x],
@@ -553,10 +619,47 @@ actions_list <- splice(
             covariate_threshold = active_analyses$covariate_threshold[x],
             age_spline = active_analyses$age_spline[x]
           )
+        }
       ),
       recursive = FALSE
     )
   ),
+  
+  # Stata models (only if stata_models not empty)
+  if (length(stata_models) > 0) {
+    splice(
+      unlist(
+        lapply(
+          1:nrow(stata),
+          function(x) {
+            apply_stata_model_function(
+              name = stata$name[x],
+              cohort = stata$cohort[x],
+              analysis = stata$analysis[x],
+              ipw = stata$ipw[x],
+              strata = stata$strata[x],
+              covariate_sex = stata$covariate_sex[x],
+              covariate_age = stata$covariate_age[x],
+              covariate_other = stata$covariate_other[x],
+              cox_start = stata$cox_start[x],
+              cox_stop = stata$cox_stop[x],
+              study_start = stata$study_start[x],
+              study_stop = stata$study_stop[x],
+              cut_points = stata$cut_points[x],
+              controls_per_case = stata$controls_per_case[x],
+              total_event_threshold = stata$total_event_threshold[x],
+              episode_event_threshold = stata$episode_event_threshold[x],
+              covariate_threshold = stata$covariate_threshold[x],
+              age_spline = stata$age_spline[x]
+            )
+          }
+        ),
+        recursive = FALSE
+      )
+    )
+  } else {
+    list()
+  },
   
   
   ## Flow ----------------------------------------------------------------------

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -41,12 +41,47 @@ age_str <- paste0(
 describe <- FALSE # This prints descriptive files for each dataset in the pipeline
 
 # List of models excluded from model output generation
-# Test first to see which models will be excluded
 
-excluded_models <- c(
-  "cohort_vax-main_preex_FALSE-pneumonia",
-  "cohort_prevax-sub_age_18_39_preex_TRUE-pf"
+#excluded_models <- c()
+
+# List of models that should run in Stata due to convergence issue
+
+stata_models <- unique(c(
+  active_analyses$name[
+    grepl("aki", active_analyses$name) 
+  ],
+  active_analyses$name[
+    grepl("sub_covidhistory", active_analyses$name) 
+  ],
+  active_analyses$name[
+    grepl("sub_covidhospital_TRUE", active_analyses$name) &
+      active_analyses$name !=
+      "cohort_vax-sub_covidhospital_TRUE_preex_FALSE-ckd"
+  ],
+    #selected by code
+    "cohort_unvax-main_preex_FALSE-ckd",
+    "cohort_prevax-sub_age_18_39_preex_FALSE-ckd",
+    "cohort_prevax-sub_age_18_39_preex_TRUE-esrd",
+    "cohort_prevax-sub_age_40_59_preex_TRUE-esrd",
+    "cohort_unvax-sub_age_80_110_preex_FALSE-ckd",
+    "cohort_vax-sub_age_40_59_preex_TRUE-esrd",
+    "cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd",
+    "cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd",
+    "cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd",
+    "cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd",
+    "cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd",
+    "cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd",
+    "cohort_vax-sub_ethnicity_black_preex_FALSE-ckd",
+    "cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd",
+    "cohort_unvax-sub_sex_male_preex_FALSE-ckd",
+    #selected by examination of outputs
+    "cohort_unvax-main_preex_TRUE-esrd",
+    "cohort_unvax-sub_age_18_39_preex_FALSE-ckd",
+    "cohort_unvax-sub_age_40_59_preex_FALSE-ckd",
+    "cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd"
+  )
 )
+
 
 # Create generic action function -----------------------------------------------
 

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -313,7 +313,7 @@ apply_stata_model_function <- function(
     ),
     action(
       name = glue("stata_cox_ipw-{name}"),
-      run = "stata-mp:latest analysis/model/cox_model.do",
+      run = "stata-mp:v1 analysis/model/cox_model.do",
       arguments = c(name, cut_points, study_start),
       needs = c(as.list(glue("ready-{name}"))),
       moderately_sensitive = list(

--- a/analysis/extra_ados/estadd.ado
+++ b/analysis/extra_ados/estadd.ado
@@ -1,0 +1,2465 @@
+*! version 2.3.5  05feb2016  Ben Jann
+*  1. estadd and helpers
+*  2. estadd_local
+*  3. estadd_scalar
+*  4. estadd_matrix
+*  5. estadd_mean
+*  6. estadd_sd
+*  7. estadd_beta
+*  8. estadd_coxsnell
+*  9. estadd_nagelkerke
+* 10. estadd_ysumm
+* 11. estadd_summ
+* 12. estadd_vif
+* 13. estadd_ebsd
+* 14. estadd_expb
+* 15. estadd_pcorr
+* 16. estadd_lrtest
+* 17. estadd_brent
+* 18. estadd_fitstat
+* 19. estadd_listcoef
+* 20. estadd_mlogtest
+* 21. estadd_prchange
+* 22. estadd_prvalue
+* 23. estadd_asprvalue
+* 24. estadd_margins
+* 99. copy of erepost.ado
+
+* 1.
+program estadd
+    version 8.2
+    local caller : di _caller()
+    capt _on_colon_parse `macval(0)'
+    if !_rc {
+        local 0 `"`s(before)'"'                 // cannot apply macval() here
+        local names `"`s(after)'"'
+    }
+    syntax anything(equalok id="subcommand") [if] [in] [fw aw iw pw] [, * ]
+    if regexm(`"`anything'"',"^r\((.*)\)$") {  // check -estadd r(name)-
+        capt confirm scalar `anything'
+        if _rc {
+            capt confirm matrix `anything'
+            if _rc {
+                di as err `"`anything' not found"'
+                exit 111
+            }
+            else {
+                local anything `"matrix `anything'"'
+            }
+        }
+        else {
+            local anything `"scalar `anything'"'
+        }
+    }
+    gettoken subcommand : anything
+    capt confirm name `subcommand'
+    if _rc {
+        di as err "invalid subcommand"
+        exit 198
+    }
+    if `"`options'"'!="" local options `", `options'"'
+    if `"`weight'`exp'"'!="" local wgtexp `"[`weight'`exp']"'
+
+//expand estimates names and backup current estimates if necessary
+    tempname rcurrent ecurrent
+    capt _return drop `rcurrent'
+    _return hold `rcurrent'
+    capt noisily {
+        local names: list retok names
+        if "`names'"=="" {
+            local names "."
+            local qui
+        }
+        else local qui quietly
+        foreach name of local names {
+            if "`name'"=="." {
+                capt est_expand "`name'"
+                if _rc local enames "`enames'`name' "
+                else local enames "`enames'`r(names)' "
+            }
+            else {
+                est_expand "`name'" //=> error if estimates not found
+                local enames "`enames'`r(names)' "
+            }
+        }
+        local names: list uniq enames
+        if "`names'"=="." local active
+        else {
+            capt est_expand .
+            if _rc local active "."
+            else local active "`r(names)'"
+            if "`active'"=="." | `:list posof "`active'" in names'==0 {
+                local active
+                _est hold `ecurrent', restore estsystem nullok
+            }
+        }
+    }
+    if _rc {
+        _return restore `rcurrent'
+        exit _rc
+    }
+    _return restore `rcurrent', hold
+
+// cases:
+// - if active estimates not stored yet and "`names'"==".": simply execute
+//   estadd_subcmd to active estimates
+// - else if active estimates not stored yet: backup/restore active estimates
+// - else if active estimates stored but not in `names': backup/restore active estimates
+// - else if active estimates stored: no backup but restore at end
+
+//loop over estimates names and run subcommand
+    nobreak {
+        foreach m of local names {
+            if "`names'"!="." {
+                if "`m'"=="." _est unhold `ecurrent'
+                else {
+                    capt confirm new var _est_`m' // fix e(sample)
+                    if _rc qui replace _est_`m' = 0 if _est_`m' >=.
+                    _est unhold `m'
+                }
+            }
+            backup_estimates_name
+            capt n break `qui' version `caller': ///
+                estadd_`macval(anything)' `if' `in' `wgtexp' `options'
+            local rc = _rc
+            restore_estimates_name
+            if "`names'"!="." {
+                if "`m'"=="." _est hold `ecurrent', restore estsystem nullok
+                else _est hold `m', estimates varname(_est_`m')
+            }
+            if `rc' continue, break
+        }
+        if "`active'"!="" estimates restore `active', noh
+    }
+    _return restore `rcurrent'
+    if `rc' {
+        if `rc' == 199 di as error "invalid subcommand"
+        exit `rc'
+    }
+end
+
+program define backup_estimates_name, eclass
+    ereturn local _estadd_estimates_name `"`e(_estimates_name)'"'
+    ereturn local _estimates_name ""
+end
+program define restore_estimates_name, eclass
+    local hold `"`e(_estadd_estimates_name)'"'
+    ereturn local _estadd_estimates_name ""
+    ereturn local _estimates_name `"`hold'"'
+end
+
+program confirm_new_ename
+    capture confirm existence `e(`0')'
+    if !_rc {
+        di as err "e(`0') already defined"
+        exit 110
+    }
+end
+
+program confirm_esample
+    local efun: e(functions)
+    if `:list posof "sample" in efun'==0 {
+        di as err "e(sample) information not available"
+        exit 498
+    }
+end
+
+program confirm_numvar
+    args var
+    local ts = index("`var'",".")
+    confirm numeric variable `=substr("`var'",`ts'+1,.)'
+end
+
+program define added_macro
+    args name
+    di as txt %25s `"e(`name') : "' `""{res:`e(`name')'}""' // cannot apply macval() here
+end
+
+program define added_scalar
+    args name label
+    di as txt %25s `"e(`name') = "' " " as res e(`name') _c
+    if `"`label'"'!="" {
+        di as txt _col(38) `"(`label')"'
+    }
+    else di ""
+end
+
+program define added_matrix
+    args name label
+    capture {
+        local r = rowsof(e(`name'))
+        local c = colsof(e(`name'))
+    }
+    if _rc {
+        tempname tmp
+        mat `tmp' = e(`name')
+        local r = rowsof(`tmp')
+        local c = colsof(`tmp')
+    }
+    di as txt %25s `"e(`name') : "' " " ///
+        as res "`r' x `c'" _c
+    if `"`label'"'=="_rown" {
+        local thelabel: rownames e(`name')
+        local thelabel: list retok thelabel
+        if `r'>1 {
+            local thelabel: subinstr local thelabel " " ", ", all
+        }
+        di as txt _col(38) `"(`thelabel')"'
+    }
+    else if `"`label'"'!="" {
+        di as txt _col(38) `"(`label')"'
+    }
+    else di ""
+end
+
+* 2.
+* -estadd- subroutine: add local
+program estadd_loc
+    estadd_local `macval(0)'
+end
+program estadd_loca
+    estadd_local `macval(0)'
+end
+program estadd_local, eclass
+    version 8.2
+    syntax anything(equalok) [, Prefix(name) Replace Quietly ]
+    gettoken name def : anything , parse(" =:")
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'`name'
+    }
+    ereturn local `prefix'`name'`macval(def)'
+    di _n as txt "added macro:"
+    added_macro `prefix'`name'
+end
+
+* 3.
+* -estadd- subroutine: add scalar
+program estadd_sca
+    estadd_scalar `0'
+end
+program estadd_scal
+    estadd_scalar `0'
+end
+program estadd_scala
+    estadd_scalar `0'
+end
+program estadd_scalar, eclass
+    version 8.2
+    syntax anything(equalok) [, Prefix(name) Replace Quietly ]
+    if regexm("`anything'","^r\((.*)\)$") {     // estadd scalar r(name)
+        local name = regexs(1)
+        capt confirm name `name'
+        confirm scalar `anything'
+        if _rc error 198
+        local equ  "`anything'"
+    }
+    else {
+        local isname 0
+        gettoken name equ0: anything, parse(" =")
+        capt confirm name `name'
+        if _rc error 198
+        else if `"`equ0'"'==""  {               // estadd scalar name
+            local isname 1
+            local equ  "scalar(`name')"
+        }
+        else {                                  // estadd scalar name [=] exp
+            gettoken trash equ : equ0, parse(" =")
+            if `"`trash'"'!="=" {
+                local equ `"`equ0'"'
+            }
+        }
+    }
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'`name'
+    }
+    ereturn scalar `prefix'`name' = `equ'
+    di _n as txt "added scalar:"
+    added_scalar `prefix'`name'
+end
+
+* 4.
+* -estadd- subroutine: add matrix
+program estadd_mat
+    estadd_matrix `0'
+end
+program estadd_matr
+    estadd_matrix `0'
+end
+program estadd_matri
+    estadd_matrix `0'
+end
+program estadd_matrix, eclass
+    version 8.2
+    syntax anything(equalok) [, Prefix(name) Replace Quietly ]
+    if regexm("`anything'","^r\((.*)\)$") {     // estadd matrix r(name)
+        local name = regexs(1)
+        capt confirm name `name'
+        if _rc error 198
+        confirm matrix `anything'
+        local equ  "`anything'"
+    }
+    else {
+        local isname 0
+        gettoken name equ0: anything, parse(" =")
+        capt confirm name `name'
+        if _rc error 198
+        else if `"`equ0'"'==""  {               // estadd matrix name
+            local isname 1
+            local equ  "`name'"
+        }
+        else {                                  // estadd matrix name [=] exp
+            gettoken trash equ : equ0, parse(" =")
+            if `"`trash'"'!="=" {
+                local equ `"`equ0'"'
+            }
+        }
+    }
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'`name'
+    }
+    tempname M
+    mat `M' = `equ'
+    ereturn matrix `prefix'`name' = `M'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'`name'
+end
+
+* 5.
+* -estadd- subroutine: means of regressors
+program define estadd_mean, eclass
+    version 8.2
+    syntax [, Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'mean
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//copy coefficients matrix and determine varnames
+    tempname results
+    mat `results' = e(b)
+    local vars: colnames `results'
+//loop over variables: calculate -mean-
+    local j 0
+    foreach var of local vars {
+        local ++j
+        capture confirm_numvar `var'
+        if _rc mat `results'[1,`j'] = .z
+        else {
+            capt su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop', meanonly
+            mat `results'[1,`j'] = cond(_rc,.,r(mean))
+        }
+    }
+//return the results
+    ereturn matrix `prefix'mean = `results'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'mean
+end
+
+* 6.
+* -estadd- subroutine: standard deviations of regressors
+program define estadd_sd, eclass
+    version 8.2
+    syntax [, noBinary Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'sd
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//copy coefficients matrix and determine varnames
+    tempname results
+    mat `results' = e(b)
+    local vars: colnames `results'
+//loop over variables: calculate -mean-
+    local j 0
+    foreach var of local vars {
+        local ++j
+        capture confirm_numvar `var'
+        if _rc mat `results'[1,`j'] = .z
+        else {
+            capture assert `var'==0 | `var'==1 if e(sample) & `subpop'
+            if _rc | "`binary'"=="" {
+                capt su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop'
+                mat `results'[1,`j'] = cond(_rc,.,r(sd))
+            }
+            else mat `results'[1,`j'] = .z
+        }
+    }
+//return the results
+    ereturn matrix `prefix'sd = `results'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'sd
+end
+
+* 7.
+* -estadd- subroutine: standardized coefficients
+program define estadd_beta, eclass
+    version 8.2
+    syntax [, Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'beta
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//copy coefficients matrix and determine varnames
+    tempname results sddep
+    mat `results' = e(b)
+    local vars: colnames `results'
+    local eqs: coleq `results', q
+    local depv "`e(depvar)'"
+//loop over variables: calculate -beta-
+    local j 0
+    local lastdepvar
+    foreach var of local vars {
+        local depvar: word `++j' of `eqs'
+        if "`depvar'"=="_" local depvar "`depv'"
+        capture confirm_numvar `depvar'
+        if _rc mat `results'[1,`j'] = .z
+        else {
+            if "`depvar'"!="`lastdepvar'" {
+                capt su `depvar' [`wtype'`e(wexp)'] if e(sample) & `subpop'
+                scalar `sddep' = cond(_rc,.,r(sd))
+            }
+            capture confirm_numvar `var'
+            if _rc mat `results'[1,`j'] = .z
+            else {
+                capt su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop'
+                mat `results'[1,`j'] = cond(_rc,.,`results'[1,`j'] * r(sd) / `sddep')
+            }
+        }
+        local lastdepvar "`depvar'"
+    }
+//return the results
+    ereturn matrix `prefix'beta = `results'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'beta
+end
+
+* 8.
+* -estadd- subroutine: Cox & Snell Pseudo R-Squared
+program define estadd_coxsnell, eclass
+    version 8.2
+    syntax [, Prefix(name) Replace Quietly ]
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'coxsnell
+//compute statistic
+    tempname results
+    scalar `results' = 1 - exp((e(ll_0)-e(ll))*2/e(N))  // = 1 - exp(e(ll_0)-e(ll))^(2/e(N))
+//return the results
+    *di as txt "Cox & Snell Pseudo R2 = " as res `results'
+    ereturn scalar `prefix'coxsnell = `results'
+    di _n as txt "added scalar:"
+    added_scalar `prefix'coxsnell
+end
+
+* 9.
+* -estadd- subroutine: Nagelkerke Pseudo R-Squared
+program define estadd_nagelkerke, eclass
+    version 8.2
+    syntax [, Prefix(name) Replace Quietly ]
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'nagelkerke
+//compute statistic
+    tempname results
+    scalar `results' = (1 - exp((e(ll_0)-e(ll))*2/e(N))) / (1 - exp(e(ll_0)*2/e(N)))
+        // = (1 - exp(e(ll_0)-e(ll))^(2/e(N))) / (1 - exp(e(ll_0))^(2/e(N)))
+//return the results
+    *di as txt "Nagelkerke Pseudo R2 = " as res `results'
+    ereturn scalar `prefix'nagelkerke = `results'
+    di _n as txt "added scalar:"
+    added_scalar `prefix'nagelkerke
+end
+
+* 10.
+* -estadd- subroutine: summary statistics for dependent variable
+program define estadd_ysumm, eclass
+    version 8.2
+    syntax [, MEan SUm MIn MAx RAnge sd Var cv SEMean SKewness ///
+     Kurtosis MEDian p1 p5 p10 p25 p50 p75 p90 p95 p99 iqr q all ///
+     Prefix(passthru) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//default prefix
+    if `"`prefix'"'=="" local prefix y
+    else {
+        local 0 ", `prefix'"
+        syntax [, prefix(name) ]
+    }
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//determine list of stats
+    tempname results
+    local Stats p99 p95 p90 p75 p50 p25 p10 p5 p1 kurtosis ///
+     skewness var sd max min sum mean
+    if "`all'"!="" {
+        local stats `Stats'
+        local range range
+        local cv cv
+        local semean semean
+        local iqr iqr
+        local sumtype detail
+    }
+    else {
+        if "`q'"!="" {
+            local p25 p25
+            local p50 p50
+            local p75 p75
+        }
+        if "`median'"!="" local p50 p50
+        foreach stat of local Stats {
+            if "``stat''"!="" {
+                local stats: list stats | stat
+            }
+        }
+        if "`stats'"=="" & "`range'"=="" & "`cv'"=="" & ///
+         "`semean'"=="" & "`iqr'"=="" local stats sd max min mean
+        local sumtype sum mean min max
+        if "`:list stats - sumtype'"=="" & "`cv'"=="" & ///
+         "`semean'"=="" & "`iqr'"=="" local sumtype meanonly
+        else {
+            local sumtype `sumtype' Var sd
+            if "`:list stats - sumtype'"=="" & "`iqr'"=="" local sumtype
+            else local sumtype detail
+        }
+    }
+    local Stats: subinstr local stats "var" "Var"
+    local nstats: word count `iqr' `semean' `cv' `range' `stats'
+    if "`replace'"=="" {
+        foreach stat in `iqr' `semean' `cv' `range' `stats' {
+            confirm_new_ename `prefix'`=lower("`stat'")'
+        }
+    }
+//calculate stats
+    local var: word 1 of `e(depvar)'
+    mat `results' = J(`nstats',1,.z)
+    qui su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop', `sumtype'
+    local i 0
+    if "`iqr'"!="" {
+        mat `results'[`++i',1] = r(p75) - r(p25)
+    }
+    if "`semean'"!="" {
+        mat `results'[`++i',1] = r(sd) / sqrt(r(N))
+    }
+    if "`cv'"!="" {
+        mat `results'[`++i',1] = r(sd) / r(mean)
+    }
+    if "`range'"!="" {
+        mat `results'[`++i',1] = r(max) - r(min)
+    }
+    foreach stat of local Stats {
+        mat `results'[`++i',1] = r(`stat')
+    }
+//return the results
+    local i 0
+    di as txt _n "added scalars:"
+    foreach stat in `iqr' `semean' `cv' `range' `stats' {
+        local sname = lower("`stat'")
+        ereturn scalar `prefix'`sname' = `results'[`++i',1]
+        added_scalar `prefix'`sname'
+    }
+end
+
+* 11.
+* -estadd- subroutine: various summary statistics
+program define estadd_summ, eclass
+    version 8.2
+    syntax [, MEan SUm MIn MAx RAnge sd Var cv SEMean SKewness ///
+     Kurtosis MEDian p1 p5 p10 p25 p50 p75 p90 p95 p99 iqr q all ///
+     Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//determine list of stats
+    tempname results results2
+    local Stats p99 p95 p90 p75 p50 p25 p10 p5 p1 kurtosis ///
+     skewness var sd max min sum mean
+    if "`all'"!="" {
+        local stats `Stats'
+        local range range
+        local cv cv
+        local semean semean
+        local iqr iqr
+        local sumtype detail
+    }
+    else {
+        if "`q'"!="" {
+            local p25 p25
+            local p50 p50
+            local p75 p75
+        }
+        if "`median'"!="" local p50 p50
+        foreach stat of local Stats {
+            if "``stat''"!="" {
+                local stats: list stats | stat
+            }
+        }
+        if "`stats'"=="" & "`range'"=="" & "`cv'"=="" & ///
+         "`semean'"=="" & "`iqr'"=="" local stats sd max min mean
+        local sumtype sum mean min max
+        if "`:list stats - sumtype'"=="" & "`cv'"=="" & ///
+         "`semean'"=="" & "`iqr'"=="" local sumtype meanonly
+        else {
+            local sumtype `sumtype' Var sd
+            if "`:list stats - sumtype'"=="" & "`iqr'"=="" local sumtype
+            else local sumtype detail
+        }
+    }
+    local Stats: subinstr local stats "var" "Var"
+    local nstats: word count `iqr' `semean' `cv' `range' `stats'
+    if "`replace'"=="" {
+        foreach stat in `iqr' `semean' `cv' `range' `stats' {
+            confirm_new_ename `prefix'`=lower("`stat'")'
+        }
+    }
+//copy coefficients matrix and determine varnames
+    mat `results' = e(b)
+    local vars: colnames `results'
+    if `nstats'>1 {
+        mat `results' = `results' \ J(`nstats'-1,colsof(`results'),.z)
+    }
+//loop over variables: calculate stats
+    local j 0
+    foreach var of local vars {
+        local ++j
+        capture confirm_numvar `var'
+        if _rc mat `results'[1,`j'] = .z
+        else {
+            capt su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop', `sumtype'
+            local i 0
+            if "`iqr'"!="" {
+                mat `results'[`++i',`j'] = cond(_rc,.,r(p75) - r(p25))
+            }
+            if "`semean'"!="" {
+                mat `results'[`++i',`j'] = cond(_rc,.,r(sd) / sqrt(r(N)))
+            }
+            if "`cv'"!="" {
+                mat `results'[`++i',`j'] = cond(_rc,.,r(sd) / r(mean))
+            }
+            if "`range'"!="" {
+                mat `results'[`++i',`j'] = cond(_rc,.,r(max) - r(min))
+            }
+            foreach stat of local Stats {
+                mat `results'[`++i',`j'] = cond(_rc,.,r(`stat'))
+            }
+        }
+    }
+//return the results
+    local i 0
+    di as txt _n "added matrices:"
+    foreach stat in `iqr' `semean' `cv' `range' `stats' {
+        local sname = lower("`stat'")
+        mat `results2' = `results'[`++i',1...]
+        ereturn matrix `prefix'`sname' = `results2'
+        added_matrix `prefix'`sname'
+    }
+end
+
+* 12.
+* -estadd- subroutine: variance inflation factors
+program define estadd_vif, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax [, TOLerance SQRvif Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'vif
+        if "`tolerance'"!="" confirm_new_ename `prefix'tolerance
+        if "`sqrvif'"!="" confirm_new_ename `prefix'sqrvif
+    }
+//copy coefficients matrix and set to .z
+    tempname results results2 results3
+    matrix `results' = e(b)
+    forv j = 1/`=colsof(`results')' {
+        mat `results'[1,`j'] = .z
+    }
+    if "`tolerance'"!="" mat `results2' = `results'
+    if "`sqrvif'"!="" mat `results3' = `results'
+//compute VIF and add to results vector
+    capt n `quietly' version `caller': vif
+    if _rc {
+        if _rc == 301 di as err "-estadd:vif- can only be used after -regress-"
+        exit _rc
+    }
+    local i 0
+    local name "`r(name_`++i')'"
+    while "`name'"!="" {
+        local j = colnumb(`results',"`name'")
+        if `j'<. {
+            matrix `results'[1,`j'] = r(vif_`i')
+            if "`tolerance'"!="" matrix `results2'[1,`j'] = 1 / r(vif_`i')
+            if "`sqrvif'"!="" matrix `results3'[1,`j'] = sqrt( r(vif_`i') )
+        }
+        local name "`r(name_`++i')'"
+    }
+//return the results
+    if "`sqrvif'"!="" | "`tolerance'"!="" di as txt _n "added matrices:"
+    else di as txt _n "added matrix:"
+    if "`sqrvif'"!="" {
+        ereturn matrix `prefix'sqrvif = `results3'
+        added_matrix `prefix'sqrvif
+    }
+    if "`tolerance'"!="" {
+        ereturn matrix `prefix'tolerance = `results2'
+        added_matrix `prefix'tolerance
+    }
+    ereturn matrix `prefix'vif = `results'
+    added_matrix `prefix'vif
+end
+
+* 13.
+* -estadd- subroutine: standardized factor change coefficients
+program define estadd_ebsd, eclass
+    version 8.2
+    syntax [, Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'ebsd
+//use aweights with -summarize-
+    local wtype `e(wtype)'
+    if "`wtype'"=="pweight" local wtype aweight
+//subpop?
+    local subpop "`e(subpop)'"
+    if "`subpop'"=="" local subpop 1
+//copy coefficients matrix and determine varnames
+    tempname results
+    mat `results' = e(b)
+    local vars: colnames `results'
+//loop over variables: calculate -mean-
+    local j 0
+    foreach var of local vars {
+        local ++j
+        capture confirm_numvar `var'
+        if _rc mat `results'[1,`j'] = .z
+        else {
+            capt su `var' [`wtype'`e(wexp)'] if e(sample) & `subpop'
+            mat `results'[1,`j'] = cond(_rc,.,exp( `results'[1,`j'] * r(sd)))
+        }
+    }
+//return the results
+    ereturn matrix `prefix'ebsd = `results'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'ebsd
+end
+
+* 14.
+* -estadd- subroutine: exponentiated coefficients
+program define estadd_expb, eclass
+    version 8.2
+    syntax [, noCONStant Prefix(name) Replace Quietly ]
+//check e()-names
+    if "`replace'"=="" confirm_new_ename `prefix'expb
+//copy coefficients matrix and determine names of coefficients
+    tempname results
+    mat `results' = e(b)
+    local coefs: colnames `results'
+//loop over coefficients
+    local j 0
+    foreach coef of local coefs {
+        local ++j
+        if `"`constant'"'!="" & `"`coef'"'=="_cons" {
+            mat `results'[1,`j'] = .z
+        }
+        else {
+            mat `results'[1,`j'] = exp(`results'[1,`j'])
+        }
+    }
+//return the results
+    ereturn matrix `prefix'expb = `results'
+    di _n as txt "added matrix:"
+    added_matrix `prefix'expb
+end
+
+* 15.
+* -estadd- subroutine: partial and semi-partial correlations
+program define estadd_pcorr, eclass
+    version 8.2
+    syntax [, semi Prefix(name) Replace Quietly ]
+//check availability of e(sample)
+    confirm_esample
+//check e()-names
+    if "`replace'"=="" {
+        if "`semi'"!="" confirm_new_ename `prefix'spcorr
+        confirm_new_ename `prefix'pcorr
+    }
+//copy coefficients matrix and set to .z
+    tempname results results2
+    matrix `results' = e(b)
+    forv j = 1/`=colsof(`results')' {
+        mat `results'[1,`j'] = .z
+    }
+    local eqs: coleq `results', quoted
+    local eq: word 1 of `eqs'
+    mat `results2' = `results'[1,"`eq':"]
+    local vars: colnames `results2'
+    foreach var of local vars {
+        capt confirm numeric var `var'
+        if !_rc local temp "`temp'`var' "
+    }
+    local vars "`temp'"
+    if "`semi'"!="" mat `results2' = `results'
+    else {
+        mat drop `results2'
+        local results2
+    }
+    local depv: word 1 of `e(depvar)'
+//compute statistics and add to results vector
+    local wtype `e(wtype)'
+    if inlist("`wtype'","pweight","iweight") local wtype aweight
+    _estadd_pcorr_compute `depv' `vars' [`wtype'`e(wexp)'] if e(sample), ///
+     eq(`eq') results(`results') results2(`results2')
+//return the results
+    if "`semi'"!="" {
+        di as txt _n "added matrices:"
+        ereturn matrix `prefix'spcorr = `results2'
+        added_matrix `prefix'spcorr
+    }
+    else di as txt _n "added matrix:"
+    ereturn matrix `prefix'pcorr = `results'
+    added_matrix `prefix'pcorr
+end
+program define _estadd_pcorr_compute // based on pcorr.ado by StataCorp
+                                     // and pcorr2.ado by Richard Williams
+    syntax varlist(min=1) [aw fw] [if], eq(str) results(str) [ results2(str) ]
+    marksample touse
+    tempname hcurrent
+    _est hold `hcurrent', restore
+    quietly reg `varlist' [`weight'`exp'] if `touse'
+    if (e(N)==0 | e(N)>=.) error 2000
+    local NmK = e(df_r)
+    local R2 = e(r2)
+    gettoken depv varlist: varlist
+    foreach var of local varlist {
+        quietly test `var'
+        if r(F)<. {
+            local s "1"
+            if _b[`var']<0 local s "-1"
+            local c = colnumb(`results',"`eq':`var'")
+            mat `results'[1,`c'] = `s' * sqrt(r(F)/(r(F)+`NmK'))
+            if "`results2'"!="" {
+                mat `results2'[1,`c'] = `s' * sqrt(r(F)*((1-`R2')/`NmK'))
+            }
+        }
+    }
+end
+
+* 16.
+* -estadd- subroutine: Likelihood-ratio test
+program define estadd_lrtest, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax anything(id="model") [, Name(name) Prefix(name) Replace Quietly * ]
+    if "`name'"=="" local name lrtest_
+//check e()-names
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'`name'p
+        confirm_new_ename `prefix'`name'chi2
+        confirm_new_ename `prefix'`name'df
+    }
+//compute statistics
+    `quietly' version `caller': lrtest `anything', `options'
+//return the results
+    ereturn scalar `prefix'`name'p = r(p)
+    ereturn scalar `prefix'`name'chi2 = r(chi2)
+    ereturn scalar `prefix'`name'df = r(df)
+    di _n as txt "added scalars:"
+    added_scalar `prefix'`name'p
+    added_scalar `prefix'`name'chi2
+    added_scalar `prefix'`name'df
+end
+
+* 17.
+* -estadd- subroutine: support for -brant- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_brant, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax [ , Prefix(name) Replace Quietly * ]
+    capt findfile brant.ado
+    if _rc {
+        di as error "fitstat.ado from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+// check names
+    if "`replace'"=="" {
+        foreach name in brant_chi2 brant_df brant_p brant {
+            confirm_new_ename `prefix'`name'
+        }
+    }
+// compute and return the results
+    `quietly' version `caller': brant, `options'
+    di as txt _n "added scalars:"
+    foreach stat in chi2 df p {
+        ereturn scalar `prefix'brant_`stat' = r(`stat')
+        added_scalar `prefix'brant_`stat'
+    }
+    tempname mat
+    matrix `mat' = r(ivtests)
+    matrix `mat' = `mat''
+    ereturn matrix `prefix'brant = `mat'
+    di as txt _n "added matrix:"
+    added_matrix `prefix'brant _rown
+end
+
+* 18.
+* -estadd- subroutine: support for -fitstat- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_fitstat, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax [ , Prefix(name) Replace Quietly Bic * ]
+    capt findfile fitstat.ado
+    if _rc {
+        di as error "fitstat.ado from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+    `quietly' version `caller': fitstat, `bic' `options'
+    local stats: r(scalars)
+    local allstats                                                  ///
+        dev dev_df lrx2 lrx2_df lrx2_p r2_adj r2_mf r2_mfadj r2_ml  ///
+        r2_cu r2_mz r2_ef v_ystar v_error r2_ct r2_ctadj aic aic_n  ///
+        bic bic_p statabic stataaic n_rhs n_parm
+    local stats: list allstats & stats
+    if "`bic'"!="" {
+        local bic aic aic_n bic bic_p statabic stataaic
+        local stats: list bic & stats
+    }
+
+
+// check names
+    if "`replace'"=="" {
+        foreach stat of local stats {
+            if inlist("`stat'", "bic", "aic") local rname `stat'0
+            else local rname `stat'
+            confirm_new_ename `prefix'`rname'
+        }
+    }
+
+// return the results
+    di as txt _n "added scalars:"
+    foreach stat of local stats {
+        if inlist("`stat'", "bic", "aic") local rname `stat'0
+        else local rname `stat'
+        ereturn scalar `prefix'`rname' = r(`stat')
+        added_scalar `prefix'`rname'
+    }
+end
+
+* 19.
+* -estadd- subroutine: support for -listcoef- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_listcoef, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax [anything] [ , Prefix(name) Replace Quietly ///
+     nosd gt lt ADJacent Matrix EXpand * ]
+
+// handle some options and look for e(sample)
+    if `"`matrix'"'!="" {
+        local matrix matrix
+    }
+    if `"`e(cmd)'"'=="slogit" & "`expand'"!="" {
+        di as err "-expand- option not supported"
+        exit 198
+    }
+    confirm_esample
+
+// set some constants
+    local listcoef_matrices  "xs ys std fact facts pct pcts"
+    if "`sd'"=="" local listcoef_matrices "`listcoef_matrices' sdx"
+
+// run listcoef
+    capt findfile listcoef.ado
+    if _rc {
+        di as error "-listcoef- from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+    `quietly' version `caller': listcoef `anything' , matrix `gt' `lt' `adjacent' `options'
+
+// check existing e()'s
+    if "`replace'"=="" {
+        confirm_new_ename `prefix'pvalue
+        foreach matrix of local listcoef_matrices {
+            _estadd_listcoef_ChkEName b_`matrix', prefix(`prefix')
+        }
+    }
+
+// grab r()-results and post in e()
+    di as txt _n "added matrices:"
+    if inlist(`"`e(cmd)'"',"mlogit","mprobit") {
+        _estadd_listcoef_AddResToNomModl `listcoef_matrices', prefix(`prefix') `gt' `lt' `adjacent'
+    }
+    else {
+        foreach matrix of local listcoef_matrices {
+            _estadd_listcoef_AddMatToE `matrix', prefix(`prefix')
+        }
+    }
+end
+program define _estadd_listcoef_ChkEName
+    syntax name [, prefix(str) ]
+    capt confirm matrix r(`namelist')
+    if _rc exit
+    confirm_new_ename `prefix'`namelist'
+end
+program define _estadd_listcoef_AddMatToE, eclass
+    syntax name [, prefix(str) ]
+    capt confirm matrix r(b_`namelist')
+    if _rc exit
+    tempname tmp
+    matrix `tmp' = r(b_`namelist')
+    capt confirm matrix r(b2_`namelist')
+    if _rc==0 {
+        local eqnames: coleq e(b), quoted
+        local eqnames: list uniq eqnames
+        local eqname: word 1 of `eqnames'
+        mat coleq `tmp' = `"`eqname'"'
+        tempname tmp2
+        matrix `tmp2' = r(b2_`namelist')
+        local eqname: word 2 of `eqnames'
+        mat coleq `tmp2' = `"`eqname'"'
+        mat `tmp' = `tmp' , `tmp2'
+        mat drop `tmp2'
+    }
+    ereturn matrix `prefix'b_`namelist' = `tmp'
+    added_matrix `prefix'b_`namelist' _rown
+end
+program define _estadd_listcoef_AddResToNomModl, eclass
+    syntax anything(name=listcoef_matrices) [, prefix(str) gt lt ADJacent ]
+    if "`lt'"=="" & "`gt'"=="" {
+        local lt lt
+        local gt gt
+    }
+    local adjacent = "`adjacent'"!=""
+    local lt = "`lt'"!=""
+    local gt = "`gt'"!=""
+
+// outcomes and labels
+    tempname outcomes
+    if `"`e(cmd)'"'=="mlogit" {
+        if c(stata_version) < 9 local type cat
+        else                    local type out
+        mat `outcomes' = e(`type')
+        local noutcomes = colsof(`outcomes')
+        local eqnames `"`e(eqnames)'"'
+        if (`:list sizeof eqnames'<`noutcomes') {
+            local ibase = e(ibase`type')
+        }
+        else local ibase 0
+        forv i = 1/`noutcomes' {
+            if `i'==`ibase' {
+                local outcomelab`i' `"`e(baselab)'"'
+            }
+            else {
+                gettoken eq eqnames : eqnames
+                local outcomelab`i' `"`eq'"'
+            }
+            if `"`outcomelab`i''"'=="" {
+                local outcomelab`i': di `outcomes'[1,`i']
+            }
+        }
+    }
+    else if `"`e(cmd)'"'=="mprobit" {
+        mat `outcomes' = e(outcomes)'
+        local noutcomes = colsof(`outcomes')
+        forv i = 1/`noutcomes' {
+            local outcomelab`i' `"`e(out`i')'"'
+        }
+    }
+    else {
+        di as err `"`e(cmd)' not supported"'
+        exit 499
+    }
+
+// collect vectors
+    tempname stats
+    mat `stats' = r(b) \ r(b_z) \ r(b_z) \ r(b_p)
+    forv i = 1/`=colsof(`stats')' {
+        mat `stats'[2,`i'] = `stats'[1,`i'] / `stats'[3,`i']
+    }
+    mat rown `stats' = "b" "se" "z" "P>|z|"
+    local enames "b_raw b_se b_z b_p"
+    foreach matrix of local listcoef_matrices {
+        capt confirm matrix r(b_`matrix')
+        if _rc continue
+        mat `stats' = `stats' \ r(b_`matrix')
+        local enames `"`enames' b_`matrix'"'
+    }
+
+// select/reorder contrasts of interest
+    local contrast "r(contrast)"
+    local ncontrast = colsof(`contrast')
+    tempname stats0 temp
+    matrix rename `stats' `stats0'
+    forv i = 1/`noutcomes' {
+        local out1 = `outcomes'[1, `i']
+        local j 0
+        forv j = 1/`noutcomes' {
+            local out2 = `outcomes'[1, `j']
+            if `out1'==`out2' continue
+            if `adjacent' & abs(`i'-`j')>1 continue
+            if `lt'==0 & `out1'<`out2' continue
+            if `gt'==0 & `out1'>`out2' continue
+            forv l = 1/`ncontrast' {
+                if el(`contrast',1,`l')!=`out1' continue
+                if el(`contrast',2,`l')!=`out2' continue
+                mat `temp' = `stats0'[1..., `l']
+                mat coleq `temp' = `"`outcomelab`i''-`outcomelab`j''"'
+                mat `stats' = nullmat(`stats'), `temp'
+            }
+        }
+    }
+    capt mat drop `stats0'
+
+// post rows to e()
+    local i 0
+    foreach ename of local enames {
+        local ++i
+        mat `temp' = `stats'[`i', 1...]
+        ereturn matrix `prefix'`ename' = `temp'
+        added_matrix `prefix'`ename' _rown
+    }
+end
+
+* 20.
+* -estadd- subroutine: support for -mlogtest- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_mlogtest, eclass
+    version 8.2
+    local caller : di _caller()
+    syntax [anything] [ , Prefix(name) Replace Quietly set(passthru) * ]
+    `quietly' version `caller': mlogtest `anything' , `set' `options'
+    local rmat: r(matrices)
+
+    // check names
+    if `"`replace'"'=="" {
+        foreach m in combine lrcomb {
+            if `:list m in rmat'==0 continue
+            forv r = 1/`=rowsof(r(`m'))' {
+                local cat1 = el(r(`m'),`r',1)
+                local cat2 = el(r(`m'),`r',2)
+                confirm_new_ename `prefix'`m'_`cat1'_`cat2'_chi2
+                confirm_new_ename `prefix'`m'_`cat1'_`cat2'_df
+                confirm_new_ename `prefix'`m'_`cat1'_`cat2'_p
+            }
+        }
+        foreach m in hausman suest smhsiao {
+            if `:list m in rmat'==0 continue
+            forv r = 1/`=rowsof(r(`m'))' {
+                local cat = el(r(`m'),`r',1)
+                confirm_new_ename `prefix'`m'_`cat'_chi2
+                confirm_new_ename `prefix'`m'_`cat'_df
+                confirm_new_ename `prefix'`m'_`cat'_p
+            }
+        }
+        if `"`set'"'!="" {
+            foreach m in wald lrtest {
+                if `:list m in rmat'==0 continue
+                local i 0
+                local r = rownumb(r(`m'),"set_`++i'")
+                while(`r'<.) {
+                    confirm_new_ename `prefix'`m'_set`i'_chi2
+                    confirm_new_ename `prefix'`m'_set`i'_df
+                    confirm_new_ename `prefix'`m'_set`i'_p
+                    local r = rownumb(r(`m'),"set_`++i'")
+                }
+            }
+        }
+        foreach m in wald lrtest {
+            if `:list m in rmat'==0 continue
+            local r .
+            if `"`set'"'!="" local r = rownumb(r(`m'),"set_1")-1
+            if `r'<1 continue
+            confirm_new_ename `prefix'`m'
+       }
+    }
+
+    local di_added_scalars `"di _n as txt "added scalars:"'
+    // combine
+    foreach m in combine lrcomb {
+        if `:list m in rmat'==0 continue
+        `di_added_scalars'
+        local di_added_scalars
+        forv r = 1/`=rowsof(r(`m'))' {
+            local cat1 = el(r(`m'),`r',1)
+            local cat2 = el(r(`m'),`r',2)
+            eret scalar `prefix'`m'_`cat1'_`cat2'_chi2 = el(r(`m'),`r',3)
+            added_scalar `prefix'`m'_`cat1'_`cat2'_chi2
+            eret scalar `prefix'`m'_`cat1'_`cat2'_df   = el(r(`m'),`r',4)
+            added_scalar `prefix'`m'_`cat1'_`cat2'_df
+            eret scalar `prefix'`m'_`cat1'_`cat2'_p    = el(r(`m'),`r',5)
+            added_scalar `prefix'`m'_`cat1'_`cat2'_p
+        }
+    }
+    // iia
+    foreach m in hausman suest smhsiao {
+        if `:list m in rmat'==0 continue
+        `di_added_scalars'
+        local di_added_scalars
+        if "`m'"=="smhsiao" local skip 2
+        else                local skip 0
+        forv r = 1/`=rowsof(r(`m'))' {
+            local cat = el(r(`m'),`r',1)
+            eret scalar `prefix'`m'_`cat'_chi2 = el(r(`m'),`r',2+`skip')
+            added_scalar `prefix'`m'_`cat'_chi2
+            eret scalar `prefix'`m'_`cat'_df   = el(r(`m'),`r',3+`skip')
+            added_scalar `prefix'`m'_`cat'_df
+            eret scalar `prefix'`m'_`cat'_p    = el(r(`m'),`r',4+`skip')
+            added_scalar `prefix'`m'_`cat'_p
+        }
+    }
+
+    // wald/lrtest
+    tempname tmp
+    if `"`set'"'!="" {
+        foreach m in wald lrtest {
+            if `:list m in rmat'==0 continue
+            local i 0
+            local r = rownumb(r(`m'),"set_`++i'")
+            if `r'>=. continue
+            `di_added_scalars'
+            local di_added_scalars
+            while(`r'<.) {
+                eret scalar `prefix'`m'_set`i'_chi2 = el(r(`m'),`r',1)
+                added_scalar `prefix'`m'_set`i'_chi2
+                eret scalar `prefix'`m'_set`i'_df   = el(r(`m'),`r',2)
+                added_scalar `prefix'`m'_set`i'_df
+                eret scalar `prefix'`m'_set`i'_p    = el(r(`m'),`r',3)
+                added_scalar `prefix'`m'_set`i'_p
+                local r = rownumb(r(`m'),"set_`++i'")
+            }
+        }
+    }
+    local di_added_matrices `"di _n as txt "added matrices:"'
+    foreach m in wald lrtest {
+        if `:list m in rmat'==0 continue
+        local r .
+        if `"`set'"'!="" local r = rownumb(r(`m'),"set_1")-1
+        if `r'<1 continue
+        `di_added_matrices'
+        local di_added_matrices
+        mat `tmp' = r(`m')
+        mat `tmp' = `tmp'[1..`r',1...]'
+        eret mat `prefix'`m' = `tmp'
+        added_matrix `prefix'`m' _rown
+    }
+
+end
+
+
+* 21.
+* -estadd- subroutine: support for -prchange- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_prchange
+    version 8.2
+    local caller : di _caller()
+    syntax [anything] [if] [in] [ , Prefix(name) Replace Quietly ///
+        PAttern(str) Binary(str) Continuous(str) NOAvg Avg split SPLIT2(name) ///
+            adapt /// old syntax; now works as synonym for noavg
+        Outcome(passthru) Fromto noBAse * ]
+
+// handle some options
+    if `"`split2'"'!="" local split split
+    if "`split'"!="" & `"`outcome'"'!="" {
+        di as err "split and outcome() not both allowed"
+        exit 198
+    }
+    if "`split'"!="" & `"`avg'`noavg'"'!="" {
+        di as err "split and avg not both allowed"
+        exit 198
+    }
+    if "`avg'"!="" & `"`outcome'"'!="" {
+        di as err "avg and outcome not both allowed"
+        exit 198
+    }
+    if "`avg'"!="" & "`noavg'"!="" {
+        di as err "avg and noavg not both allowed"
+        exit 198
+    }
+    if `"`adapt'"'!=""  local noavg noavg
+    if `:list sizeof binary'>1 | `:list sizeof continuous'>1  error 198
+    estadd_prchange_ExpandType binary `"`binary'"'
+    estadd_prchange_ExpandType continuous `"`continuous'"'
+    if `"`binary'"'==""     local binary 2
+    if `"`continuous'"'=="" local continuous 4
+    if `"`pattern'"'!="" {
+        estadd_prchange_ExpandType pattern `"`pattern'"'
+    }
+
+// check e(sample)
+    confirm_esample
+
+// run prchange
+    capt findfile prchange.ado
+    if _rc {
+        di as error "-prchange- from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+    `quietly' version `caller': prchange `anything' `if' `in', `base' `outcome' `fromto' `options'
+
+// determine type of model (ordinal: nomord = 1; nominal: nomord = 2)
+    local nomord = (r(modeltype)=="typical nomord")
+    if inlist(`"`e(cmd)'"',"mlogit","mprobit") local nomord = 2
+    if "`avg'`noavg'"!="" {
+        if `nomord'==0 {
+            di as err "avg not allowed with this model"
+            exit 198
+        }
+    }
+    if !`nomord' & "`split'"!="" {
+        di as err "split not allowed with this model"
+        exit 198
+    }
+
+// determine outcome number (in prchange-returns)
+    if `"`outcome'"'!="" {
+        if `nomord' {
+            forv i = 1/`=colsof(r(catval))' {
+                if el(r(catval), 1, `i') == r(outcome) {
+                    local outcomenum `i'
+                    continue, break
+                }
+            }
+            if "`outcomenum'"=="" { // should never happen
+                di as err `"outcome `outcome' not found"'
+                exit 499
+            }
+        }
+        else {
+            local outcomenum =  colnumb(r(predval), `"`r(outcome)'"')
+        }
+    }
+
+// check names
+    if "`replace'"=="" {
+        if `"`outcome'"'!="" | "`split'"!="" | `nomord'==0 {
+            confirm_new_ename `prefix'predval
+            if `"`outcome'"'!="" | "`split'"!="" {
+                confirm_new_ename `prefix'outcome
+            }
+        }
+        else {
+            forv i = 1/`=colsof(r(catval))' {
+                local theoutcome: di el(r(catval),1,`i')
+                confirm_new_ename `prefix'predval`theoutcome'
+            }
+        }
+        confirm_new_ename `prefix'delta
+        confirm_new_ename `prefix'centered
+        confirm_new_ename `prefix'dc
+        if "`fromto'"!="" {
+            confirm_new_ename `prefix'dcfrom
+            confirm_new_ename `prefix'dcto
+        }
+        if "`nobase'"=="" {
+            confirm_new_ename `prefix'X
+        }
+    }
+
+// grab r()-results and post in e()
+    if "`split'"!="" {
+        if `"`split2'"'=="" {
+            local split2 `"`e(_estadd_estimates_name)'"'
+            if `"`split2'"'=="" {
+                local split2 `"`e(cmd)'"'
+            }
+            local split2 `"`split2'_"'
+        }
+        _estadd_prchange_StoreEachOutc `split2' , nomord(`nomord') ///
+            pattern(`pattern') binary(`binary') continuous(`continuous') ///
+            `base' `fromto' prefix(`prefix')
+    }
+    else {
+        _estadd_prchange_AddStuffToE, nomord(`nomord') outcome(`outcomenum') ///
+            pattern(`pattern') binary(`binary') continuous(`continuous') ///
+            `avg' `noavg' `base' `fromto' prefix(`prefix')
+    }
+end
+program estadd_prchange_ExpandType
+    args name list
+    foreach l of local list {
+        local w = length(`"`l'"')
+        if      `"`l'"'==substr("minmax",1,max(2,`w'))      local type 1
+        else if `"`l'"'==substr("01",1,max(1,`w'))          local type 2
+        else if `"`l'"'==substr("delta",1,max(1,`w'))       local type 3
+        else if `"`l'"'==substr("sd",1,max(1,`w'))          local type 4
+        else if `"`l'"'==substr("margefct",1,max(1,`w'))    local type 5
+        else {
+            di as err `"'`l'' not allowed"'
+            exit 198
+        }
+        local newlist `newlist' `type'
+    }
+    c_local `name' `newlist'
+end
+program define _estadd_prchange_AddStuffToE, eclass
+//      input                            add
+// =========================    ========================================
+// outcome() nomord    opt      change changenm change# predval  outcome
+//   no        0        -         x                      last
+//   yes       0        -         x                       x        x
+//   no       1/2       -                 x       all    all
+//   yes      1/2       -                          x      x        x
+//   no       1/2      avg                x              all
+//   no       1/2     noavg                       all    all
+//  nobase==""  => add X, SD, Min, Max
+//  all models  => add centered, delta
+    syntax , nomord(str) [ pattern(passthru) binary(passthru) continuous(passthru) ///
+        outcome(str) NOAVG avg nobase fromto prefix(str) split ] //
+// prepare predval and determine value of outcome
+    if `"`outcome'"'!="" {
+        tempname predv
+        mat `predv' = r(predval)
+        mat `predv' = `predv'[1...,`outcome']
+        if `nomord' {
+            local theoutcome: di el(r(catval),1,`outcome')
+        }
+        else {
+            local theoutcome: colnames `predv'
+        }
+    }
+// add scalars
+    di _n as txt "added scalars:"
+// - predval and outcome
+    local cpredval = colsof(r(predval))
+    if `"`outcome'"'!="" {
+        ereturn scalar `prefix'predval = `predv'[1,1]
+        added_scalar `prefix'predval `"`lab_predval'"'
+        ereturn scalar `prefix'outcome = `theoutcome'
+        added_scalar `prefix'outcome
+    }
+    else if `nomord' { // add all
+        forv i=1/`cpredval' {
+            local theoutcome: di el(r(catval),1,`i')
+            ereturn scalar `prefix'predval`theoutcome' = el(r(predval),1,`i')
+            added_scalar `prefix'predval`theoutcome'
+        }
+    }
+    else { // add last
+        ereturn scalar `prefix'predval = el(r(predval),1,`cpredval')
+        added_scalar `prefix'predval
+    }
+// - delta and centered
+    ereturn scalar `prefix'delta = r(delta)
+    added_scalar `prefix'delta
+    ereturn scalar `prefix'centered = r(centered)
+    added_scalar `prefix'centered
+// add matrices
+    di _n as txt "added matrices:"
+    if `nomord'==0 {
+        if r(modeltype)=="twoeq count" & "`test'"=="" {
+            local eq: coleq e(b)
+            local eq: word 1 of `eq'
+        }
+        _estadd_prchange_PostMat r(change), prefix(`prefix') ///
+            name(dc) `pattern' `binary' `continuous' `fromto' eq(`eq')
+    }
+    else {
+        if `"`outcome'"'=="" {
+            if "`avg'"!="" local nomordmat "r(changemn)"
+            else {
+                tempname nomordmat
+                _estadd_prchange_GatherNomChMat `nomordmat' `noavg'
+            }
+            _estadd_prchange_PostMat `nomordmat', prefix(`prefix') ///
+                name(dc) `pattern' `binary' `continuous' `fromto'
+        }
+        else {
+            if `nomord'==2 {
+                _estadd_prchange_GetEqnmNomModl `theoutcome'
+            }
+            if `"`split'"'!="" {
+                _estadd_prchange_PostMat r(change`theoutcome'), prefix(`prefix') ///
+                    name(dc) `pattern' `binary' `continuous' `fromto' eq(`eq')
+            }
+            else {
+                _estadd_prchange_PostMat r(change), prefix(`prefix') ///
+                    name(dc) `pattern' `binary' `continuous' `fromto' eq(`eq')
+            }
+        }
+    }
+    if `"`base'"'=="" {
+        _estadd_prchange_PostMat r(baseval), prefix(`prefix') name(X)
+    }
+    if `"`pattern'"'=="" {
+        _estadd_prchange_dcNote, prefix(`prefix') name(dc) `binary' `continuous'
+    }
+end
+program define _estadd_prchange_dcNote
+    syntax [ , prefix(str) name(str) binary(str) continuous(str) ]
+    local res `""{res:minmax} change" "{res:01} change" "{res:delta} change" "{res:sd} change" "{res:margefct}""'
+    local bres: word `binary' of `res'
+    local cres: word `continuous' of `res'
+    di _n as txt `"first row in e(dc) contains:"'
+    di _n `"  `bres' for binary variables"'
+    di    `"  `cres' for continuous variables"'
+end
+program define _estadd_prchange_PostMat, eclass
+    syntax anything, name(str) [ Fromto eq(str) prefix(str) ///
+        pattern(passthru) binary(passthru) continuous(passthru) ]
+    capt confirm matrix `anything'
+    if _rc exit
+    tempname tmp1
+    local nmlist "`name'"
+    matrix `tmp1' = `anything'
+    if `"`eq'"'!="" {
+        mat coleq `tmp1' = `"`eq'"'
+    }
+    if `"`pattern'`binary'`continuous'"'!="" {
+        tempname pattmat
+        _estadd_prchange_Merge `tmp1', pattmat(`pattmat') `pattern' `binary' `continuous' `fromto'
+    }
+    if "`fromto'"!="" {
+        local nmlist "`nmlist' `name'from `name'to"
+        tempname tmp tmp2 tmp3
+        mat rename `tmp1' `tmp'
+        local r = rowsof(`tmp')
+        local i = 1
+        while (`i'<=`r') {
+            if (`r'-`i')>=2 {
+                mat `tmp2' = nullmat(`tmp2') \ `tmp'[`i++',1...] // from
+                mat `tmp3' = nullmat(`tmp3') \ `tmp'[`i++',1...] // to
+            }
+            mat `tmp1' = nullmat(`tmp1') \ `tmp'[`i++',1...]
+        }
+        mat drop `tmp'
+    }
+    local i 0
+    foreach nm of local nmlist {
+        local ++i
+        local rown: rown `tmp`i''
+        mat rown `tmp`i'' = `rown'  // fix problem with leading blanks in equations
+        ereturn matrix `prefix'`nm' = `tmp`i''
+        added_matrix `prefix'`nm' _rown
+    }
+    if `"`pattmat'"'!="" {
+        ereturn matrix `prefix'pattern = `pattmat'
+        added_matrix `prefix'pattern
+    }
+end
+program define _estadd_prchange_Merge
+    syntax name(name=tmp1) [, pattmat(str) pattern(str) binary(str) continuous(str) fromto ]
+    tempname tmp
+    mat rename `tmp1' `tmp'
+    local r = cond("`fromto'"!="", 3, 1)
+    mat `tmp1' = `tmp'[1..`r',1...]*.
+    mat `pattmat' = `tmp'[1,1...]*.
+    local rtot = rowsof(`tmp')
+    mat rown `tmp1' = main
+    mat rown `pattmat' = :type
+    local vars: colnames `tmp1'
+    local eqs: coleq `tmp1', quoted
+    local j 0
+    foreach var of local vars {
+        local ++j
+        gettoken eq eqs : eqs
+        if `"`eq'"'!=`"`lasteq'"' gettoken type rest : pattern
+        else                      gettoken type rest : rest
+        local lasteq `"`eq'"'
+        if `"`type'"'=="" {
+            capt assert `var'==0|`var'==1 if e(sample) & `var'<.
+            if _rc local type `continuous'
+            else   local type `binary'
+        }
+        local ii = (`type'-1)*`r'+1
+        forv i = 1/`r' {
+            if `r'>1 & `i'<3 & `ii'>=`rtot' {
+                mat `tmp1'[`i',`j'] = .z
+            }
+            else {
+                mat `tmp1'[`i',`j'] = `tmp'[`ii++',`j']
+            }
+        }
+        mat `pattmat'[1,`j'] = `type'
+    }
+    mat `tmp1' = `tmp1' \ `tmp'
+end
+program define _estadd_prchange_GatherNomChMat
+    args mat noavg
+    local cmd `"`e(cmd)'"'
+    tempname tmpmat
+    if `"`noavg'"'=="" {
+        mat `tmpmat' = r(changemn)
+        mat coleq `tmpmat' = `"Avg|Chg|"'
+        mat `mat' = `tmpmat'
+    }
+    if `"`cmd'"'=="mlogit" {
+        if c(stata_version) < 9 local outcat cat
+        else local outcat out
+        local k_cat = e(k_`outcat')
+        local eqnames `"`e(eqnames)'"'
+        if `k_cat'>`:list sizeof eqnames' { // no base equation
+            local ibase = e(ibase`outcat')
+            local baselab `"`e(baselab)'"'
+            if `"`baselab'"'=="" {
+                local baselab `"`e(base`outcat')'"'
+            }
+            forv i = 1/`k_cat' {
+                if `i'==`ibase' {
+                    local eq `"`"`baselab'"'"'
+                }
+                else gettoken eq eqnames : eqnames, quotes
+                local temp `"`temp' `eq'"'
+            }
+            local eqnames: list retok temp
+        }
+        local i 0
+        foreach eq of local eqnames {
+            local ++i
+            local theoutcome: di el(e(`outcat'),1,`i')
+            mat `tmpmat' = r(change`theoutcome')
+            mat coleq `tmpmat' = `"`eq'"'
+            mat `mat' = nullmat(`mat'), `tmpmat'
+        }
+    }
+    else if `"`cmd'"'=="mprobit" {
+        local eqnames `"`e(outeqs)'"'
+        local i 0
+        foreach eq of local eqnames {
+            local ++i
+            local theoutcome: di el(e(outcomes),`i',1)
+            mat `tmpmat' = r(change`theoutcome')
+            mat coleq `tmpmat' = `"`eq'"'
+            mat `mat' = nullmat(`mat'), `tmpmat'
+        }
+    }
+    else { // ordered models
+        local eqnames : colnames r(catval)
+        local i 0
+        foreach eq of local eqnames {
+            local ++i
+            local theoutcome: di el(r(catval),1,`i')
+            mat `tmpmat' = r(change`theoutcome')
+            mat coleq `tmpmat' = `"`eq'"'
+            mat `mat' = nullmat(`mat'), `tmpmat'
+        }
+    }
+end
+program define _estadd_prchange_GetEqnmNomModl
+    args theoutcome
+    local cmd `"`e(cmd)'"'
+    if `"`cmd'"'=="mlogit" {
+        if c(stata_version) < 9 local outcat cat
+        else local outcat out
+        local k_cat = e(k_`outcat')
+        local eqnames `"`e(eqnames)'"'
+        local nobase = (`k_cat'>`:list sizeof eqnames')
+        if `nobase' {
+            local ibase = e(ibase`outcat')
+            local baselab `"`e(baselab)'"'
+        }
+        forv i = 1/`k_cat' {
+            if `nobase' {
+                if `i'==`ibase' {
+                    local eq `"`baselab'"'
+                }
+                else gettoken eq eqnames : eqnames
+            }
+            else gettoken eq eqnames : eqnames
+            if el(e(`outcat'),1,`i')==`theoutcome' {
+                local value `"`eq'"'
+                continue, break
+            }
+        }
+    }
+    else if `"`cmd'"'=="mprobit" {
+        local eqnames `"`e(outeqs)'"'
+        local i 0
+        foreach eq of local eqnames {
+            if el(e(outcomes),`++i',1)==`theoutcome' {
+                local value `"`eq'"'
+                continue, break
+            }
+        }
+    }
+    if `"`value'"'=="" local value `theoutcome'
+    c_local eq `"`value'"'
+end
+program define _estadd_prchange_StoreEachOutc // only for nomord models
+    syntax anything [, nomord(str) nobase fromto prefix(passthru) ///
+        pattern(passthru) binary(passthru) continuous(passthru) ]
+// backup estimates
+    tempname hcurrent
+    _est hold `hcurrent', copy restore estsystem
+    if `"`nomord'"'=="2" {  // backup b and V
+        tempname b bi V Vi
+        mat `b' = e(b)
+        mat `V' = e(V)
+    }
+// cycle through categories
+    local k_kat = colsof(r(predval))
+    tempname catval catvali
+    mat `catval' = r(catval)
+    forv i=1/`k_kat' {
+        mat `catvali' = `catval'[1...,`i']
+        local catlabi: colnames `catvali'
+        local catnumi: di `catvali'[1,1]
+        if `"`nomord'"'=="2" {
+            _estadd_prchange_GetEqnmNomModl `catnumi'
+            if colnumb(`b', `"`eq':"')<. {
+                mat `bi' = `b'[1...,`"`eq':"']
+                mat `Vi' = `V'[`"`eq':"',`"`eq':"']
+            }
+            else {  // base outcome; get first eq and set zero
+                local tmp : coleq `b', q
+                gettoken tmp : tmp
+                mat `bi' = `b'[1...,`"`tmp':"'] * 0
+                mat `Vi' = `V'[`"`tmp':"',`"`tmp':"'] * 0
+            }
+            mat coleq `bi' = ""
+            mat coleq `Vi' = ""
+            mat roweq `Vi' = ""
+            erepost b=`bi' V=`Vi'
+        }
+        `qui' _estadd_prchange_AddStuffToE, split nomord(1) outcome(`i') ///
+            `base' `fromto' `pattern' `binary' `continuous' `prefix'
+        `qui' di ""
+        local qui qui
+        _eststo `anything'`catnumi', title(`"`catlabi'"') // store without e(sample)
+        di as txt "results for outcome " as res `catnumi' ///
+         as txt " stored as " as res "`anything'`catnumi'"
+    }
+// retore estimates
+    _est unhold `hcurrent'
+end
+
+* 22.
+* -estadd- subroutine: support for -prvalue- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_prvalue, eclass
+    version 9.2
+    local caller : di _caller()
+    syntax [anything] [if] [in] [ , Prefix(passthru) Replace Quietly ///
+        LABel(str) Title(passthru) swap Diff * ]
+
+// post
+    if `"`anything'"'!="" {
+        gettoken post post2 : anything
+        if `"`post'"'!="post" {
+            di as err `"`post' not allowed"'
+            exit 198
+        }
+        else if `"`label'"'!="" {
+            di as err "label() not allowed"
+            exit 198
+        }
+        _estadd_prvalue_Post `post2' `if' `in', `prefix' `replace' `quietly' ///
+            `title' `swap' `diff' `options'
+        exit
+    }
+    else if `"`title'"'!="" {
+        di as err "title() not allowed"
+        exit 198
+    }
+    else if "`swap'"!="" {
+        di as err "swap not allowed"
+        exit 198
+    }
+
+// look for e(sample)
+    confirm_esample
+
+// run prvalue
+    capt findfile prvalue.ado
+    if _rc {
+        di as error "-prvalue- from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+    `quietly' version `caller': prvalue `if' `in', `diff' `options'
+
+// append?
+    capture confirm existence `e(_estadd_prvalue)'
+    local append = (_rc==0) & ("`replace'"=="")
+    tempname prvalue prvalue_x prvalue_x2
+    if `append' {
+        mat `prvalue'   = e(_estadd_prvalue)
+        mat `prvalue_x' = e(_estadd_prvalue_x)
+        capt mat `prvalue_x2' = e(_estadd_prvalue_x2)
+        local ires = rowsof(`prvalue') + 1
+    }
+    else local ires 1
+    if `"`label'"'=="" {
+        local label "pred`ires'"
+    }
+    else {
+        local label = substr(`"`label'"', 1, 30)  // 30 characters max
+        local problemchars `": . `"""'"'
+        foreach char of local problemchars {
+            local label: subinstr local label `"`char'"' "_", all
+        }
+    }
+
+// collect results
+    tempname pred
+    mat `pred' = r(pred)
+    if `"`diff'"'!="" {
+        _estadd_prvalue_GetRidOfD `pred'
+    }
+    _estadd_prvalue_ReshapePred `pred', label(`label')
+    _estadd_prvalue_AddPred `prvalue' `pred' `append'
+    _estadd_prvalue_AddX `prvalue_x', label(`label')
+    capture confirm matrix r(x2)
+    local hasx2 = _rc==0
+    if `hasx2' {
+        _estadd_prvalue_AddX `prvalue_x2', label(`label') two
+    }
+
+// post in e()
+    di as txt _n cond(`append',"updated","added") " matrices:"
+    ereturn matrix _estadd_prvalue = `prvalue'
+    added_matrix _estadd_prvalue
+    ereturn matrix _estadd_prvalue_x = `prvalue_x'
+    added_matrix _estadd_prvalue_x
+    if `hasx2' {
+        ereturn matrix _estadd_prvalue_x2 = `prvalue_x2'
+        added_matrix _estadd_prvalue_x2
+    }
+end
+program _estadd_prvalue_GetRidOfD
+    args pred
+    local coln: colnames `pred'
+    local firstcol: word 1 of `coln'
+    local nfirstcol = substr("`firstcol'",2,.)
+    local coln : subinstr local coln "`firstcol'" "`nfirstcol'" , word
+    mat coln `pred' = `coln'
+end
+program _estadd_prvalue_ReshapePred
+    syntax anything, label(str)
+    tempname tmp res
+    local r = rowsof(`anything')
+    forv i=1/`r' {
+        mat `tmp' = `anything'[`i',1...]
+        local nm: rownames `tmp'
+        mat coleq `tmp' = `"`nm'"'
+        mat `res' = nullmat(`res'), `tmp'
+    }
+    mat rown `res' = `"`label'"'
+    mat `anything' = `res'
+end
+program _estadd_prvalue_AddPred
+    args prvalue pred append
+    if `append' {
+        local coln1: colfullnames `prvalue'
+        local coln2: colfullnames `pred'
+        if `"`coln1'"'!=`"`coln2'"' {
+            di as err "incompatible prvalue results"
+            exit 498
+        }
+    }
+    mat `prvalue' = nullmat(`prvalue') \ `pred'
+end
+program  _estadd_prvalue_AddX
+    syntax anything, label(str) [ two ]
+    if "`two'"!="" local two 2
+    tempname tmp
+    mat `tmp' = r(x`two')
+    mat rown `tmp' = `"`label'"'
+    mat `anything' = nullmat(`anything') \ `tmp'
+end
+program _estadd_prvalue_Post, eclass
+    syntax [name(name=post2)] [ , Prefix(name) Replace Quietly ///
+        Title(passthru) swap ]
+    capture confirm matrix e(_estadd_prvalue)
+    if _rc {
+        di as err "prvalue results not found"
+        exit 498
+    }
+// backup estimates
+    tempname hcurrent
+    _est hold `hcurrent', copy restore estsystem
+    local cmd = e(cmd)
+    local depvar = e(depvar)
+    local N = e(N)
+    local estname `"`e(_estadd_estimates_name)'"'
+
+// get results
+    tempname prvalue prvalue_x prvalue_x2
+    mat `prvalue' = e(_estadd_prvalue)
+    mat `prvalue_x' = e(_estadd_prvalue_x)
+    capture confirm matrix e(_estadd_prvalue_x2)
+    local hasx2 = _rc==0
+    if `hasx2' {
+        mat `prvalue_x2' = e(_estadd_prvalue_x2)
+    }
+
+// return prvalues
+    tempname tmp tmp2 b se
+    if "`swap'"=="" {
+        local eqs: coleq `prvalue', q
+        local eqs: list uniq eqs
+        foreach eq of local eqs {
+            mat `tmp' = `prvalue'[1...,`"`eq':"']
+            mat `tmp2' = `tmp'[1...,1]'
+            mat coleq `tmp2' = `"`eq'"'
+            mat roweq `tmp2' = ""
+            mat `b' = nullmat(`b'), `tmp2'
+            mat `tmp2' = `tmp'[1...,`"`eq':SE"']'
+            mat coleq `tmp2' = `"`eq'"'
+            mat roweq `tmp2' = ""
+            mat `se' = nullmat(`se'), `tmp2'
+        }
+        mat drop `tmp' `tmp2'
+    }
+    else {
+        local r = rowsof(`prvalue')
+        local c = colsof(`prvalue')
+        local coln: colnames `prvalue'
+        local eqs: coleq `prvalue', q
+        mat coln `prvalue' = `eqs'
+        mat coleq `prvalue' = `coln'
+        local coln: list uniq coln
+        local ncol: list sizeof coln
+        local icol: list posof "SE" in coln
+        forv i=1/`r' {
+            mat `tmp' = `prvalue'[`i',1...]
+            local labl : rownames `tmp'
+            forv j=1(`ncol')`c' {
+                mat `tmp2' = nullmat(`tmp2'), `tmp'[1...,`j']
+            }
+            mat coleq `tmp2' = `"`labl'"'
+            mat `b' = nullmat(`b'), `tmp2'
+            mat drop `tmp2'
+            forv j=`icol'(`ncol')`c' {
+                mat `tmp2' = nullmat(`tmp2'), `tmp'[1...,`j']
+            }
+            mat coleq `tmp2' = `"`labl'"'
+            mat `se' = nullmat(`se'), `tmp2'
+            mat drop `tmp2'
+        }
+        mat drop `tmp'
+    }
+    ereturn post `b', obs(`N')
+    ereturn local model "`cmd'"
+    ereturn local cmd "estadd_prvalue"
+    ereturn local depvar "`depvar'"
+    di as txt _n "scalars:"
+    added_scalar N
+    di as txt _n "macros:"
+    added_macro depvar
+    added_macro cmd
+    added_macro model
+    added_macro properties
+    di as txt _n "matrices:"
+    added_matrix b "predictions"
+    ereturn matrix se = `se'
+    added_matrix se "standard errors"
+    local istat 0
+    foreach stat in LB UB Category Cond {
+        local elabel: word `++istat' of "lower CI bounds" "upper CI bounds" ///
+            "outcome values" "conditional predictions"
+        if "`swap'"=="" {
+            foreach eq of local eqs {
+                local colnumb = colnumb(`prvalue',`"`eq':`stat'"')
+                if `colnumb'>=. continue
+                mat `tmp2' = `prvalue'[1...,`colnumb']'
+                mat coleq `tmp2' = `"`eq'"'
+                mat roweq `tmp2' = ""
+                mat `tmp' = nullmat(`tmp'), `tmp2'
+            }
+        }
+        else {
+            local icol: list posof "`stat'" in coln
+            if `icol'==0 continue
+            forv i=1/`r' {
+                mat `tmp2' = `prvalue'[`i',1...]
+                local labl : rownames `tmp2'
+                mat coleq `tmp2' = `"`labl'"'
+                forv j=`icol'(`ncol')`c' {
+                    mat `tmp' = nullmat(`tmp'), `tmp2'[1...,`j']
+                }
+            }
+            mat drop `tmp2'
+        }
+        capt confirm matrix `tmp'
+        if _rc==0 {
+            ereturn matrix `prefix'`stat' = `tmp'
+            added_matrix `prefix'`stat' "`elabel'"
+        }
+    }
+
+// return x-values
+    matrix `prvalue_x' = `prvalue_x''
+    ereturn matrix `prefix'X = `prvalue_x'
+    added_matrix `prefix'X _rown
+    if `hasx2' {
+        matrix `prvalue_x2' = `prvalue_x2''
+        ereturn matrix `prefix'X2 = `prvalue_x2'
+        added_matrix `prefix'X2 _rown
+    }
+
+// store
+    if "`post2'"!="" {
+        _eststo `estname'`post2', `title'
+        di as txt _n "results stored as " as res "`estname'`post2'"
+    }
+    else if `"`title'"'!="" {
+        estimates change ., `title'
+    }
+
+// retore estimates
+    if "`post2'"!="" {
+        _est unhold `hcurrent'
+    }
+    else {
+        _est unhold `hcurrent', not
+    }
+end
+
+* 23.
+* -estadd- subroutine: support for -asprvalue- by Long and Freese
+* (see http://www.indiana.edu/~jslsoc/spost.htm)
+program define estadd_asprvalue, eclass
+    version 9.2
+    local caller : di _caller()
+    syntax [anything] [ , Prefix(passthru) Replace Quietly ///
+        LABel(str) Title(passthru) swap * ]
+
+// post
+    if `"`anything'"'!="" {
+        gettoken post post2 : anything
+        if `"`post'"'!="post" {
+            di as err `"`post' not allowed"'
+            exit 198
+        }
+        else if `"`label'"'!="" {
+            di as err "label() not allowed"
+            exit 198
+        }
+        _estadd_asprvalue_Post `post2' , `prefix' `replace' `quietly' ///
+            `title' `swap' `options'
+        exit
+    }
+    else if `"`title'"'!="" {
+        di as err "title() not allowed"
+        exit 198
+    }
+    else if "`swap'"!="" {
+        di as err "swap not allowed"
+        exit 198
+    }
+
+// look for e(sample)
+    confirm_esample
+
+// run prvalue
+    capt findfile asprvalue.ado
+    if _rc {
+        di as error "-asprvalue- from the -spost9_ado- package by Long and Freese required"
+        di as error `"type {stata "net from http://www.indiana.edu/~jslsoc/stata"}"'
+        error 499
+    }
+    `quietly' version `caller': asprvalue , `options'
+
+// append?
+    capture confirm existence `e(_estadd_asprval)'
+    local append = (_rc==0) & ("`replace'"=="")
+    tempname asprval asprval_asv asprval_csv
+    if `append' {
+        mat `asprval'          = e(_estadd_asprval)
+        capt mat `asprval_asv' = e(_estadd_asprval_asv)
+        capt mat `asprval_csv' = e(_estadd_asprval_csv)
+        local ires = rowsof(`asprval') + 1
+    }
+    else local ires 1
+    if `"`label'"'=="" {
+        local label "pred`ires'"
+    }
+    else {
+        local label = substr(`"`label'"', 1, 30)  // 30 characters max
+        local problemchars `": . `"""'"'
+        foreach char of local problemchars {
+            local label: subinstr local label `"`char'"' "_", all
+        }
+    }
+
+// collect results
+    tempname res
+    mat `res' = r(p)
+    _estadd_asprvalue_Reshape `res', label(`label')
+    _estadd_asprvalue_Add `asprval' `res' `append'
+    capture confirm matrix r(asv)
+    local hasasv = _rc==0
+    if `hasasv' {
+        mat `res' = r(asv)
+        _estadd_asprvalue_Reshape `res', label(`label')
+        _estadd_asprvalue_Add `asprval_asv' `res' `append'
+    }
+    capture confirm matrix r(csv)
+    local hascsv = _rc==0
+    if `hascsv' {
+        _estadd_asprvalue_AddCsv `asprval_csv', label(`label')
+    }
+
+// post in e()
+    di as txt _n cond(`append',"updated","added") " matrices:"
+    ereturn matrix _estadd_asprval = `asprval'
+    added_matrix _estadd_asprval
+    if `hasasv' {
+        ereturn matrix _estadd_asprval_asv = `asprval_asv'
+        added_matrix _estadd_asprval_asv
+    }
+    if `hascsv' {
+        ereturn matrix _estadd_asprval_csv = `asprval_csv'
+        added_matrix _estadd_asprval_csv
+    }
+end
+program _estadd_asprvalue_Reshape
+    syntax anything, label(str)
+    tempname tmp res
+    local r = rowsof(`anything')
+    forv i=1/`r' {
+        mat `tmp' = `anything'[`i',1...]
+        local nm: rownames `tmp'
+        mat coleq `tmp' = `"`nm'"'
+        mat `res' = nullmat(`res'), `tmp'
+    }
+    mat rown `res' = `"`label'"'
+    mat `anything' = `res'
+end
+program _estadd_asprvalue_Add
+    args master using append
+    if `append' {
+        local coln1: colfullnames `master'
+        local coln2: colfullnames `using'
+        if `"`coln1'"'!=`"`coln2'"' {
+            di as err "incompatible asprvalue results"
+            exit 498
+        }
+    }
+    mat `master' = nullmat(`master') \ `using'
+end
+program _estadd_asprvalue_AddCsv
+    syntax anything, label(str)
+    tempname tmp
+    mat `tmp' = r(csv)
+    mat rown `tmp' = `"`label'"'
+    mat `anything' = nullmat(`anything') \ `tmp'
+end
+program _estadd_asprvalue_Post, eclass
+    syntax [name(name=post2)] [ , Prefix(name) Replace Quietly ///
+        Title(passthru) swap ]
+    capture confirm matrix e(_estadd_asprval)
+    if _rc {
+        di as err "asprvalue results not found"
+        exit 498
+    }
+
+// backup estimates
+    tempname hcurrent
+    _est hold `hcurrent', copy restore estsystem
+    local cmd = e(cmd)
+    local depvar = e(depvar)
+    local N = e(N)
+    local estname `"`e(_estadd_estimates_name)'"'
+
+// get results
+    tempname asprval asprval_asv asprval_csv
+    mat `asprval' = e(_estadd_asprval)
+    capture confirm matrix e(_estadd_asprval_asv)
+    local hasasv = _rc==0
+    if `hasasv' {
+        mat `asprval_asv' = e(_estadd_asprval_asv)
+    }
+    capture confirm matrix e(_estadd_asprval_csv)
+    local hascsv = _rc==0
+    if `hascsv' {
+        mat `asprval_csv' = e(_estadd_asprval_csv)
+    }
+
+// return predictions
+    tempname tmp tmp2 b
+    if "`swap'"=="" {
+        local eqs: coleq `asprval', q
+        local eqs: list uniq eqs
+        foreach eq of local eqs {
+            mat `tmp' = `asprval'[1...,`"`eq':"']
+            mat `tmp2' = `tmp'[1...,1]'
+            mat coleq `tmp2' = `"`eq'"'
+            mat roweq `tmp2' = ""
+            mat `b' = nullmat(`b'), `tmp2'
+        }
+        mat drop `tmp' `tmp2'
+    }
+    else {
+        local r = rowsof(`asprval')
+        local coln: colnames `asprval'
+        local eqs: coleq `asprval', q
+        mat coln `asprval' = `eqs'
+        forv i=1/`r' {
+            mat `tmp' = `asprval'[`i',1...]
+            local labl : rownames `tmp'
+            mat coleq `tmp' = `"`labl'"'
+            mat `b' = nullmat(`b'), `tmp'
+        }
+        mat drop `tmp'
+    }
+    ereturn post `b', obs(`N')
+    ereturn local model "`cmd'"
+    ereturn local cmd "estadd_asprvalue"
+    ereturn local depvar "`depvar'"
+    di as txt _n "scalars:"
+    added_scalar N
+    di as txt _n "macros:"
+    added_macro depvar
+    added_macro cmd
+    added_macro model
+    added_macro properties
+    di as txt _n "matrices:"
+    added_matrix b "predictions"
+
+// return asv-values
+    if `hasasv' {
+        if "`swap'"=="" {
+            local vars: coleq `asprval_asv'
+            local vars: list uniq vars
+            local cats: colnames `asprval_asv'
+            local cats: list uniq cats
+            foreach var of local vars {
+                foreach cat of local cats {
+                    mat `tmp2' = `asprval_asv'[1...,`"`var':`cat'"']'
+                    mat coleq `tmp2' = `"`cat'"'
+                    mat roweq `tmp2' = ""
+                    mat `tmp' = nullmat(`tmp'), `tmp2'
+                }
+                mat rown `tmp' = `"`var'"'
+                mat `b' = nullmat(`b') \ `tmp'
+                mat drop `tmp'
+            }
+        }
+        else {
+            local r = rowsof(`asprval_asv')
+            local vars: coleq `asprval_asv'
+            local vars: list uniq vars
+            forv i=1/`r' {
+                foreach var of local vars {
+                    mat `tmp2' = `asprval_asv'[`i',`"`var':"']
+                    local lbl: rownames `tmp2'
+                    mat coleq `tmp2' = `"`lbl'"'
+                    mat rown `tmp2' = `"`var'"'
+                    mat `tmp' = nullmat(`tmp') \ `tmp2'
+                }
+                mat `b' = nullmat(`b') , `tmp'
+                mat drop `tmp'
+            }
+        }
+        ereturn matrix `prefix'asv = `b'
+        added_matrix `prefix'asv _rown
+    }
+// return csv-values
+    if `hascsv' {
+        matrix `asprval_csv' = `asprval_csv''
+        ereturn matrix `prefix'csv = `asprval_csv'
+        added_matrix `prefix'csv _rown
+    }
+
+// store
+    if "`post2'"!="" {
+        _eststo `estname'`post2', `title'
+        di as txt _n "results stored as " as res "`estname'`post2'"
+    }
+    else if `"`title'"'!="" {
+        estimates change ., `title'
+    }
+
+// retore estimates
+    if "`post2'"!="" {
+        _est unhold `hcurrent'
+    }
+    else {
+        _est unhold `hcurrent', not
+    }
+end
+
+* 24. estadd_margins
+program define estadd_margins, eclass
+    version 11.0
+    local caller : di _caller()
+    syntax [ anything(everything equalok)] [fw aw iw pw] [, Prefix(name) Replace Quietly * ]
+
+// set default prefix
+    if "`prefix'"=="" local prefix "margins_"
+
+// compute and return the results
+    if `"`weight'`exp'"'!="" local wgtexp `"[`weight'`exp']"'
+    `quietly' version `caller': margins `anything' `wgtexp', `options'
+
+// check names
+    local rscalars: r(scalars)
+    local rmacros: r(macros)
+    local rmatrices: r(matrices)
+    local rmatrices: subinstr local rmatrices "V" "se", word
+    if "`replace'"=="" {
+        foreach nmlist in rscalars rmacros rmatrices  {
+            foreach name of local `nmlist' {
+                confirm_new_ename `prefix'`name'
+            }
+        }
+    }
+
+// add results
+    di as txt _n "added scalars:"
+    foreach name of local rscalars {
+        ereturn scalar `prefix'`name' = r(`name')
+        added_scalar `prefix'`name'
+    }
+    di as txt _n "added macros:"
+    foreach name of local rmacros {
+        ereturn local `prefix'`name' `"`r(`name')'"'
+        added_macro `prefix'`name'
+    }
+    di as txt _n "added matrices:"
+    tempname tmpmat
+    foreach name of local rmatrices {
+        if "`name'"=="se" {
+            mat `tmpmat' = vecdiag(r(V))
+            forv i = 1/`=colsof(`tmpmat')' {
+                mat `tmpmat'[1,`i'] = sqrt(`tmpmat'[1,`i'])
+            }
+        }
+        else {
+            mat `tmpmat' = r(`name')
+        }
+        eret matrix `prefix'`name' = `tmpmat'
+        added_matrix `prefix'`name'
+    }
+end
+
+* 99.
+* copy of erepost.ado, version 1.0.1, Ben Jann, 30jul2007
+* used by estadd_listcoef and estadd_prchange
+prog erepost, eclass
+    version 8.2
+    syntax [anything(equalok)] [, cmd(str) noEsample Esample2(varname) REName ///
+        Obs(passthru) Dof(passthru) PROPerties(passthru) * ]
+    if "`esample'"!="" & "`esample2'"!="" {
+        di as err "only one allowed of noesample and esample()"
+        exit 198
+    }
+// parse [b = b] [V = V]
+    if `"`anything'"'!="" {
+        tokenize `"`anything'"', parse(" =")
+        if `"`7'"'!="" error 198
+        if `"`1'"'=="b" {
+            if `"`2'"'=="=" & `"`3'"'!="" {
+                local b `"`3'"'
+                confirm matrix `b'
+            }
+            else error 198
+            if `"`4'"'=="V" {
+                if `"`5'"'=="=" & `"`6'"'!="" {
+                    local v `"`6'"'
+                    confirm matrix `b'
+                }
+                else error 198
+            }
+            else if `"`4'"'!="" error 198
+        }
+        else if `"`1'"'=="V" {
+            if `"`4'"'!="" error 198
+            if `"`2'"'=="=" & `"`3'"'!="" {
+                local v `"`3'"'
+                confirm matrix `v'
+            }
+            else error 198
+        }
+        else error 198
+    }
+//backup existing e()'s
+    if "`esample2'"!="" {
+        local sample "`esample2'"
+    }
+    else if "`esample'"=="" {
+        tempvar sample
+        gen byte `sample' = e(sample)
+    }
+    local emacros: e(macros)
+    if `"`properties'"'!="" {
+        local emacros: subinstr local emacros "properties" "", word
+    }
+    foreach emacro of local emacros {
+        local e_`emacro' `"`e(`emacro')'"'
+    }
+    local escalars: e(scalars)
+    if `"`obs'"'!="" {
+        local escalars: subinstr local escalars "N" "", word
+    }
+    if `"`dof'"'!="" {
+        local escalars: subinstr local escalars "df_r" "", word
+    }
+    foreach escalar of local escalars {
+        tempname e_`escalar'
+        scalar `e_`escalar'' = e(`escalar')
+    }
+    local ematrices: e(matrices)
+    if "`b'"=="" & `:list posof "b" in ematrices' {
+        tempname b
+        mat `b' = e(b)
+    }
+    if "`v'"=="" & `:list posof "V" in ematrices' {
+        tempname v
+        mat `v' = e(V)
+    }
+    local bV "b V"
+    local ematrices: list ematrices - bV
+    foreach ematrix of local ematrices {
+        tempname e_`ematrix'
+        matrix `e_`ematrix'' = e(`ematrix')
+    }
+// rename
+    if "`b'"!="" & "`v'"!="" & "`rename'"!="" {
+        local eqnames: coleq `b', q
+        local vnames: colnames `b'
+        mat coleq `v' = `eqnames'
+        mat coln `v' = `vnames'
+        mat roweq `v' = `eqnames'
+        mat rown `v' = `vnames'
+    }
+// post results
+    if "`esample'"=="" {
+        eret post `b' `v', esample(`sample') `obs' `dof' `properties' `options'
+    }
+    else {
+        eret post `b' `v', `obs' `dof' `properties' `options'
+    }
+    foreach emacro of local emacros {
+        eret local `emacro' `"`e_`emacro''"'
+    }
+    if `"`cmd'"'!="" {
+        eret local cmd `"`cmd'"'
+    }
+    foreach escalar of local escalars {
+        eret scalar `escalar' = scalar(`e_`escalar'')
+    }
+    foreach ematrix of local ematrices {
+        eret matrix `ematrix' = `e_`ematrix''
+    }
+end

--- a/analysis/extra_ados/estadd.hlp
+++ b/analysis/extra_ados/estadd.hlp
@@ -1,0 +1,939 @@
+{smcl}
+{* 01feb2017}{...}
+{hi:help estadd}{right:also see: {helpb esttab}, {helpb estout}, {helpb eststo}, {helpb estpost}}
+{right: {browse "http://repec.sowi.unibe.ch/stata/estout/"}}
+{hline}
+
+{title:Title}
+
+{p 4 4 2}{hi:estadd} {hline 2} Add results to (stored) estimates
+
+
+{title:Syntax}
+
+{p 8 15 2}
+{cmd:estadd} {it:{help estadd##subcommands:subcommand}} [{cmd:,}
+{it:{help estadd##opts:options}} ] [ {cmd::} {it:namelist} ]
+
+
+    where {it:namelist} is {cmd:_all} | {cmd:*} | {it:name} [{it:name} ...]
+
+{marker subcommands}
+    {it:subcommands}{col 26}description
+    {hline 65}
+    Elementary
+      {helpb estadd##local:{ul:loc}al} {it:name ...}{col 26}{...}
+add a macro
+      {helpb estadd##scalar:{ul:sca}lar} {it:name} {cmd:=} {it:exp}{col 26}{...}
+add a scalar
+      {helpb estadd##matrix:{ul:mat}rix} {it:name} {cmd:=} {it:mat}{col 26}{...}
+add a matrix
+      {helpb estadd##rreturn:r({it:name})}{col 26}{...}
+add contents of {cmd:r(}{it:name}{cmd:)} (matrix or scalar)
+
+    Statistics for each
+    coefficient
+      {helpb estadd##beta:beta}{col 26}{...}
+standardized coefficients
+      {helpb estadd##vif:vif}{col 26}{...}
+variance inflation factors (after {cmd:regress})
+      {helpb estadd##pcorr:pcorr}{col 26}{...}
+partial (and semi-partial) correlations
+      {helpb estadd##expb:expb}{col 26}{...}
+exponentiated coefficients
+      {helpb estadd##ebsd:ebsd}{col 26}{...}
+standardized factor change coefficients
+      {helpb estadd##mean:mean}{col 26}{...}
+means of regressors
+      {helpb estadd##sd:sd}{col 26}{...}
+standard deviations of regressors
+      {helpb estadd##summ:summ}{col 26}{...}
+various descriptives of the regressors
+
+    Summary statistics
+      {helpb estadd##coxsnell:coxsnell}{col 26}{...}
+Cox & Snell's pseudo R-squared
+      {helpb estadd##nagelkerke:nagelkerke}{col 26}{...}
+Nagelkerke's pseudo R-squared
+      {helpb estadd##lrtest:lrtest} {it:model}{col 26}{...}
+likelihood-ratio test
+      {helpb estadd##ysumm:ysumm}{col 26}{...}
+descriptives of the dependent variable
+
+    Other
+      {helpb estadd##margins:margins}{col 26}{...}
+add results from {cmd:margins} (Stata 11 or newer)
+
+    {help estadd##spost:SPost9}
+      {helpb estadd##brant:brant}{col 26}{...}
+add results from {cmd:brant} (if installed)
+      {helpb estadd##fitstat:fitstat}{col 26}{...}
+add results from {cmd:fitstat} (if installed)
+      {helpb estadd##listcoef:listcoef}{col 26}{...}
+add results from {cmd:listcoef} (if installed)
+      {helpb estadd##mlogtest:mlogtest}{col 26}{...}
+add results from {cmd:mlogtest} (if installed)
+      {helpb estadd##prchange:prchange}{col 26}{...}
+add results from {cmd:prchange} (if installed)
+      {helpb estadd##prvalue:prvalue}{col 26}{...}
+add results from {cmd:prvalue} (if installed)
+      {helpb estadd##asprvalue:asprvalue}{col 26}{...}
+add results from {cmd:asprvalue} (if installed)
+    {hline 65}
+
+{marker opts}
+    {it:{help estadd##options:options}}{col 26}description
+    {hline 65}
+      {cmdab:r:eplace}{col 26}{...}
+permit overwriting existing {cmd:e()}'s
+      {cmdab:p:refix(}{it:string}{cmd:)}{col 26}{...}
+specify prefix for names of added results
+      {cmdab:q:uietly}{col 26}{...}
+suppress output from subcommand (if any)
+      {it:subcmdopts}{col 26}{...}
+subcommand specific options
+    {hline 65}
+
+
+{title:Description}
+
+{p 4 4 2}
+{cmd:estadd} adds additional results to the {cmd:e()}-returns of an
+estimation command (see help {help estcom}, help {helpb ereturn}). If no
+{it:namelist} is provided, then the results are added to the
+currently active estimates (i.e. the model fit last). If these
+estimates have been previously stored, the stored copy of the
+estimates will also be modified. Alternatively, if {it:namelist} is
+provided after the colon, results are added to all indicated sets of
+stored estimates (see help {helpb estimates store} or help
+{helpb eststo}). You may use the {cmd:*} and {cmd:?}
+wildcards in {it:namelist}. Execution is silent if {it:namelist} is
+provided.
+
+{p 4 4 2}
+Adding additional results to the {cmd:e()}-returns is useful, for example,
+if the estimates be tabulated by commands such as {helpb estout}
+or {helpb esttab}. See the {help estadd##examples:Examples} section below for
+illustration of the usage of {cmd:estadd}.
+
+{p 4 4 2}Technical note: Some of the subcommands below make use of the
+information contained in {cmd:e(sample)} to determine estimation sample.
+These subcommands return error if the estimates do not contain
+{cmd:e(sample)}.
+
+
+{title:Subcommands}
+
+{dlgtab:Elementary}
+{marker local}
+{p 4 8 2}
+{cmd:estadd} {cmdab:loc:al} {it:name ...}
+
+{p 8 8 2}
+adds in macro {cmd:e(}{it:name}{cmd:)} the specified contents (also
+see help {helpb ereturn}).
+
+{marker scalar}
+{p 4 8 2}
+{cmd:estadd} {cmdab:sca:lar} {it:name} {cmd:=} {it:exp}
+
+{p 8 8 2}
+adds in scalar {cmd:e(}{it:name}{cmd:)} the evaluation of {it:exp}
+(also see help {helpb ereturn}). {it:name} must not be {cmd:b} or {cmd:V}.
+
+{p 4 8 2}
+{cmd:estadd} {cmdab:sca:lar} {cmd:r(}{it:name}{cmd:)}
+
+{p 8 8 2}
+adds in scalar {cmd:e(}{it:name}{cmd:)} the value of scalar 
+{cmd:r(}{it:name}{cmd:)}. {it:name} must not be {cmd:b} or {cmd:V}.
+
+{p 4 8 2}
+{cmd:estadd} {cmdab:sca:lar} {it:name}
+
+{p 8 8 2}
+adds in scalar {cmd:e(}{it:name}{cmd:)} the the value of scalar 
+{it:name}. {it:name} must not be {cmd:b} or {cmd:V}.
+
+{marker matrix}
+{p 4 8 2}
+{cmd:estadd} {cmdab:mat:rix} {it:name} {cmd:=} {it:matrix_expression}
+
+{p 8 8 2}
+adds in matrix {cmd:e(}{it:name}{cmd:)} the evaluation of {it:matrix_expression}
+(also see help {helpb matrix define}). {it:name} must not be {cmd:b} or {cmd:V}.
+
+{p 4 8 2}
+{cmd:estadd} {cmdab:mat:rix} {cmd:r(}{it:name}{cmd:)}
+
+{p 8 8 2}
+adds in matrix {cmd:e(}{it:name}{cmd:)} a copy of matrix 
+{cmd:r(}{it:name}{cmd:)}. {it:name} must not be {cmd:b} or {cmd:V}.
+
+{p 4 8 2}
+{cmd:estadd} {cmdab:mat:rix} {it:name}
+
+{p 8 8 2}
+adds in matrix {cmd:e(}{it:name}{cmd:)} a copy of matrix {it:name}. {it:name} 
+must not be {cmd:b} or {cmd:V}.
+
+{marker rreturn}
+{p 4 8 2}
+{cmd:estadd} {cmd:r(}{it:name}{cmd:)}
+
+{p 8 8 2}
+adds in {cmd:e(}{it:name}{cmd:)} the value of scalar {cmd:r(}{it:name}{cmd:)}
+or a copy of matrix {cmd:r(}{it:name}{cmd:)}, depending on the nature of
+{cmd:r(}{it:name}{cmd:)}. {it:name} must not be {cmd:b} or {cmd:V}.
+
+
+{dlgtab:Statistics for each coefficient}
+{marker beta}
+{p 4 8 2}
+{cmd:estadd} {cmd:beta}
+
+{p 8 8 2}
+adds in {cmd:e(beta)} the standardized beta coefficients.
+
+{marker vif}
+{p 4 8 2}
+{cmd:estadd} {cmd:vif} [{cmd:,} {cmdab:tol:erance} {cmdab:sqr:vif} ]
+
+{p 8 8 2}
+adds in {cmd:e(vif)} the variance inflation factors (VIFs) for the
+regressors (see help {helpb vif}). Note that {cmd:vif} only works
+with estimates produced by {helpb regress}. {cmd:tolerance}
+additionally adds the tolerances (1/VIF) in {cmd:e(tolerance)}.
+{cmd:sqrvif} additionally adds the square roots of the VIFs in
+{cmd:e(sqrvif)}.
+
+{marker pcorr}
+{p 4 8 2}
+{cmd:estadd} {cmd:pcorr} [{cmd:, semi} ]
+
+{p 8 8 2}
+adds the partial correlations (see help {helpb pcorr}) and,
+optionally, the semi-partial correlations between the dependent
+variable and the individual regressors (see, e.g., the {cmd:pcorr2}
+package from the SSC Archive). In the case of multiple-equations
+models, the results are computed for the first equation only. The
+partial correlations will be returned in {cmd:e(pcorr)} and, if
+{cmd:semi} is specified, the semi-partial correlations will be
+returned in {cmd:e(spcorr)}.
+
+{marker expb}
+{p 4 8 2}
+{cmd:estadd} {cmd:expb} [{cmd:,} {cmdab:nocons:tant} ]
+
+{p 8 8 2}
+adds in {cmd:e(expb)} the exponentiated coefficients (see the help
+{it:{help eform_option}}). {cmd:noconstant} excludes the constant
+from the added results.
+
+{marker ebsd}
+{p 4 8 2}
+{cmd:estadd} {cmd:ebsd}
+
+{p 8 8 2}
+adds in {cmd:e(ebsd)} the standardized factor change coefficients,
+i.e. exp(b_jS_j), where b_j is the raw coefficient and S_j is the
+standard deviation of regressor j, that are sometimes reported for
+logistic regression (see Long 1997).
+
+{marker mean}
+{p 4 8 2}
+{cmd:estadd} {cmd:mean}
+
+{p 8 8 2}
+adds in {cmd:e(mean)} the means of the regressors.
+
+{marker sd}
+{p 4 8 2}
+{cmd:estadd} {cmd:sd} [{cmd:,} {cmdab:nob:inary} ]
+
+{p 8 8 2}
+adds in {cmd:e(sd)} the standard deviations of the regressors.
+{cmd:nobinary} suppresses the computation of the standard deviation
+for 0/1 variables.
+
+{marker summ}
+{p 4 8 2}
+{cmd:estadd} {cmd:summ} [{cmd:,} {it:stats} ]
+
+{p 8 8 2}
+adds vectors of the regressors' descriptive statistics to the
+estimates. The following {it:stats} are available:
+{p_end}
+{marker stats}
+        {it:stats}{col 26}description
+        {hline 59}
+          {cmdab:me:an}{col 26}mean
+          {cmdab:su:m}{col 26}sum
+          {cmdab:mi:n}{col 26}minimum
+          {cmdab:ma:x}{col 26}maximum
+          {cmdab:ra:nge}{col 26}range = max - min
+          {cmd:sd}{col 26}standard deviation
+          {cmdab:v:ar}{col 26}variance
+          {cmd:cv}{col 26}coefficient of variation (sd/mean)
+          {cmdab:sem:ean}{col 26}standard error of mean = sd/sqrt(n)
+          {cmdab:sk:ewness}{col 26}skewness
+          {cmdab:k:urtosis}{col 26}kurtosis
+          {cmd:p1}{col 26}1st percentile
+          {cmd:p5}{col 26}5th percentile
+          {cmd:p10}{col 26}10th percentile
+          {cmd:p25}{col 26}25th percentile
+          {cmd:p50}{col 26}50th percentile
+          {cmd:p75}{col 26}75th percentile
+          {cmd:p90}{col 26}90th percentile
+          {cmd:p95}{col 26}95th percentile
+          {cmd:p99}{col 26}99th percentile
+          {cmd:iqr}{col 26}interquartile range = p75 - p25
+          {cmd:all}{col 26}all of the above
+          {cmdab:med:ian}{col 26}equivalent to specifying "{cmd:p50}"
+          {cmd:q}{col 26}equivalent to specifying "{cmd:p25 p50 p75}"
+        {hline 59}
+
+{p 8 8 2}
+The default is {cmd:mean sd min max}. Alternatively, indicate the
+desired statistics. For example, to add information on the
+regressors' skewness and kurtosis, type
+
+            {inp:. estadd summ, skewness kurtosis}
+
+{p 8 8 2}
+The statistics names are used as the names for the returned {cmd:e()}
+matrices. For example, {cmd:estadd summ, mean} will store the means
+of the regressors in {cmd:e(mean)}.
+
+
+{dlgtab:Summary statistics}
+{marker coxsnell}
+{p 4 8 2}
+{cmd:estadd} {cmd:coxsnell}
+
+{p 8 8 2}
+adds in {cmd:e(coxsnell)} the Cox & Snell pseudo R-squared, which is
+defined as
+
+{p 12 12 2}
+r2_coxsnell = 1 - ( L0 / L1 )^(2/N)
+
+{p 8 8 2}
+where L0 is the likelihood of the model without regressors, L1 the
+likelihood of the full model, and N is the sample size.
+
+{marker nagelkerke}
+{p 4 8 2}
+{cmd:estadd} {cmd:nagelkerke}
+
+{p 8 8 2}
+adds in {cmd:e(nagelkerke)} the Nagelkerke pseudo R-squared (or Cragg
+& Uhler pseudo R-squared), which is defined as
+
+{p 12 12 2}
+r2_nagelkerke = r2_coxsnell / (1 - L0^(2/N))
+
+{marker lrtest}
+{p 4 8 2}
+{cmd:estadd} {cmd:lrtest} {it:model} [{cmd:,} {cmdab:n:ame:(}{it:string}{cmd:)}
+{it:{help lrtest:lrtest_options}} ]
+
+{p 8 8 2}
+adds the results from a likelihood-ratio test, where {it:model} is
+the comparison model (see help {helpb lrtest}). Added are
+{cmd:e(lrtest_chi2)}, {cmd:e(lrtest_df)}, and {cmd:e(lrtest_p)}. The
+names may be modified using the {cmd:name()} option. Specify
+{cmd:name(}{it:myname}{cmd:)} to add {cmd:e(}{it:myname}{cmd:chi2)},
+{cmd:e(}{it:myname}{cmd:df)}, and {cmd:e(}{it:myname}{cmd:p)}. See
+help {helpb lrtest} for the {it:lrtest_options}.
+
+{marker ysumm}
+{p 4 8 2}
+{cmd:estadd} {cmd:ysumm} [{cmd:,} {it:stats} ]
+
+{p 8 8 2}
+adds descriptive statistics of the dependent variable. See the
+{helpb estadd##summ:summ} subcommand above for a list of the available
+{it:stats}. The default is {cmd:mean sd min max}. The default prefix
+for the names of the added scalars is {cmd:y} (e.g. the mean of the
+dependent variable will be returned in {cmd:e(ymean)}). Use
+{cmd:estadd}'s {cmd:prefix()} option to change the prefix. If a model
+has multiple dependent variables, results for the first variable will
+be added.
+
+{dlgtab:Other}
+{marker margins}
+{p 4 8 2}
+{cmd:estadd} {cmd:margins} [{it:marginlist}] [{it:if}] [{it:in}] [{it:weight}] [, {it:options} ]
+
+{p 8 8 2} 
+adds results from the {cmd:margins} command, which was introduced 
+in Stata 11. See help {helpb margins} for options. All results returned by 
+{cmd:margins} except {cmd:e(V)} are added using "{cmd:margins_}" as a default 
+prefix. For example, the margins are added in {cmd:e(margins_b)}. The 
+standard errors are added in {cmd:e(margins_se)}. Use the {helpb estadd##opts:prefix()} 
+option to change the default prefix.
+
+{marker spost}
+{dlgtab:SPost9}
+
+{p 4 4 2} The following subcommands are wrappers for
+commands from Long and Freese's {helpb SPost9} package (see
+{browse "http://www.indiana.edu/~jslsoc/spost9.htm"}). Type
+
+        . {net "from http://www.indiana.edu/~jslsoc/stata":net from http://www.indiana.edu/~jslsoc/stata}
+
+{p 4 4 2}
+to obtain the {cmd:SPost9} package (spost9_ado). {cmd:SPost} for Stata 8 (spostado) is not
+supported.
+
+{p 4 4 2}For examples on using the subcommands see
+{browse "http://repec.sowi.unibe.ch/stata/estout/spost.html"}.
+
+{marker brant}
+{p 4 8 2}
+{cmd:estadd brant} [{cmd:,} {it:{help brant:brant_options}} ]
+
+{p 8 8 2}
+applies {helpb brant} from Long and
+Freese's {helpb SPost} package and adds the returned results to
+{cmd:e()}. You may specify {it:brant_options} as described in
+help {helpb brant}. The following results are added:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        Scalars
+          {cmd:brant_chi2}  Chi-squared of overall Brant test
+          {cmd:brant_df}    Degrees of freedom of overall Brant test
+          {cmd:brant_p}     P-value of overall Brant test
+
+        Matrix
+          {cmd:brant}       Test results for individual regressors
+                      (rows: chi2, p<chi2)
+        {hline 60}
+
+{p 4 4 2}To address the rows of {cmd:e(brant)} in {helpb estout}'s {cmd:cells()} 
+option type {cmd:brant[chi2]} and {cmd:brant[p<chi2]}.
+
+{marker fitstat}
+{p 4 8 2}
+{cmd:estadd fitstat} [{cmd:,} {it:{help fitstat:fitstat_options}} ]
+
+{p 8 8 2}
+applies {helpb fitstat} from Long and
+Freese's {helpb SPost} package and adds the returned scalars to
+{cmd:e()}. You may specify {it:fitstat_options} as described in
+help {helpb fitstat}. Depending on model
+and options, a selection of the following scalar statistics is added:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        {cmd:dev}           Deviance (D)
+        {cmd:dev_df}        Degrees of freedom of D
+        {cmd:lrx2}          LR or Wald X2
+        {cmd:lrx2_df}       Degrees of freedom of X2
+        {cmd:lrx2_p}        Prob > LR or Wald X2
+        {cmd:r2_adj}        Adjusted R2
+        {cmd:r2_mf}         McFadden's R2
+        {cmd:r2_mfadj}      McFadden's Adj R2
+        {cmd:r2_ml}         ML (Cox-Snell) R2
+        {cmd:r2_cu}         Cragg-Uhler(Nagelkerke) R2
+        {cmd:r2_mz}         McKelvey & Zavoina's R2
+        {cmd:r2_ef}         Efron's R2
+        {cmd:v_ystar}       Variance of y*
+        {cmd:v_error}       Variance of error
+        {cmd:r2_ct}         Count R2
+        {cmd:r2_ctadj}      Adj Count R2
+        {cmd:aic0}          AIC
+        {cmd:aic_n}         AIC*n
+        {cmd:bic0}          BIC
+        {cmd:bic_p}         BIC'
+        {cmd:statabic}      BIC used by Stata
+        {cmd:stataaic}      AIC used by Stata
+        {cmd:n_rhs}         Number of rhs variables
+        {cmd:n_parm}        Number of parameters
+        {hline 60}
+
+{marker listcoef}
+{p 4 8 2}
+{cmd:estadd listcoef} [{it:varlist}] [{cmd:,} {cmd:nosd} {it:{help listcoef:listcoef_options}} ]
+
+{p 8 8 2}
+applies {helpb listcoef} from Long and
+Freese's {helpb SPost} package and adds the returned results to
+{cmd:e()}. You may specify {it:listcoef_options} as described in
+help {helpb listcoef}. Furthermore,  option {cmd:nosd} suppresses 
+adding the standard deviations of the variables in {cmd:e(b_sdx)}.
+
+{p 8 8 2}Depending on the estimation command and options, several of the
+following matrices are added:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        {cmd:b_xs}          x-standardized coefficients
+        {cmd:b_ys}          y-standardized coefficients
+        {cmd:b_std}         Fully standardized coefficients
+        {cmd:b_fact}        Factor change coefficients
+        {cmd:b_facts}       Standardized factor change coefficients
+        {cmd:b_pct}         Percent change coefficients
+        {cmd:b_pcts}        Standardized percent change coefficients
+        {cmd:b_sdx}         Standard deviation of the Xs
+        {hline 60}
+
+{p 8 8 2}For nominal models ({helpb mlogit}, {helpb mprobit}) the 
+original parametrization of {cmd:e(b)} may not match the contrasts 
+computed by {cmd:listcoef}. To be able to tabulate standardized 
+coefficients along with the raw coefficients for the requested 
+contrasts, the following additional matrices are added for 
+these models:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        {cmd:b_raw}         raw coefficients
+        {cmd:b_se}          standard errors of raw coefficients
+        {cmd:b_z}           z statistics
+        {cmd:b_p}           p-values
+        {hline 60}
+
+{marker mlogtest}
+{p 4 8 2}
+{cmd:estadd mlogtest} [{it:varlist}] [{cmd:,} {it:{help mlogtest:mlogtest_options}} ]
+
+{p 8 8 2}
+applies {helpb mlogtest} from Long and
+Freese's {helpb SPost} package and adds the returned results to
+{cmd:e()}. You may specify {it:mlogtest_options} as described in
+help {helpb mlogtest}.
+
+{p 8 8 2}Depending on the specified options, a selection of the following
+returns are added:
+
+        {cmd:e(}{it:...}{cmd:)}               Contents
+        {hline 60}
+        Scalars
+          {cmd:hausman_set}{it:#}{cmd:_chi2}  Hausman IIA tests using {helpb hausman}
+          {cmd:hausman_set}{it:#}{cmd:_df}
+          {cmd:hausman_set}{it:#}{cmd:_p}
+
+          {cmd:suest_set}{it:#}{cmd:_chi2}    Hausman IIA tests using {helpb suest}
+          {cmd:suest_set}{it:#}{cmd:_df}
+          {cmd:suest_set}{it:#}{cmd:_p}
+
+          {cmd:smhsiao_set}{it:#}{cmd:_chi2}  Small-Hsiao IIA tests
+          {cmd:smhsiao_set}{it:#}{cmd:_df}
+          {cmd:smhsiao_set}{it:#}{cmd:_p}
+
+          {cmd:combine_}{it:#1}{cmd:_}{it:#2}{cmd:_chi2} Wald tests for combination of outcomes
+          {cmd:combine_}{it:#1}{cmd:_}{it:#2}{cmd:_df}
+          {cmd:combine_}{it:#1}{cmd:_}{it:#2}{cmd:_p}
+
+          {cmd:lrcomb_}{it:#1}{cmd:_}{it:#2}{cmd:_chi2}  LR tests for combination of outcomes
+          {cmd:lrcomb_}{it:#1}{cmd:_}{it:#2}{cmd:_df}
+          {cmd:lrcomb_}{it:#1}{cmd:_}{it:#2}{cmd:_p}
+
+          {cmd:wald_set}{it:#}{cmd:_chi2}     Wald tests for sets of independent
+          {cmd:wald_set}{it:#}{cmd:_df}       variables
+          {cmd:wald_set}{it:#}{cmd:_p}
+
+          {cmd:lrtest_set}{it:#}{cmd:_chi2}   LR tests for sets of independent
+          {cmd:lrtest_set}{it:#}{cmd:_df}     variables
+          {cmd:lrtest_set}{it:#}{cmd:_p}
+
+        Matrices
+          {cmd:wald}               Wald tests for individual variables
+                             (rows: chi2, df, p)
+          {cmd:lrtest}             LR tests for individual variables
+                             (rows: chi2, df, p)
+        {hline 60}
+
+{p 4 4 2}To address the rows of {cmd:e(wald)} and {cmd:e(lrtest)} in {helpb estout}'s 
+{cmd:cells()} option type the row names in brackets, for example, {cmd:wald[p]} or 
+{cmd:lrtest[chi2]}.
+
+{marker prchange}
+{p 4 8 2}
+{cmd:estadd prchange} [{it:varlist}] [{cmd:if} {it:exp}] [{cmd:in} {it:range}] [{cmd:,}
+ {cmdab:pa:ttern(}{it:typepattern}{cmd:)} {cmdab:b:inary(}{it:type}{cmd:)} {cmdab:c:ontinuous(}{it:type}{cmd:)}
+ [{cmd:no}]{cmdab:a:vg} {cmd:split}[{cmd:(}{it:prefix}{cmd:)}] {it:{help prchange:prchange_options}} ]
+
+{p 8 8 2}
+applies {helpb prchange} from Long and
+Freese's {helpb SPost} package and adds the returned results to
+{cmd:e()}. You may specify {it:prchange_options} as described in
+help {helpb prchange}. In particular, the {cmd:outcome()} option may be
+used with models for count, ordered, or nominal outcomes
+to request results for a specific outcome. Further options are:
+
+{p 8 12 2}{cmd:pattern(}{it:typepattern}{cmd:)}, {cmd:binary(}{it:type}{cmd:)}, and
+{cmd:continuous(}{it:type}{cmd:)} to determine which types of discrete change
+effects are added as the main results. The default is to add the 0 to 1
+change effect for binary variables and the standard deviation change effect
+for continuous variables. Use {cmd:binary(}{it:type}{cmd:)} and
+{cmd:continuous(}{it:type}{cmd:)} to change these defaults. Available
+types are:
+
+                {it:type}        Description
+                {hline 48}
+                {cmdab:mi:nmax}      minimum to maximum change effect
+                {cmdab:0:1}          0 to 1 change effect
+                {cmdab:d:elta}       {cmd:delta()} change effect
+                {cmdab:s:d}          standard deviation change effect
+                {cmdab:m:argefct}    marginal effect (some models only)
+                {hline 48}
+
+{p 12 12 2}Use {cmd:pattern(}{it:typepattern}{cmd:)} if you want to determine the
+type of the added effects individually for each regressor. For example,
+{bind:{cmd:pattern(minmax sd delta)}} would add {cmd:minmax} for the first regressor,
+{cmd:sd} for the second, and {cmd:delta} for the third, and then proceed
+using the defaults for the remaining variables.
+
+{p 8 12 2}{cmd:avg} to request that only the average results over 
+all outcomes are added if applied to ordered
+or nominal models ({helpb ologit}, {helpb oprobit}, {helpb slogit}, {helpb mlogit}, {helpb mprobit}). The 
+default is to add the average results as well as the individual results for 
+the different outcomes (unless {helpb prchange}'s {cmd:outcome()} option is 
+specified, in which case only results for the indicated outcome are 
+added). Furthermore, specify {cmd:noavg} to suppress the average results 
+and only add the outcome-specific results. {cmd:avg} cannot be combined with {cmd:split} 
+or {cmd:outcome()}. 
+
+{p 8 12 2}{cmd:split}[{cmd:(}{it:prefix}{cmd:)}] to save 
+each outcome's results in a separate estimation set if applied to ordered
+or nominal models ({helpb ologit}, {helpb oprobit}, {helpb slogit}, {helpb mlogit},
+{helpb mprobit}). The estimation sets are named
+{it:prefix}{it:#}, where {it:#} is the value of the outcome at hand. If no
+{it:prefix} is provided, the name of the estimation set followed by an
+underscore is used as the prefix. If the estimation set has no name
+(because it has not been stored yet) the name of the estimation command
+followed by an underscore is used as the prefix (e.g. {cmd:ologit_}). The
+estimation sets stored by the {cmd:split} option are intended for
+tabulation only and should not be used with other post-estimation
+commands.
+
+{p 8 8 2}Depending on model and options, several of the following matrices
+and scalars are added:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        Scalars
+          {cmd:centered}    {cmd:1} if effects are centered, {cmd:0} else
+          {cmd:delta}       Value of {cmd:delta()}
+          {cmd:predval}[{it:#}]  Prediction(s) at the base values
+          {cmd:outcome}     Outcome value ({cmd:outcome()}/{cmd:split} only)
+
+        Matrices
+          {cmd:dc}          Discrete change effects (rows: main, minmax,
+                      01, delta, sd [, margefct])
+          {cmd:pattern}     Types of effects in the main row of {cmd:e(dc)}
+          {cmd:X}           Base values and descriptive statistics
+                      (rows: X, SD, Min, Max)
+        {hline 60}
+
+{p 8 8 2}The {cmd:e(dc)} and {cmd:e(X)} matrices have multiple rows. The
+{cmd:e(dc)} matrix contains the main results as determined by
+{cmd:pattern()}, {cmd:binary()}, and {cmd:continuous()} in the first row.
+The second and following rows contain the separate results for each type of
+effect using the labels provided by {cmd:prchange} as row names. Type
+{cmd:dc[}{it:#}{cmd:]} or {cmd:dc[}{it:rowname}{cmd:]} to address the rows
+in {helpb estout}'s {cmd:cells()} option, where {it:#} is the row number 
+or {it:rowname} is the
+row name. For example, type {cmd:dc[-+sd/2]} to address the centered
+standard deviation change effects. To tabulate the main results (1st row),
+simply type {cmd:dc}. {cmd:e(pattern)} indicates the types of effects
+contained in the main row of {cmd:e(dc)} using numeric codes. The codes are 1
+for the minimum to maximum change effect, 2 for the 0 to 1 change effect, 3
+for the {cmd:delta()} change effect, 4 for the standard deviation change
+effect, and 5 for the marginal effect. {cmd:e(X)} has four rows
+containing the base values, standard deviations, minimums, and maximums. If
+the {cmd:fromto} option is specified, two additional matrices,
+{cmd:e(dcfrom)} and {cmd:e(dcto)} are added. 
+
+{marker prvalue}
+{p 4 8 2}
+{cmd:estadd prvalue} [{cmd:if} {it:exp}] [{cmd:in} {it:range}] [{cmd:,} {cmdab:lab:el:(}{it:string}{cmd:)}
+{it:{help prvalue:prvalue_options}} ]
+
+{p 4 8 2}
+{cmd:estadd prvalue} {cmd:post} [{it:name}] [{cmd:,} {cmdab:t:itle:(}{it:string}{cmd:)} {cmd:swap} ]
+
+{p 8 8 2} applies {helpb prvalue} from Long and Freese's {helpb SPost}
+package and adds the returned results to {cmd:e()}. The procedure is to
+first collect a series of predictions by repeated calls to
+{cmd:estadd prvalue} and then apply {cmd:estadd prvalue post} to prepare the results
+for tabulation as in the following example:
+
+            {com}. logit lfp k5 k618 age wc hc lwg inc
+            . estadd prvalue, x(inc 10) label(low inc)
+            . estadd prvalue, x(inc 20) label(med inc)
+            . estadd prvalue, x(inc 30) label(high inc)
+            . estadd prvalue post
+            . estout{txt}
+
+{p 8 8 2} You may specify {it:prvalue_options} with {cmd:estadd prvalue} as
+described in help {helpb prvalue}. For example, use {cmd:x()} and
+{cmd:rest()} to set the values of the independent variables. Use
+{cmd:label()} to label the single calls. "pred#" is used as label if
+{cmd:label()} is omitted, where # is the number of the call. Labels may
+contain spaces but they will be trimmed to a maximum
+length of 30 characters and some characters ({cmd::},
+{cmd:.}, {cmd:"}) will be replaced by underscore. The results
+from the single calls are collected in matrix {cmd:e(_estadd_prvalue)}
+(predictions) and matrix {cmd:e(_estadd_prvalue_x)} (x-values). Specify
+{cmd:replace} to drop results from previous calls.
+
+{p 8 8 2}
+{cmd:estadd prvalue post} posts the collected predictions in {cmd:e(b)}
+so that they can be tabulated. The following results are saved:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        Scalars
+          {cmd:N}           number of observations
+
+        Macros
+          {cmd:depvar}      name of dependent variable
+          {cmd:cmd}         {cmd:estadd_prvalue}
+          {cmd:model}       model estimation command
+          {cmd:properties}  {cmd:b}
+
+        Matrices
+          {cmd:b}           predictions
+          {cmd:se}          standard errors
+          {cmd:LB}          lower confidence interval bounds
+          {cmd:UB}          upper confidence interval bounds
+          {cmd:Category}    outcome values
+          {cmd:Cond}        conditional predictions (some models only)
+          {cmd:X}           values of predictors (for each prediction)
+          {cmd:X2}          second equation predictors (some models only)
+        {hline 60}
+
+{p 8 8 2} {cmd:estadd prvalue post} replaces the current model unless
+{it:name} is specified, in which case the results are stored under {it:name} and the model
+remains active. However, if the model has a name
+(because it has been stored), the name of the model is used as a prefix.
+If, for example, the model has been stored as {cmd:model1}, then
+{cmd:estadd prvalue post} stores its results under {cmd:model1}{it:name}.
+Use {cmd:title()} to specify a title for the stored results.
+
+{p 8 8 2}The default for {cmd:estadd prvalue post} is to arrange
+{cmd:e(b)} in a way so that predictions are grouped by outcome (i.e. outcome labels are used
+as equations). Alternatively, specify {cmd:swap} to group predictions by
+{cmd:prvalue} calls (i.e. to use the prediction labels as equations).
+
+{p 8 8 2}{cmd:e(X)} contains one row for each independent variable. To address the rows in
+{helpb estout}'s {cmd:cells()} option type {cmd:X[}{it:varname}{cmd:]}, where {it:varname} is
+the name of the variable of interest. {cmd:e(X2)}, if provided, is analogous to {cmd:e(X)}.
+
+{marker asprvalue}
+{p 4 8 2}
+{cmd:estadd asprvalue} [{cmd:,} {cmdab:lab:el:(}{it:string}{cmd:)}
+{it:{help asprvalue:asprvalue_options}} ]
+
+{p 4 8 2}
+{cmd:estadd asprvalue} {cmd:post} [{it:name}] [{cmd:,} {cmdab:t:itle:(}{it:string}{cmd:)} {cmd:swap} ]
+
+{p 8 8 2} applies {helpb asprvalue} from Long and Freese's {helpb SPost}
+package and adds the returned results to {cmd:e()}. The procedure is to
+first collect a series of predictions by repeated calls to
+{cmd:estadd asprvalue} and then apply {cmd:estadd asprvalue post} to prepare the results
+for tabulation as in the following example:
+
+            {com}. clogit choice train bus time invc, group(id)
+            . estadd asprvalue, cat(train bus) label(at means)
+            . estadd asprvalue, cat(train bus) rest(asmean) label(at asmeans)
+            . estadd asprvalue post
+            . estout{txt}
+
+{p 8 8 2} You may specify {it:asprvalue_options} with {cmd:estadd asprvalue} as
+described in help {helpb asprvalue}. For example, use {cmd:x()} and
+{cmd:rest()} to set the values of the independent variables.  Use
+{cmd:label()} to label the single calls. "pred#" is used as label if
+{cmd:label()} is omitted, where # is the number of the call.  Labels may
+contain spaces but they will be trimmed to a maximum
+length of 30 characters and some characters ({cmd::},
+{cmd:.}, {cmd:"}) will be replaced by underscore. The results
+from the single calls are collected in matrices {cmd:e(_estadd_asprval)}
+(predictions), {cmd:e(_estadd_asprval_asv)} (values of alternative-specific
+variables), and {cmd:e(_estadd_asprval_csv)} (values of case-specific
+variables). Specify {cmd:replace} to drop results from previous calls.
+
+{p 8 8 2}
+{cmd:estadd asprvalue post} posts the collected predictions in {cmd:e(b)}
+so that they can be tabulated. The following results are saved:
+
+        {cmd:e(}{it:...}{cmd:)}        Contents
+        {hline 60}
+        Scalars
+          {cmd:N}           number of observations
+
+        Macros
+          {cmd:depvar}      name of dependent variable
+          {cmd:cmd}         {cmd:estadd_asprvalue}
+          {cmd:model}       model estimation command
+          {cmd:properties}  {cmd:b}
+
+        Matrices
+          {cmd:b}           predictions
+          {cmd:asv}         alternative-specific variables (if available)
+          {cmd:csv}         case-specific variables (if available)
+        {hline 60}
+
+{p 8 8 2} {cmd:estadd asprvalue post} replaces the current model unless
+{it:name} is specified, in which case the results are stored under
+{it:name} and the model remains active. However, if the model has a name
+(because it has been stored), the name of the model is used as a prefix.
+If, for example, the model has been stored as {cmd:model1}, then
+{cmd:estadd asprvalue post} stores its results under {cmd:model1}{it:name}.
+Use {cmd:title()} to specify a title for the stored results.
+
+{p 8 8 2}The default for {cmd:estadd asprvalue post} is to arrange
+{cmd:e(b)} in a way so that predictions are grouped by outcome (i.e. outcome labels are used
+as equations). Alternatively, specify {cmd:swap} to group predictions by
+{cmd:prvalue} calls (i.e. to use the prediction labels as equations).
+
+{p 8 8 2}{cmd:e(asv)} and {cmd:e(csv)} contain one row for each variable.
+To address the rows in {helpb estout}'s {cmd:cells()} option type
+{cmd:asv[}{it:varname}{cmd:]} or {cmd:csv[}{it:varname}{cmd:]}, where
+{it:varname} is the name of the variable of interest.
+
+{marker options}
+{title:Options}
+
+{p 4 8 2}
+{cmd:replace} permits {cmd:estadd} to overwrite existing {cmd:e()}
+macros, scalars, or matrices.
+
+{p 4 8 2}
+{cmd:prefix(}{it:string}{cmd:)} denotes a prefix for the names of the
+added results. The default prefix is an empty string. For example, if
+{cmd:prefix(}{it:string}{cmd:)} is specified, the {cmd:beta}
+subcommand will return the matrix {cmd:e(}{it:string}{cmd:beta)}.
+
+{p 4 8 2}{cmd:quietly} suppresses the output from the called subcommand and displays only
+the list of added results. Note that many of {cmd:estadd}'s subcommands do not generate
+output, in which case {cmd:quietly} has no effect.
+
+{p 4 8 2}
+{it:subcmdopts} are subcommand specific options. See the descriptions
+of the subcommands above.
+
+{marker examples}
+{title:Examples}
+
+{p 4 4 2}Example 1: Add {cmd:r()}-returns from other programs to the
+current estimates
+
+        {com}. sysuse auto
+        {txt}(1978 Automobile Data)
+
+        {com}. quietly regress price mpg weight
+        {txt}
+        {com}. test mpg=weight
+
+        {txt} ( 1)  {res}mpg - weight = 0
+
+        {txt}       F(  1,    71) ={res}    0.36
+        {txt}{col 13}Prob > F ={res}    0.5514
+        {txt}
+        {com}. estadd scalar p_diff = r(p)
+
+        {txt}added scalar:
+                     e(p_diff) =  {res}.55138216
+        {txt}
+        {com}. estout, stats(p_diff)
+        {res}
+        {txt}{hline 25}
+        {txt}                        b
+        {txt}{hline 25}
+        {txt}mpg         {res}    -49.51222{txt}
+        {txt}weight      {res}     1.746559{txt}
+        {txt}_cons       {res}     1946.069{txt}
+        {txt}{hline 25}
+        {txt}p_diff      {res}     .5513822{txt}
+        {txt}{hline 25}
+
+
+{p 4 4 2}Example 2: Add means and standard deviations of the model's regressors
+to the current estimates
+
+        {com}. quietly logit foreign price mpg
+        {txt}
+        {com}. estadd summ, mean sd
+
+        {txt}added matrices:
+                         e(sd) :  {res}1 x 3
+                       {txt}e(mean) :  {res}1 x 3
+        {txt}
+        {com}. estout, cells("mean sd") drop(_cons)
+        {res}
+        {txt}{hline 38}
+        {txt}                     mean           sd
+        {txt}{hline 38}
+        {txt}price       {res}     6165.257     2949.496{txt}
+        {txt}mpg         {res}      21.2973     5.785503{txt}
+        {txt}{hline 38}
+
+
+{p 4 4 2}
+Example 3: Add standardized beta coefficients to stored estimates
+
+        {com}. eststo: quietly regress price mpg
+        {txt}({res}est1{txt} stored)
+
+        {com}. eststo: quietly regress price mpg foreign
+        {txt}({res}est2{txt} stored)
+
+        {com}. estadd beta: *
+        {txt}
+        {com}. estout, cells(beta)  drop(_cons)
+        {res}
+        {txt}{hline 38}
+        {txt}                     est1         est2
+        {txt}                     beta         beta
+        {txt}{hline 38}
+        {txt}mpg         {res}    -.4685967    -.5770712{txt}
+        {txt}foreign     {res}                  .2757378{txt}
+        {txt}{hline 38}
+
+
+{p 4 4 2}See
+{browse "http://repec.sowi.unibe.ch/stata/estout/"}
+for additional examples.
+
+
+{title:Writing one's own subcommands}
+
+{p 4 4 2}
+A program providing a new {cmd:estadd} subcommand should be called
+{cmd:estadd_}{it:mysubcommand} (see help {helpb program} for advice
+on defining programs). {it:mysubcommand} will be available to {cmd:estadd} as a new
+{it:subcommand} after the program definition has been executed or
+saved to a file called "estadd_{it:mysubcommand}.ado" in either the
+current directory or somewhere else in the {cmd:adopath}
+(see help {helpb sysdir}).
+
+{p 4 4 2}
+Use the subcommands provided within "estadd.ado" as a starting
+point for writing new subcommands. See
+{browse "http://repec.sowi.unibe.ch/stata/estout/estadd.html#007"}
+for an example.
+
+
+{title:Author}
+
+{p 4 4 2} Ben Jann, Institute of Sociology, University of Bern, jann@soz.unibe.ch
+
+
+{title:Also see}
+
+    Manual:  {hi:[R] estimates}
+
+{p 4 13 2}Online:  help for
+ {helpb estimates},
+ {helpb ereturn},
+ {helpb program},
+ {helpb esttab}, 
+ {helpb estout}, 
+ {helpb eststo}, 
+ {helpb estpost}
+{p_end}

--- a/analysis/extra_ados/estout.ado
+++ b/analysis/extra_ados/estout.ado
@@ -1,0 +1,4959 @@
+*! version 3.31  26apr2022  Ben Jann
+
+program define estout, rclass
+    version 8.2
+    return local cmdline estout `macval(0)'
+    syntax [anything] [using] [ , ///
+        Cells(string asis) ///
+        Drop(string asis)  ///
+        Keep(string asis) ///
+        Order(string asis) ///
+        REName(passthru) ///
+        Indicate(string asis) ///
+        TRansform(string asis) ///
+        EQuations(passthru) ///
+        EFORM2(string) ///
+        Margin2(string) ///
+        DIscrete(string asis) ///
+        MEQs(string) ///
+        DROPPED2(string) ///
+        level(numlist max=1 int >=10 <=99) ///
+        Stats(string asis) ///
+        STARLevels(string asis) ///
+        STARKeep(string asis) ///
+        STARDrop(string asis) ///
+        VARwidth(numlist max=1 int >=0) ///
+        MODELwidth(numlist int >=0) ///
+        EXTRAcols(numlist sort) ///
+        BEGin(string asis) ///
+        DELimiter(string asis) ///
+        INCELLdelimiter(string asis) ///
+        end(string asis) ///
+        DMarker(string) ///
+        MSign(string) ///
+        SUBstitute(string asis) ///
+        INTERACTion(string asis) ///
+        TItle(string) ///
+        note(string) ///
+        PREHead(string asis) ///
+        POSTHead(string asis) ///
+        PREFoot(string asis) ///
+        POSTFoot(string asis) ///
+        HLinechar(string) ///
+        VARLabels(string asis) ///
+        REFcat(string asis) ///
+        MLabels(string asis) ///
+        NUMbers2(string asis) ///
+        COLLabels(string asis) ///
+        EQLabels(string asis) ///
+        MGRoups(string asis) ///
+        LABCOL2(string asis) ///
+        TOPfile(string) ///
+        BOTtomfile(string) ///
+        STYle(string) ///
+        DEFaults(string) ///
+        * ///
+        ]
+    MoreOptions, `options'
+    if "`style'"!="" local defaults "`style'"
+
+*Matrix mode
+    tempname B
+    MatrixMode, `anything' `rename' // resets the cells argument
+        // and returns r(coefs) etc. and local 'matrixmode'
+    if (`matrixmode'==1) {
+        local models `r(names)'
+        local nmodels = r(nmodels)
+        local ccols = r(ccols)
+        if `ccols'>0 {
+            mat `B'  = r(coefs)
+        }
+    }
+
+*Parse suboptions
+    local elnum 0
+    if `"`cells'"'!="none" {
+        gettoken row rest: cells, bind match(par) qed(qed)
+        if `"`par'"'=="(" local qed 1
+        local cells
+        while `"`row'"'!="" {
+            local newrow
+            gettoken opt row: row, parse(" ([&")
+            if `"`macval(row)'"'=="" & `qed'==0 {
+                local row0
+                gettoken trash: rest, parse("[")
+                if `"`trash'"'=="[" {
+                    gettoken trash rest: rest, parse("[")
+                    gettoken mrow rest: rest, parse("]") q
+                    gettoken trash rest: rest, parse("]")
+                    if `"`trash'"'!="]" {
+                        error 198
+                    }
+                }
+                gettoken trash: rest, match(par)
+                if `"`par'"'=="(" {
+                    gettoken opt2 rest: rest, match(par)
+                }
+                else local opt2
+            }
+            else {
+                gettoken trash: row, parse("[")
+                if `"`trash'"'=="[" {
+                    gettoken trash row: row, parse("[")
+                    gettoken mrow row: row, parse("]") q
+                    gettoken trash row: row, parse("]")
+                    if `"`trash'"'!="]" {
+                        error 198
+                    }
+                }
+                gettoken trash row0: row, match(par)
+                gettoken opt2: row, match(par)
+            }
+            while "`opt'"!="" {
+                if "`opt'"!="&" & "`opt'"!="." {
+                    local `opt'_tname "el`++elnum'"
+                    local ``opt'_tname'_ "`opt'"
+                    local newrow `"`newrow' ``opt'_tname'"'
+                    if `"`par'"'!="(" local opt2
+                    ParseValueSubopts ``opt'_tname' `opt', mrow(`mrow') `macval(opt2)'
+                    local mrow
+                }
+                else {
+                    if `"`par'"'=="(" | `"`mrow'"'!="" error 198
+                    local newrow `"`newrow' `opt'"'
+                }
+                if `"`par'"'!="(" {
+                    gettoken opt row: row, parse(" ([&")
+                }
+                else {
+                    gettoken opt row: row0, parse(" ([&")
+                }
+                gettoken trash: row, parse("[")
+                if `"`trash'"'=="[" {
+                    gettoken trash row: row, parse("[")
+                    gettoken mrow row: row, parse("]") q
+                    gettoken trash row: row, parse("]")
+                    if `"`trash'"'!="]" {
+                        error 198
+                    }
+                }
+                gettoken trash row0: row, match(par)
+                gettoken opt2: row, match(par)
+            }
+            local newrow: list retok newrow
+            if `qed' local cells `"`cells'"`newrow'" "'
+            else local cells `"`cells'`newrow' "'
+            gettoken row rest: rest, bind match(par) qed(qed)
+            if `"`par'"'=="(" local qed 1
+        }
+        local cells: list retok cells
+    }
+    if "`eform2'"!="" {
+        local eform "`eform2'"
+        local eform2
+    }
+    if `"`transform'"'!="" {
+        ParseTransformSubopts `transform'
+    }
+    if "`margin2'"!="" {
+        local margin "`margin2'"
+        local margin2
+    }
+    if `"`dropped'"'!="" local dropped "(dropped)"
+    if `"`macval(dropped2)'"'!="" {
+        local dropped `"`macval(dropped2)'"'
+        local dropped2
+    }
+    if `"`macval(stats)'"'!="" {
+        ParseStatsSubopts `macval(stats)'
+        if `"`macval(statslabels)'"'!="" {
+            if trim(`"`statslabels'"')=="none" {
+                local statslabelsnone none
+                local statslabels
+            }
+            else {
+                ParseLabelsSubopts statslabels `macval(statslabels)'
+            }
+        }
+    }
+    foreach opt in mgroups mlabels eqlabels collabels varlabels {
+        if `"`macval(`opt')'"'!="" {
+            if trim(`"``opt''"')=="none" {
+                local `opt'none none
+                local `opt'
+            }
+            else {
+                ParseLabelsSubopts `opt' `macval(`opt')'
+            }
+        }
+    }
+    if `"`macval(numbers2)'"'!="" {
+        local numbers `"`macval(numbers2)'"'
+        local numbers2
+    }
+    if `"`macval(indicate)'"'!="" {
+        ParseIndicateOpts `macval(indicate)'
+    }
+    if `"`macval(refcat)'"'!="" {
+        ParseRefcatOpts `macval(refcat)'
+    }
+    if `"`macval(starlevels)'"'!="" {
+        ParseStarlevels `macval(starlevels)'
+    }
+    if `"`macval(labcol2)'"'!="" {
+        ParseLabCol2 `macval(labcol2)'
+    }
+
+*Process No-Options
+    foreach opt in unstack eform margin dropped discrete stardetach wrap ///
+     legend label refcatlabel numbers lz abbrev replace append type showtabs ///
+     smcltags smclrules smclmidrules smcleqrules asis outfilenoteoff ///
+     omitted baselevels rtfencode {
+        if "`no`opt''"!="" local `opt'
+    }
+
+*Defaults
+    if "`defaults'"=="esttab"               local defaults "tab"
+    if "`defaults'"=="" & `"`using'"'==""   local defaults "smcl"
+    if inlist("`defaults'", "", "smcl", "tab", "fixed", "tex", "html","mmd")  {
+        local varwidthfactor = (1 + ("`eqlabelsmerge'"!="" & "`unstack'"=="")*.5)
+        if inlist("`defaults'", "", "tab") {
+            if `"`macval(delimiter)'"'==""   local delimiter _tab
+            if `"`macval(interaction)'"'=="" local interaction `"" # ""'
+        }
+        else if "`defaults'"=="smcl" {
+            if "`varwidth'"==""              local varwidth = cond("`label'"=="", 12, 20) * `varwidthfactor'
+            if "`modelwidth'"==""            local modelwidth 12
+            if "`noabbrev'"==""              local abbrev abbrev
+            if `"`macval(delimiter)'"'==""   local delimiter `"" ""'
+            if "`nosmcltags'"==""            local smcltags smcltags
+            if "`nosmclrules'"==""           local smclrules smclrules
+            if "`asis'"==""                  local noasis noasis
+            if `"`macval(interaction)'"'=="" local interaction `"" # ""'
+        }
+        else if "`defaults'"=="fixed" {
+            if "`varwidth'"==""              local varwidth = cond("`label'"=="", 12, 20) * `varwidthfactor'
+            if "`modelwidth'"==""            local modelwidth 12
+            if "`noabbrev'"==""              local abbrev abbrev
+            if `"`macval(delimiter)'"'==""   local delimiter `"" ""'
+            if `"`macval(interaction)'"'=="" local interaction `"" # ""'
+        }
+        else if "`defaults'"=="tex" {
+            if "`varwidth'"==""              local varwidth = cond("`label'"=="", 12, 20) * `varwidthfactor'
+            if "`modelwidth'"==""            local modelwidth 12
+            if `"`macval(delimiter)'"'==""   local delimiter &
+            if `"`macval(end)'"'=="" {
+                local end \\\
+            }
+            if `"`macval(interaction)'"'=="" local interaction `"" $\times$ ""'
+        }
+        else if "`defaults'"=="html" {
+            if "`varwidth'"==""              local varwidth = cond("`label'"=="", 12, 20) * `varwidthfactor'
+            if "`modelwidth'"==""            local modelwidth 12
+            if `"`macval(begin)'"'==""       local begin <tr><td>
+            if `"`macval(delimiter)'"'==""   local delimiter </td><td>
+            if `"`macval(end)'"'==""         local end </td></tr>
+            if `"`macval(interaction)'"'=="" local interaction `"" # ""'
+        }
+        else if "`defaults'"=="mmd" {
+            if "`varwidth'"==""              local varwidth = cond("`label'"=="", 12, 20) * `varwidthfactor'
+            if "`modelwidth'"==""            local modelwidth 12
+            if `"`macval(begin)'"'==""       local begin "| "
+            if `"`macval(delimiter)'"'==""   local delimiter " | "
+            if `"`macval(end)'"'==""         local end " |"
+            if `"`macval(interaction)'"'=="" local interaction `"" # ""'
+        }
+        if "`nostatslabelsfirst'"=="" local statslabelsfirst first
+        if "`nostatslabelslast'"==""  local statslabelslast last
+        if "`novarlabelsfirst'"==""   local varlabelsfirst first
+        if "`novarlabelslast'"==""    local varlabelslast last
+        if "`noeqlabelsfirst'"==""    local eqlabelsfirst first
+        if "`noeqlabelslast'"==""     local eqlabelslast last
+        if "`nolz'"==""               local lz lz
+        if `"`macval(discrete)'"'=="" & "`nodiscrete'"=="" {
+            local discrete `"" (d)" for discrete change of dummy variable from 0 to 1"'
+        }
+        if `"`macval(indicatelabels)'"'=="" local indicatelabels "Yes No"
+        if `"`macval(refcatlabel)'"'=="" & "`norefcatlabel'"==""    local refcatlabel "ref."
+        if `"`macval(incelldelimiter)'"'=="" local incelldelimiter " "
+        if "`noomitted'"==""          local omitted omitted
+        if "`nobaselevels'"==""       local baselevels baselevels
+    }
+    else {
+        capture findfile estout_`defaults'.def
+        if _rc {
+            di as error `"`defaults' style not available "' ///
+             `"(file estout_`defaults'.def not found)"'
+            exit 601
+        }
+        else {
+            tempname file
+            file open `file' using `"`r(fn)'"', read text
+            if c(SE) local max 244
+            else local max 80
+            while 1 {
+                ReadLine `max' `file'
+                if `"`line'"'=="" continue, break
+                gettoken opt line: line
+                else if index(`"`opt'"',"_") {
+                    gettoken opt0 opt1: opt, parse("_")
+                    if `"``opt0'_tname'"'!="" {
+                        local opt `"``opt0'_tname'`opt1'"'
+                    }
+                }
+                if `"`macval(`opt')'"'=="" & `"`no`opt''"'=="" {
+                    if `"`opt'"'=="cells" {
+                        local newline
+                        gettoken row rest: line, match(par) qed(qed)
+                        if `"`par'"'=="(" local qed 1
+                        while `"`row'"'!="" {
+                            local newrow
+                            gettoken el row: row, parse(" &")
+                            while `"`el'"'!="" {
+                                if `"`el'"'!="." & `"`el'"'!="&" {
+                                    local `el'_tname "el`++elnum'"
+                                    local ``el'_tname'_ "`el'"
+                                    local newrow "`newrow' ``el'_tname'"
+                                }
+                                else {
+                                    local newrow "`newrow' `el'"
+                                }
+                                gettoken el row: row, parse(" &")
+                            }
+                            local newrow: list retok newrow
+                            if `qed' local newline `"`newline'"`newrow'" "'
+                            else local newline `"`newline'`newrow' "'
+                            gettoken row rest: rest, match(par) qed(qed)
+                            if `"`par'"'=="(" local qed 1
+                        }
+                        local line `"`newline'"'
+                    }
+                    local line: list retok line
+                    local `opt' `"`macval(line)'"'
+                }
+            }
+            file close `file'
+        }
+    }
+    if "`notype'"=="" & `"`using'"'=="" local type type
+    if "`smcltags'"=="" & "`noasis'"=="" local asis asis
+    if "`asis'"!="" local asis "_asis"
+    if "`smclrules'"!="" & "`nosmclmidrules'"=="" local smclmidrules smclmidrules
+    if "`smclmidrules'"!="" & "`nosmcleqrules'"=="" local smcleqrules smcleqrules
+    local haslabcol2 = (`"`macval(labcol2)'"'!="")
+
+*title/notes option
+    if `"`macval(prehead)'`macval(posthead)'`macval(prefoot)'`macval(postfoot)'"'=="" {
+        if `"`macval(title)'"'!="" {
+            local prehead `"`"`macval(title)'"'"'
+        }
+        if `"`macval(note)'"'!="" {
+            local postfoot `"`"`macval(note)'"'"'
+        }
+    }
+
+*Generate/clean-up cell contents
+    if `"`:list clean cells'"'=="" {
+        local cells b
+        local b_tname "b"
+        local b_ "b"
+    }
+    else if `"`:list clean cells'"'=="none" {
+        local cells
+    }
+    CellsCheck `"`cells'"'
+    if `:list sizeof incelldelimiter'==1 gettoken incelldelimiter: incelldelimiter
+
+*Special treatment of confidence intervals
+    if "`level'"=="" local level $S_level
+    if `level'<10 | `level'>99 {
+        di as error "level(`level') invalid"
+        exit 198
+    }
+    if "`ci_tname'"!="" {
+        if `"`macval(`ci_tname'_label)'"'=="" {
+            local `ci_tname'_label "ci`level'"
+        }
+        if `"`macval(`ci_tname'_par)'"'=="" {
+            local `ci_tname'_par `""" , """'
+        }
+        gettoken 1 2 : `ci_tname'_par
+        gettoken 2 3 : 2
+        gettoken 3 : 3
+        local `ci_tname'_l_par `""`macval(1)'" "`macval(2)'""'
+        local `ci_tname'_u_par `""" "`macval(3)'""'
+    }
+    if "`ci_l_tname'"!="" {
+        if `"`macval(`ci_l_tname'_label)'"'=="" {
+            local `ci_l_tname'_label "min`level'"
+        }
+    }
+    if "`ci_u_tname'"!="" {
+        if `"`macval(`ci_u_tname'_label)'"'=="" {
+            local `ci_u_tname'_label "max`level'"
+        }
+    }
+
+*Formats
+    local firstv: word 1 of `values'
+    if "`firstv'"=="" local firstv "b"
+    if "``firstv'_fmt'"=="" local `firstv'_fmt %9.0g
+    foreach v of local values {
+        if "``v'_fmt'"=="" local `v'_fmt "``firstv'_fmt'"
+        if `"`macval(`v'_label)'"'=="" {
+            local `v'_label "``v'_'"
+        }
+    }
+
+*Check margin option / prepare discrete option / prepare dropped option
+    if "`margin'"!="" {
+        if !inlist("`margin'","margin","u","c","p") {
+            di as error "margin(`margin') invalid"
+            exit 198
+        }
+        if `"`macval(discrete)'"'!="" {
+            gettoken discrete discrete2: discrete
+        }
+    }
+    else local discrete
+    local droppedison = (`"`macval(dropped)'"'!="")
+
+*Formats/labels/stars for statistics
+    if "`statsfmt'"=="" local statsfmt: word 1 of ``firstv'_fmt'
+    ProcessStatslayout `"`stats'"' `"`statsfmt'"' `"`statsstar'"' ///
+     `"`statslayout'"' `"`statspchar'"'
+    local stats: list uniq stats
+    if "`statsstar'"!="" local p " p"
+    else local p
+
+*Significance stars
+    local tablehasstars 0
+    foreach v of local values {
+        local el "``v'_'"
+        if "``v'_star'"!="" | inlist("`el'","_star","_sigsign") {
+            if "``v'_pvalue'"=="" local `v'_pvalue p
+            local tablehasstars 1
+        }
+    }
+
+*Check/define starlevels/make levelslegend
+    if `tablehasstars' | `"`statsstar'"'!="" {
+        if `"`macval(starlevels)'"'=="" ///
+         local starlevels "* 0.05 ** 0.01 *** 0.001"
+        CheckStarvals `"`macval(starlevels)'"' `"`macval(starlevelslabel)'"' ///
+         `"`macval(starlevelsdelimiter)'"'
+    }
+
+*Get coefficients/variances/statistics: _estout_getres
+*   - prepare transform/eform
+    if `"`transform'"'=="" {  // transform() overwrites eform()
+        if "`eform'"!="" {
+            local transform "exp(@) exp(@)"
+            if "`eform'"!="eform" {
+                local transformpattern "`eform'"
+            }
+        }
+    }
+    foreach m of local transformpattern {
+        if !( "`m'"=="1" | "`m'"=="0" ) {
+            di as error "invalid pattern in transform(,pattern()) or eform()"
+            exit 198
+        }
+    }
+*   - handle pvalue() suboption
+    if `tablehasstars' {
+        local temp
+        foreach v of local values {
+            local temp: list temp | `v'_pvalue
+        }
+        foreach v of local temp {
+            if `"``v'_tname'"'=="" {
+                local `v'_tname "el`++elnum'"
+                local ``v'_tname'_ "`v'"
+                local values: list values | `v'_tname
+            }
+        }
+    }
+*   - prepare list of results to get from e()-matrices
+    if "`ci_tname'"!="" {
+        local values: subinstr local values "`ci_tname'" "`ci_tname'_l `ci_tname'_u", word
+        local `ci_tname'_l_ "ci_l"
+        local ci_l_tname "`ci_tname'_l"
+        local `ci_tname'_u_ ci_u
+        local ci_u_tname "`ci_tname'_u"
+    }
+    foreach v of local values {
+        local temp = ("``v'_transpose'"!="")
+        local values1mrow `"`values1mrow' `"``v'_' `temp' ``v'_mrow'"'"'
+    }
+    tempname D St
+    if `matrixmode'==0 {
+*   - expand model names
+        if `"`anything'"'=="" {
+            capt est_expand $eststo
+            if !_rc {
+                local anything `"$eststo"'
+            }
+            if `'"`anything'"'!="" {
+                if `"`: e(scalars)'`: e(macros)'`: e(matrices)'`: e(functions)'"'!="" {
+                    local inlist: list posof `"`e(_estimates_name)'"' in anything
+                    if `inlist'==0 {
+                        di as txt "(tabulating estimates stored by eststo;" ///
+                            `" specify "." to tabulate the active results)"'
+                    }
+                }
+            }
+        }
+        if `"`anything'"'=="" local anything "."
+        capt est_expand `"`anything'"'
+        if _rc {
+            if _rc==301 {  // add e(cmd)="." to current estimates if undefined
+                if `:list posof "." in anything' & `"`e(cmd)'"'=="" {
+                    if `"`: e(scalars)'`: e(macros)'`: e(matrices)'`: e(functions)'"'!="" {
+                        qui estadd local cmd "."
+                    }
+                }
+            }
+            est_expand `"`anything'"'
+        }
+        local models `r(names)'
+        // could not happen, ...
+        if "`models'" == "" {
+            exit
+        }
+*   - get results
+        local temp names(`models') coefs(`values1mrow') stats(`stats'`p') ///
+            `rename' margin(`margin') meqs(`meqs') dropped(`droppedison') level(`level') ///
+            transform(`transform') transformpattern(`transformpattern') ///
+            `omitted' `baselevels'
+        _estout_getres, `equations' `temp'
+        local ccols = r(ccols)
+        if `"`equations'"'=="" & "`unstack'"=="" & `ccols'>0 { // specify equations("") to deactivate
+            TableIsAMess
+            if `value' {
+                _estout_getres, equations(main=1) `temp'
+            }
+        }
+        mat `St' = r(stats)
+        local nmodels = r(nmodels)
+        local ccols = r(ccols)
+        if `ccols'>0 {
+            mat `B'  = r(coefs)
+        }
+    }
+    else { // matrix mode
+        // define `St' so that code does not break
+        if `"`stats'"'!="" {
+            mat `St' = J(`:list sizeof stats',1,.z)
+            mat coln `St' = `models'
+            mat rown `St' = `stats'
+        }
+    }
+    return add
+*   - process order() option
+    if `"`order'"' != "" {
+        ExpandEqVarlist `"`order'"' `B' append
+        local order `"`value'"'
+        Order `B' `"`order'"'
+    }
+*   - process indicate() option
+    local nindicate 0
+    foreach indi of local indicate {
+        local ++nindicate
+        ProcessIndicateGrp `nindicate' `B' `nmodels' `ccols' "`unstack'" ///
+        `"`macval(indicatelabels)'"' `"`macval(indi)'"'
+    }
+*   - process keep() option
+    if `"`keep'"' != "" {
+        ExpandEqVarlist `"`keep'"' `B'
+        DropOrKeep 1 `B' `"`value'"'
+    }
+*   - process drop() option
+    if `"`drop'"' != "" {
+        ExpandEqVarlist `"`drop'"' `B'
+        DropOrKeep 0 `B' `"`value'"'
+    }
+
+*   - names and equations of final set
+    capt confirm matrix `B'
+    if _rc {
+        return local coefs  ""  // erase r(coefs)
+        return local ccols  ""
+        local R 0
+        local varlist       ""
+        local eqlist        ""
+        local eqs           "__"
+        local fullvarlist   ""
+    }
+    else {
+        tempname C
+        matrix `C' = `B'
+        RestoreEmptyEqnames `C' // replace equation name "__" by "_"
+        return matrix coefs = `C' // replace r(coefs)
+        local R = rowsof(`B')
+        local C = colsof(`B')
+        local eqlist: roweq `B', q
+        local eqlist: list clean eqlist
+        UniqEqsAndDims `"`eqlist'"'
+        if "`unstack'"!="" {
+            // unstack requires equations to be tied together
+            // RerrangeEqs resets B, eqlist, eqs, eqsdims
+            RerrangeEqs `B' `"`eqlist'"' `"`eqs'"'
+        }
+        QuotedRowNames `B'
+        local varlist `"`value'"'
+        MakeQuotedFullnames `"`varlist'"' `"`eqlist'"'
+        local fullvarlist `"`value'"'
+*   - dropped coefs
+        local droppedpos = `ccols'
+        if "`margin'"!="" {
+            local droppedpos `droppedpos' - 1
+        }
+*   - 0/1-variable indicators (for marginals)
+        mat `D' = `B'[1...,1], J(`R',1,0)  // so that row names are copied from `B'
+        mat `D' = `D'[1...,2]
+        if "`margin'"!="" {
+            forv i = 1/`R' {    // last colum for each model contains _dummy info
+                forv j = `ccols'(`ccols')`C' {
+                    if `B'[`i',`j']==1 {
+                        mat `D'[`i',1] = 1
+                    }
+                }
+            }
+        }
+    }
+
+*Prepare element specific keep/drop
+    local dash
+    tempname tmpmat
+    foreach v in star `values' {
+        local temp `"`fullvarlist'"'
+        if "`unstack'"!="" {
+            local temp2: list uniq eqs
+            local `v'`dash'eqdrop: list uniq eqs
+        }
+        if `"``v'`dash'keep'"'!="" {
+            capt mat `tmpmat' = `B'
+            ExpandEqVarlist `"``v'`dash'keep'"' `tmpmat'
+            DropOrKeep 1 `tmpmat' `"`value'"'
+            capt confirm matrix `tmpmat'
+            if _rc local temp
+            else {
+                QuotedRowNames `tmpmat'
+                MakeQuotedFullnames `"`value'"' `"`: roweq `tmpmat', q'"'
+                local temp: list temp & value
+                if "`unstack'"!="" {
+                    local value: roweq `tmpmat', q
+                    local value: list uniq value
+                    local temp2: list temp2 & value
+                }
+            }
+        }
+        if `"``v'`dash'drop'"'!="" {
+            capt mat `tmpmat' = `B'
+            ExpandEqVarlist `"``v'`dash'drop'"' `tmpmat'
+            DropOrKeep 0 `tmpmat' `"`value'"'
+            capt confirm matrix `tmpmat'
+            if _rc local temp
+            else {
+                QuotedRowNames `tmpmat'
+                MakeQuotedFullnames `"`value'"' `"`: roweq `tmpmat', q'"'
+                local temp: list temp & value
+                if "`unstack'"!="" {
+                    local value: roweq `tmpmat', q
+                    local value: list uniq value
+                    local temp2: list temp2 & value
+                }
+            }
+        }
+        local `v'`dash'drop: list fullvarlist - temp
+        if "`unstack'"!="" {
+            local `v'`dash'eqdrop: list `v'`dash'eqdrop - temp2
+        }
+        local dash "_"
+    }
+    capt mat drop `tmpmat'
+
+*Prepare unstack
+    if "`unstack'"!="" & `R'>0 {
+        local varlist: list uniq varlist
+        GetVarnamesFromOrder `"`order'"'
+        local temp: list value & varlist
+        local varlist: list temp | varlist
+        local cons _cons
+        if `:list cons in value'==0 {
+            if `:list cons in varlist' {
+                local varlist: list varlist - cons
+                local varlist: list varlist | cons
+            }
+        }
+        local R: word count `varlist'
+        local eqswide: list uniq eqs
+        forv i=1/`nindicate' {
+            ReorderEqsInIndicate `"`nmodels'"' `"`eqswide'"' ///
+             `"`indicate`i'eqs'"' `"`macval(indicate`i'lbls)'"'
+            local indicate`i'lbls `"`macval(value)'"'
+        }
+    }
+    else local eqswide "__"
+
+*Prepare coefs for tabulation
+    if `R'>0 {
+        local i 0
+        foreach v of local values {
+            local ++i
+            tempname _`v'
+            forv j = 1/`nmodels' {
+                mat `_`v'' = nullmat(`_`v''), `B'[1..., (`j'-1)*`ccols'+`i']
+            }
+            mat coln `_`v'' = `models'
+            mat coleq `_`v'' = `models'
+            if inlist("``v'_'", "t", "z") {
+                if `"``v'_abs'"'!="" {  // absolute t-values
+                    forv r = 1/`R' {
+                        forv j = 1/`nmodels' {
+                            if `_`v''[`r',`j']>=. continue
+                            mat `_`v''[`r',`j'] = abs(`_`v''[`r',`j'])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+*Model labels
+    if "`nomlabelstitles'"=="" & "`label'"!="" local mlabelstitles titles
+    local tmp: list sizeof mlabels
+    local i 0
+    foreach model of local models {
+        local ++i
+        if `i'<=`tmp' continue
+        local lab
+        if "`mlabelsdepvars'"!="" {
+            local var `"`return(m`i'_depname)'"'
+            if "`label'"!="" {
+                local temp = index(`"`var'"',".")
+                local temp2  = substr(`"`var'"',`temp'+1,.)
+                capture local lab: var l `temp2'
+                if _rc | `"`lab'"'=="" {
+                    local lab `"`temp2'"'
+                }
+                local temp2 = substr(`"`var'"',1,`temp')
+                local lab `"`temp2'`macval(lab)'"'
+            }
+            else local lab `"`var'"'
+        }
+        else if "`mlabelstitles'"!="" {
+                local lab `"`return(m`i'_estimates_title)'"'
+                if `"`lab'"'=="" local lab "`model'"
+        }
+        else {
+            local lab "`model'"
+        }
+        local mlabels `"`macval(mlabels)' `"`macval(lab)'"'"'
+    }
+    if "`mlabelsnumbers'"!="" {
+        NumberMlabels `nmodels' `"`macval(mlabels)'"'
+    }
+
+*Equations labels
+    local eqconssubok = (`"`macval(eqlabels)'"'!=`""""')
+    local numeqs: list sizeof eqs
+    local temp: list sizeof eqlabels
+    if `temp'<`numeqs' {
+        forv i = `=`temp'+1'/`numeqs' {
+            local eq: word `i' of `eqs'
+            local value
+            if "`label'"!="" {
+                capture confirm variable `eq'
+                if !_rc {
+                    local value: var l `eq'
+                }
+            }
+            if `"`value'"'=="" {
+                if `"`eq'"'=="__" local value "_"
+                else              local value "`eq'"
+            }
+            local eqlabels `"`macval(eqlabels)' `"`value'"'"'
+        }
+    }
+    if `eqconssubok' {
+        if "`eqlabelsnone'"!="" & `numeqs'>1 & "`unstack'"=="" {
+            EqReplaceCons `"`varlist'"' `"`eqlist'"' `"`eqlabels'"' `"`macval(varlabels)'"'
+            if `"`macval(value)'"'!="" {
+                local varlabels `"`macval(value)' `macval(varlabels)'"'
+            }
+        }
+    }
+
+*Column labels
+    if `"`macval(collabels)'"'=="" {
+        forv j = 1/`ncols' {
+            local temp
+            forv i = 1/`nrows' {
+                local v: word `i' of `cells'
+                local v: word `j' of `v'
+                local v: subinstr local v "&" " ", all
+                local v: subinstr local v "." "", all
+                local v: list retok v
+                foreach vi of local v {
+                    if `"`macval(temp)'"'!="" {
+                        local temp `"`macval(temp)'/"'
+                    }
+                    local temp `"`macval(temp)'`macval(`vi'_label)'"'
+                }
+            }
+            local collabels `"`macval(collabels)'`"`macval(temp)'"' "'
+        }
+    }
+
+*Prepare refcat()
+    if `"`macval(refcat)'"'!="" {
+        PrepareRefcat `"`macval(refcat)'"'
+    }
+
+*Determine table layout
+    local m 1
+    local starcol 0
+    foreach model of local models {
+        local e 0
+        foreach eq of local eqswide {
+            local stc 0
+            local ++e
+            if "`unstack'"!="" & `R'>0 {
+                ModelEqCheck `B' `"`eq'"' `m' `ccols'
+                if !`value' continue
+            }
+            local eqsrow "`eqsrow'`e' "
+            local modelsrow "`modelsrow'`m' "
+            local k 0
+            local something 0
+            forv j = 1/`ncols' {
+                local col
+                local nocol 1
+                local colhasstats 0
+                forv i = 1/`nrows' {
+                    local row: word `i' of `cells'
+                    local v: word `j' of `row'
+                    local v: subinstr local v "&" " ", all
+                    foreach vi in `v' {
+                        if "`vi'"=="." continue
+                        local colhasstats 1
+                        if "`unstack'"!="" {
+                            local inlist: list posof `"`eq'"' in `vi'_eqdrop
+                            if `inlist' continue
+                        }
+                        if "`:word `m' of ``vi'_pattern''"=="0" {
+                            local v: subinstr local v "`vi'" ".`vi'", word
+                        }
+                        else {
+                            local nocol 0
+                            if `"``vi'_star'"'!="" local starcol 1
+                        }
+                    }
+                    local v: subinstr local v " " "&", all
+                    if "`v'"=="" local v "."
+                    local col "`col'`v' "
+                }
+                if `colhasstats'==0 local nocol 0
+                if !`nocol' {
+                    local colsrow "`colsrow'`j' "
+                    if `++k'>1 {
+                        local modelsrow "`modelsrow'`m' "
+                        local eqsrow "`eqsrow'`e' "
+                    }
+                    if `"`: word `++stc' of `statscolstar''"'=="1" local starcol 1
+                    local starsrow "`starsrow'`starcol' "
+                    local starcol 0
+                    Add2Vblock `"`vblock'"' "`col'"
+                    local something 1
+                }
+            }
+            if !`something' {
+                local col
+                forv i = 1/`nrows' {
+                    local col "`col'. "
+                }
+                Add2Vblock `"`vblock'"' "`col'"
+                local colsrow "`colsrow'1 "
+                if `"`: word `++stc' of `statscolstar''"'=="1" local starcol 1
+                local starsrow "`starsrow'`starcol' "
+                local starcol 0
+            }
+        }
+        local ++m
+    }
+    CountNofEqs "`modelsrow'" "`eqsrow'"
+    local neqs `value'
+    if `"`extracols'"'!="" {
+        foreach row in model eq col star {
+            InsertAtCols `"`extracols'"' `"``row'srow'"'
+            local `row'srow `"`value'"'
+        }
+        foreach row of local vblock {
+            InsertAtCols `"`extracols'"' `"`row'"'
+            local nvblock `"`nvblock' `"`value'"'"'
+        }
+        local vblock: list clean nvblock
+    }
+    local ncols = `: word count `starsrow'' + 1 + `haslabcol2'
+
+*Modelwidth/varwidth/starwidth
+    if "`modelwidth'"=="" local modelwidth 0
+    if "`varwidth'"=="" local varwidth 0
+    local nmodelwidth: list sizeof modelwidth
+    local modelwidthzero: list uniq modelwidth
+    local modelwidthzero = ("`modelwidth'"=="0")
+    if "`labcol2width'"=="" local labcol2width `: word 1 of `modelwidth''
+    local starwidth 0
+    if `modelwidthzero'==0 {
+        if `tablehasstars' | `"`statsstar'"'!="" {
+            Starwidth `"`macval(starlevels)'"'
+            local starwidth `value'
+        }
+    }
+    if `varwidth'<2 local wrap
+
+* totcharwidth / hline
+    local totcharwidth `varwidth'
+    if c(stata_version)>=14 local length udstrlen
+    else                    local length length
+    capture {
+        local delwidth = `length'(`macval(delimiter)')
+    }
+    if _rc {
+        local delwidth = `length'(`"`macval(delimiter)'"')
+    }
+    if `haslabcol2' {
+        local totcharwidth = `totcharwidth' + `delwidth' + `labcol2width'
+    }
+    local j 0
+    foreach i of local starsrow {
+        local modelwidthj: word `=1 + mod(`j++',`nmodelwidth')' of `modelwidth'
+        local totcharwidth = `totcharwidth' + `delwidth' + `modelwidthj'
+        if `i' {
+            if "`stardetach'"!="" {
+                local ++ncols
+                local totcharwidth = `totcharwidth' + `delwidth'
+            }
+            local totcharwidth = `totcharwidth' + `starwidth'
+        }
+    }
+    IsInString "@hline" `"`0'"'  // sets local strcount
+    if `strcount' {
+        local hline `totcharwidth'
+        if `hline'>400 local hline 400 // _dup(400) is limit
+        if `"`macval(hlinechar)'"'=="" local hlinechar "-"
+        local hline: di _dup(`hline') `"`macval(hlinechar)'"'
+    }
+    else local hline
+
+* check begin, delimiter, end
+    tempfile tfile
+    tempname file
+    file open `file' using `"`tfile'"', write text
+    foreach opt in begin delimiter end {
+        capture file write `file' `macval(`opt')'
+        if _rc {
+            local `opt' `"`"`macval(`opt')'"'"'
+        }
+    }
+    file close `file'
+
+* RTF support: set macros rtfrowdef, rtfrowdefbrdrt, rtfrowdefbrdrb, rtfemptyrow
+    local hasrtfbrdr 0
+    local rtfbrdron 0
+    IsInString "@rtfrowdef" `"`begin'"' // sets local strcount
+    local hasrtf = `strcount'
+    if `hasrtf' {
+        MakeRtfRowdefs `"`macval(begin)'"' `"`starsrow'"' "`stardetach'" ///
+            `varwidth' "`modelwidth'" `haslabcol2' `labcol2width'
+        local varwidth 0
+        local wrap
+        local modelwidth 0
+        local nmodelwidth 1
+        local modelwidthzero 1
+        local starwidth 0
+        local labcol2width 0
+        IsInString "@rtfrowdefbrdr" `"`begin'"' // sets local strcount
+        if `strcount' {
+            local hasrtfbrdr 1
+            local rtfbeginbak `"`macval(begin)'"'
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrt'"'
+            local rtfbrdron 1
+        }
+        else {
+            StableSubinstr begin `"`macval(begin)'"' "@rtfrowdef" `"`rtfrowdef'"'
+        }
+    }
+
+* set widths
+    if `starwidth'>0 local fmt_stw "%-`starwidth's"
+    if `varwidth'>0 local fmt_v "%-`varwidth's"
+    if `labcol2width'>0 local fmt_l2 "%~`labcol2width's"
+    if "`mgroupsspan'`mlabelsspan'`eqlabelsspan'`collabelsspan'"!="" {
+        if `modelwidthzero'==0 {
+            file open `file' using `"`tfile'"', write text replace
+            file write `file' `macval(delimiter)'
+            file close `file'
+            file open `file' using `"`tfile'"', read text
+            file read `file' delwidth
+            file close `file'
+            local delwidth = `length'(`"`macval(delwidth)'"')
+        }
+        else local delwidth 0
+    }
+    local stardetachon = ("`stardetach'"!="")
+    if `stardetachon' {
+        local stardetach `"`macval(delimiter)'"'
+    }
+
+*Prepare @-Variables
+    local atvars2 `""`nmodels'" "`neqs'" "`totcharwidth'" `"`macval(hline)'"' `hasrtf' `"`rtfrowdefbrdrt'"' `"`rtfrowdefbrdrb'"' `"`rtfrowdef'"' `"`rtfemptyrow'"'"'
+    local atvars3 `"`"`macval(title)'"' `"`macval(note)'"' `"`macval(discrete)'`macval(discrete2)'"' `"`macval(starlegend)'"'"'
+
+*Open output file
+    file open `file' using `"`tfile'"', write text replace
+
+*Write prehead
+    if `"`macval(prehead)'"'!="" {
+        if index(`"`macval(prehead)'"',`"""')==0 {
+            local prehead `"`"`macval(prehead)'"'"'
+        }
+    }
+    foreach line of local prehead {
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(line)'"' 0 "`ncols'" `macval(atvars2)' `macval(atvars3)'
+        file write `file' `"`macval(value)'"' _n
+    }
+    local hasheader 0
+    if "`smcltags'"!="" local thesmclrule "{txt}{hline `totcharwidth'}"
+    else                local thesmclrule "{hline `totcharwidth'}"
+    if "`smclrules'"!="" {
+        file write `file' `"`thesmclrule'"' _n
+    }
+
+*Labcol2 - title
+    if `haslabcol2' {
+        IsInString `"""' `"`macval(labcol2title)'"' // sets local strcount
+        if `strcount'==0 {
+            local labcol2chunk `"`macval(labcol2title)'"'
+            local labcol2rest ""
+        }
+        else {
+            gettoken labcol2chunk labcol2rest : labcol2title
+        }
+    }
+
+*Write head: Models groups
+    if "`mgroupsnone'"=="" & `"`macval(mgroups)'"'!="" {
+        local hasheader 1
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(mgroupsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+        local mgroupsbegin `"`macval(value)'"'
+        InsertAtVariables `"`macval(mgroupsend)'"' 2 "`ncols'" `macval(atvars2)'
+        local mgroupsend `"`macval(value)'"'
+        local tmpbegin `"`macval(begin)'"'
+        local tmpend `"`macval(end)'"'
+        if "`mgroupsreplace'"!="" {
+            if `"`macval(mgroupsbegin)'"'!="" local tmpbegin
+            if `"`macval(mgroupsend)'"'!=""  local tmpend
+        }
+        MgroupsPattern "`modelsrow'" "`mgroupspattern'"
+        Abbrev `varwidth' `"`macval(mgroupslhs)'"' "`abbrev'"
+        local value: di `fmt_v' `"`macval(value)'"'
+        WriteBegin `"`file'"' `"`macval(mgroupsbegin)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `haslabcol2' {
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        WriteCaption `"`file'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`mgroupspattern'" "`mgroupspattern'" ///
+            `"`macval(mgroups)'"' "`starsrow'" "`mgroupsspan'" "`abbrev'" ///
+            "`modelwidth'" "`delwidth'" "`starwidth'" ///
+            `"`macval(mgroupserepeat)'"' `"`macval(mgroupsprefix)'"' ///
+            `"`macval(mgroupssuffix)'"' "`haslabcol2'"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(mgroupsend)'"' ///
+         `"`"`macval(value)'"'"'
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+        gettoken labcol2chunk labcol2rest : labcol2rest
+    }
+
+*Write head: Models numbers
+    if `"`macval(numbers)'"'!="" {
+        local hasheader 1
+        if "`smcltags'"!="" file write `file' "{txt}"
+        if `"`macval(numbers)'"'=="numbers" local numbers "( )"
+        file write `file' `macval(begin)' `fmt_v' (`""')
+        if `haslabcol2' {
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        tokenize `"`macval(numbers)'"'
+        numlist `"1/`nmodels'"'
+        WriteCaption `"`file'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`modelsrow'" "`modelsrow'"  ///
+            "`r(numlist)'" "`starsrow'" "`mlabelsspan'" "`abbrev'"  ///
+            "`modelwidth'" "`delwidth'" "`starwidth'" ///
+            `""' `"`macval(1)'"' `"`macval(2)'"' "`haslabcol2'"
+        file write `file' `macval(end)' _n
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+        gettoken labcol2chunk labcol2rest : labcol2rest
+    }
+
+*Write head: Models captions
+    if "`nomlabelsnone'"=="" & "`models'"=="." & `"`macval(mlabels)'"'=="." local mlabelsnone "none"
+    if "`mlabelsnone'"=="" {
+        local hasheader 1
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(mlabelsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+        local mlabelsbegin `"`macval(value)'"'
+        InsertAtVariables `"`macval(mlabelsend)'"' 2 "`ncols'" `macval(atvars2)''
+        local mlabelsend `"`macval(value)'"'
+        local tmpbegin `"`macval(begin)'"'
+        local tmpend `"`macval(end)'"'
+        if "`mlabelsreplace'"!="" {
+            if `"`macval(mlabelsbegin)'"'!="" local tmpbegin
+            if `"`macval(mlabelsend)'"'!=""  local tmpend
+        }
+        Abbrev `varwidth' `"`macval(mlabelslhs)'"' "`abbrev'"
+        local value: di `fmt_v' `"`macval(value)'"'
+        WriteBegin `"`file'"' `"`macval(mlabelsbegin)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `haslabcol2' {
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        WriteCaption `"`file'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`modelsrow'" "`modelsrow'"  ///
+            `"`macval(mlabels)'"' "`starsrow'" "`mlabelsspan'" "`abbrev'"  ///
+            "`modelwidth'" "`delwidth'" "`starwidth'" ///
+            `"`macval(mlabelserepeat)'"' `"`macval(mlabelsprefix)'"' ///
+            `"`macval(mlabelssuffix)'"' "`haslabcol2'"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(mlabelsend)'"' ///
+         `"`"`macval(value)'"'"'
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+        gettoken labcol2chunk labcol2rest : labcol2rest
+    }
+
+*Write head: Equations captions
+    if "`eqlabelsnone'"=="" {
+        InsertAtVariables `"`macval(eqlabelsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+        local eqlabelsbegin `"`macval(value)'"'
+        InsertAtVariables `"`macval(eqlabelsend)'"' 2 "`ncols'" `macval(atvars2)'
+        local eqlabelsend `"`macval(value)'"'
+    }
+    if `"`eqswide'"'!="__" & "`eqlabelsnone'"=="" {
+        local hasheader 1
+        local tmpbegin `"`macval(begin)'"'
+        local tmpend `"`macval(end)'"'
+        if "`eqlabelsreplace'"!="" {
+            if `"`macval(eqlabelsbegin)'"'!="" local tmpbegin
+            if `"`macval(eqlabelsend)'"'!=""  local tmpend
+        }
+        if "`smcltags'"!="" file write `file' "{txt}"
+        Abbrev `varwidth' `"`macval(eqlabelslhs)'"' "`abbrev'"
+        local value: di `fmt_v' `"`macval(value)'"'
+        WriteBegin `"`file'"' `"`macval(eqlabelsbegin)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `haslabcol2' {
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        WriteCaption `"`file'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`eqsrow'" "`modelsrow'" ///
+            `"`macval(eqlabels)'"' "`starsrow'" "`eqlabelsspan'"  "`abbrev'" ///
+            "`modelwidth'" "`delwidth'" "`starwidth'" ///
+            `"`macval(eqlabelserepeat)'"' `"`macval(eqlabelsprefix)'"' ///
+            `"`macval(eqlabelssuffix)'"' "`haslabcol2'"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(eqlabelsend)'"' ///
+         `"`"`macval(value)'"'"'
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+        gettoken labcol2chunk labcol2rest : labcol2rest
+    }
+
+*Write head: Columns captions
+    if `"`macval(collabels)'"'!="" & "`collabelsnone'"=="" {
+        local hasheader 1
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(collabelsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+        local collabelsbegin `"`macval(value)'"'
+        InsertAtVariables `"`macval(collabelsend)'"' 2 "`ncols'" `macval(atvars2)'
+        local collabelsend `"`macval(value)'"'
+        local tmpbegin `"`macval(begin)'"'
+        local tmpend `"`macval(end)'"'
+        if "`collabelsreplace'"!="" {
+            if `"`macval(collabelsbegin)'"'!="" local tmpbegin
+            if `"`macval(collabelsend)'"'!=""  local tmpend
+        }
+        Abbrev `varwidth' `"`macval(collabelslhs)'"' "`abbrev'"
+        local value: di `fmt_v' `"`macval(value)'"'
+        WriteBegin `"`file'"' `"`macval(collabelsbegin)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `haslabcol2' {
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        WriteCaption `"`file'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`colsrow'" "" `"`macval(collabels)'"' ///
+            "`starsrow'" "`collabelsspan'" "`abbrev'" "`modelwidth'" ///
+            "`delwidth'" "`starwidth'" `"`macval(collabelserepeat)'"' ///
+            `"`macval(collabelsprefix)'"' `"`macval(collabelssuffix)'"' "`haslabcol2'"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(collabelsend)'"' ///
+         `"`"`macval(value)'"'"'
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+        gettoken labcol2chunk labcol2rest : labcol2rest
+    }
+
+*Write posthead
+    if `hasheader' & "`smclmidrules'"!="" {
+        file write `file' `"`thesmclrule'"' _n
+    }
+    if `"`macval(posthead)'"'!="" {
+        if index(`"`macval(posthead)'"',`"""')==0 {
+            local posthead `"`"`macval(posthead)'"'"'
+        }
+    }
+    foreach line of local posthead {
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(line)'"' 0 "`ncols'" `macval(atvars2)' `macval(atvars3)'
+        file write `file' `"`macval(value)'"' _n
+    }
+
+* Create mmd alignment/divider line
+    if `"`defaults'"'=="mmd" {
+        MakeMMDdef "`varwidth'" "`haslabcol2'" "`labcol2width'" ///
+            "`modelwidth'" "`starsrow'" "`stardetachon'" "`starwidth'"
+        file write `file' `"`macval(value)'"' _n
+    }
+
+*Write body of table
+*Loop over table rows
+    InsertAtVariables `"`macval(varlabelsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+    local varlabelsbegin `"`macval(value)'"'
+    InsertAtVariables `"`macval(varlabelsend)'"' 2 "`ncols'" `macval(atvars2)'
+    local varlabelsend `"`macval(value)'"'
+    tempname first
+    if `"`vblock'"'!="" {
+        local RI = `R' + `nindicate'
+        local e 0
+        local eqdim = `R' + `nindicate'
+        local weqcnt 0
+        local theeqlabel
+        if `hasrtfbrdr' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrt'"'
+            local rtfbrdron 1
+        }
+        local varlabelsbegin0 `"`macval(varlabelsbegin)'"'
+        local eqlabelsbegin0 `"`macval(eqlabelsbegin)'"'
+        if "`eqlabelsfirst'"=="" local eqlabelsbegin0
+        forv r = 1/`R' {
+            local varlabelsend0 `"`macval(varlabelsend)'"'
+            local var: word `r' of `varlist'
+
+*Write equation name/label
+            if "`unstack'"=="" {
+                local eqvar: word `r' of `fullvarlist'
+                if `"`eqs'"'!="__" {
+                    local eqrlast `"`eqr'"'
+                    local eqr: word `r' of `eqlist'
+                    if `"`eqr'"'!=`"`eqrlast'"' & "`eqlabelsnone'"=="" {
+                        local value: word `++e' of `macval(eqlabels)'
+                        local eqdim: word `e' of `macval(eqsdims)'
+                        local weqcnt 0
+                        if `e'==`numeqs' {
+                            if "`eqlabelslast'"=="" local eqlabelsend
+                            local eqdim = `eqdim' + `nindicate'
+                        }
+                        if "`eqlabelsmerge'"!="" {
+                            local theeqlabel `"`macval(eqlabelsprefix)'`macval(value)'`macval(eqlabelssuffix)'"'
+                        }
+                        else {
+                            local tmpbegin `"`macval(begin)'"'
+                            local tmpend `"`macval(end)'"'
+                            if "`eqlabelsreplace'"!="" {
+                                if `"`macval(eqlabelsbegin0)'"'!="" local tmpbegin
+                                if `"`macval(eqlabelsend)'"'!=""  local tmpend
+                            }
+                            if `e'>1 & "`smcleqrules'"!="" {
+                                file write `file' `"`thesmclrule'"' _n
+                            }
+                            WriteBegin `"`file'"' `"`macval(eqlabelsbegin0)'"' `"`macval(tmpbegin)'"'
+                            if "`smcltags'"!="" file write `file' "{res}"
+                            WriteEqrow `"`file'"' `"`macval(delimiter)'"' ///
+                                `"`macval(stardetach)'"' `"`macval(value)'"' "`starsrow'" ///
+                                "`eqlabelsspan'" "`varwidth'" "`fmt_v'" "`abbrev'" ///
+                                "`modelwidth'" "`delwidth'" "`starwidth'" ///
+                                `"`macval(eqlabelsprefix)'"' `"`macval(eqlabelssuffix)'"' ///
+                                "`haslabcol2'" "`labcol2width'" "`fmt_l2'"
+                            if "`smcltags'"!="" file write `file' "{txt}"
+                            WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(eqlabelsend)'"'
+                            if `hasrtfbrdr' & `rtfbrdron' {
+                                StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+                                local rtfbrdron 0
+                            }
+                            local eqlabelsbegin0 `"`macval(eqlabelsbegin)'"'
+                        }
+                    }
+                }
+            }
+            local ++weqcnt
+            if `weqcnt'==1 {
+                if "`varlabelsfirst'"=="" local varlabelsbegin0
+            }
+
+*Determine rows to be written
+            local rvblock
+            foreach row of local vblock {
+                local c 0
+                local skiprow 1
+                local rowhasstats 0
+                foreach v of local row {
+                    local ++c
+                    if "`unstack'"!="" {
+                        local eqr: word `:word `c' of `eqsrow'' of `eqs'
+                        if `"`eqr'"'!="" local eqvar `"`eqr':`var'"'
+                        else local eqvar "`var'"
+                    }
+                    local v: subinstr local v "&" " ", all
+                    foreach vi of local v {
+                        if "`vi'"=="." continue
+                        if rownumb(`B',`"`eqvar'"')<. {
+                            local rowhasstats 1
+                            if index("`vi'",".")==1 continue
+                            local inlist: list posof `"`eqvar'"' in `vi'_drop
+                            if `inlist' continue
+                            local skiprow 0
+                            continue, break
+                        }
+                    }
+                    if `skiprow'==0 continue, break
+                }
+                if `rowhasstats'==0 local skiprow 0
+                if `"`ferest()'"'=="" & `"`rvblock'"'=="" local skiprow 0
+                if `skiprow' continue
+                local rvblock `"`rvblock'"`row'" "'
+            }
+            local nrvblock: list sizeof rvblock
+
+*Insert refcat() (unless refcatbelow)
+            if `"`macval(refcat)'"'!="" {
+                local isref: list posof `"`var'"' in refcatcoefs
+                if `isref' {
+                    if "`unstack'"=="" {
+                        local temp `"`eqr'"'
+                        if `"`temp'"'=="" local temp "__"
+                    }
+                    else local temp `"`eqswide'"'
+                    GenerateRefcatRow `B' `ccols' "`var'" `"`temp'"' `"`macval(refcatlabel)'"'
+                    local refcatrow `"`macval(value)'"'
+                }
+            }
+            else local isref 0
+            if `isref' & `"`refcatbelow'"'=="" {
+                if "`smcltags'"!="" file write `file' "{txt}"
+                local tmpbegin `"`macval(begin)'"'
+                local tmpend `"`macval(end)'"'
+                if "`varlabelsreplace'"!="" {
+                    if `"`macval(varlabelsbegin0)'"'!="" local tmpbegin
+                    if `"`macval(varlabelsend0)'"'!=""  local tmpend
+                }
+                if "`varlabelsnone'"=="" {
+                    local value: word `isref' of `macval(refcatnames)'
+                    Abbrev `varwidth' `"`macval(value)'"' "`abbrev'"
+                }
+                else local value
+                local value: di `fmt_v' `"`macval(varlabelsprefix)'`macval(value)'`macval(varlabelssuffix)'"'
+                WriteBegin `"`file'"' `"`macval(varlabelsbegin0)'"' `"`macval(tmpbegin)'"' ///
+                    `"`"`macval(value)'"'"'
+                if `haslabcol2' {
+                    gettoken labcol2chunk labcol2 : labcol2
+                    Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+                    if `:length local value'<245 {
+                        local value: di `fmt_l2' `"`macval(value)'"'
+                    }
+                    file write `file' `macval(delimiter)' `"`macval(value)'"'
+                }
+                if "`smcltags'"!="" file write `file' "{res}"
+                WriteStrRow `"`file'"' "`modelsrow'" `"`eqsrow'"' `"`: list sizeof eqswide'"' ///
+                    `"`macval(refcatrow)'"' `"`macval(delimiter)'"' ///
+                    `"`macval(stardetach)'"' "`starsrow'" "`abbrev'"  ///
+                    "`modelwidth'" "`delwidth'" "`starwidth'"
+                if "`smcltags'"!="" file write `file' "{txt}"
+                WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(varlabelsend0)'"'
+                if `hasrtfbrdr' & `rtfbrdron' {
+                    StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+                    local rtfbrdron 0
+                }
+                local varlabelsbegin0 `"`macval(varlabelsbegin)'"'
+            }
+
+*Write variable name/label
+            if "`smcltags'"!="" file write `file' "{txt}"
+            local tmpbegin `"`macval(begin)'"'
+            if "`varlabelsnone'"=="" {
+                VarInList `"`var'"' "`unstack'" `"`eqvar'"' ///
+                 `"`eqr'"' `"`macval(varlabelsblist)'"'
+                if `"`macval(value)'"'!="" {
+                    IsInString `"""' `"`value'"' // sets local strcount
+                    if `strcount'==0 {
+                        local value `"`"`macval(value)'"'"'
+                    }
+                    InsertAtVariables `"`macval(value)'"' 2 "`ncols'" `macval(atvars2)'
+                    WriteStrLines `"`file'"' `"`macval(value)'"'
+                    if "`varlabelsreplace'"!="" {
+                        local tmpbegin
+                        local varlabelsbegin0
+                    }
+                }
+                if "`label'"!="" {
+                    CompileVarl, vname(`var') interaction(`macval(interaction)')
+                }
+                else local varl `var'
+                VarInList `"`var'"' "`unstack'" `"`eqvar'"' ///
+                 `"`eqr'"' `"`macval(varlabels)'"'
+                if `"`macval(value)'"'!="" {
+                    local varl `"`macval(value)'"'
+                }
+                if `"`macval(discrete)'"'!="" {
+                    local temp 0
+                    if "`unstack'"=="" {
+                        if `D'[`r',1]==1 local temp 1
+                    }
+                    else {
+                        foreach eqr of local eqswide {
+                            if `D'[rownumb(`D',`"`eqr':`var'"'),1]==1 local temp 1
+                        }
+                    }
+                    if `temp'==1 & `temp'<. {
+                        local varl `"`macval(varl)'`macval(discrete)'"'
+                    }
+                }
+            }
+            else local varl
+            if `hasrtfbrdr' & `r'==`RI' & !(`isref' & `"`refcatbelow'"'!="") {
+                if `nrvblock'==1 {
+                    if `rtfbrdron' {
+                        // special case: still in first physical row of table
+                        // body; this means that the table body only has a single
+                        // physical row => need line at top and bottom
+                        StableSubinstr tmpbegin `"`macval(tmpbegin)'"' /*
+                            */ "\clbrdrt\brdrw10\brdrs" /*
+                            */ "\clbrdrt\brdrw10\brdrs\clbrdrb\brdrw10\brdrs" all
+                    }
+                    else {
+                        StableSubinstr tmpbegin `"`macval(rtfbeginbak)'"' /*
+                            */ "@rtfrowdefbrdr" `"`rtfrowdefbrdrb'"'
+                    }
+                    local rtfbrdron 1
+                }
+            }
+            if "`varlabelsreplace'"!="" {
+                if `"`macval(varlabelsbegin0)'"'!="" local tmpbegin
+            }
+            if "`wrap'"!="" & `nrvblock'>1 {
+                local wrap_i 1
+                local value: piece `wrap_i' `varwidth' of `"`macval(theeqlabel)'`macval(varl)'"', nobreak
+                Abbrev `varwidth' `"`macval(value)'"' "`abbrev'"
+            }
+            else {
+                Abbrev `varwidth' `"`macval(theeqlabel)'`macval(varl)'"' "`abbrev'"
+            }
+            local value: di `fmt_v' `"`macval(varlabelsprefix)'`macval(value)'`macval(varlabelssuffix)'"'
+            WriteBegin `"`file'"' `"`macval(varlabelsbegin0)'"' `"`macval(tmpbegin)'"' ///
+                `"`"`macval(value)'"'"'
+            if `haslabcol2' {
+                gettoken labcol2chunk labcol2 : labcol2
+                Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+                if `:length local value'<245 {
+                    local value: di `fmt_l2' `"`macval(value)'"'
+                }
+                file write `file' `macval(delimiter)' `"`macval(value)'"'
+            }
+            if `hasrtfbrdr' & `rtfbrdron' {
+                StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+                local rtfbrdron 0
+            }
+            local varlabelsbegin0 `"`macval(varlabelsbegin)'"'
+
+*Write table cells
+            if "`smcltags'"!="" file write `file' "{res}"
+            local newrow 0
+            mat `first'=J(1,`nmodels',1)
+            foreach row of local rvblock {
+                if `hasrtfbrdr' & `r'==`RI' & !(`isref' & `"`refcatbelow'"'!="") {
+                    if `"`ferest()'"'=="" {
+                        StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrb'"'
+                        local rtfbrdron 1
+                    }
+                }
+                local c 0
+                foreach v of local row {
+                    local m: word `++c' of `modelsrow'
+                    local unstackskipcoef 0
+                    if "`unstack'"!="" {
+                        capt local eqr: word `:word `c' of `eqsrow'' of `eqs'
+                        local rr = rownumb(`B', `"`eqr':`var'"')
+                        if `"`eqr'"'!="" local eqvar `"`eqr':`var'"'
+                        else local eqvar "`var'"
+                        if `rr'>=. local unstackskipcoef 1 // local v "."
+                    }
+                    else local rr `r'
+                    if `newrow' & `c'==1 {
+                        if "`smcltags'"!="" file write `file' "{txt}"
+                        if "`wrap'"!="" & `nrvblock'>1 {
+                            local value
+                            local space
+                            while (1) {
+                                local temp: piece `++wrap_i' `varwidth' of `"`macval(varl)'"', nobreak
+                                if `"`macval(temp)'"'=="" continue, break
+                                local value `"`macval(value)'`space'`macval(temp)'"'
+                                if `wrap_i'<`nrvblock' continue, break
+                                local space " "
+                            }
+                            Abbrev `varwidth' `"`macval(value)'"' "`abbrev'"
+                            local value: di `fmt_v' `"`macval(varlabelsprefix)'`macval(value)'`macval(varlabelssuffix)'"'
+                            local value `"`"`macval(value)'"'"'
+                        }
+                        else local value "_skip(`varwidth')"
+                        file write `file' `macval(end)' _n `macval(begin)' `value'
+                        if `haslabcol2' {
+                            file write `file' `macval(delimiter)' `fmt_l2' ("")
+                        }
+                        if "`smcltags'"!="" file write `file' "{res}"
+                    }
+                    local v: subinstr local v "&" " ", all
+                    local modelwidthj: word `=1+mod(`c'-1,`nmodelwidth')' of `modelwidth'
+                    if `modelwidthj'>0 local fmt_m "%`modelwidthj's"
+                    else local fmt_m
+                    local thevalue
+                    foreach vi of local v {
+                        if index("`vi'",".")!=1 {
+                            local inlist: list posof `"`eqvar'"' in `vi'_drop
+                            if `inlist' local vi "..`vi'"
+                            else {
+                                local vipar: subinstr local `vi'_par "@modelwidth" "`modelwidthj'", all
+                            }
+                        }
+                        if index("`vi'",".")==1 {
+                            local value
+                        }
+                        else if `unstackskipcoef' {
+                            local value `"``vi'_vacant'"'
+                        }
+                        else if `B'[`rr',`m'*`droppedpos']==1 & `droppedison' {
+                            if `first'[1,`m'] {
+                                local value `"`macval(dropped)'"'
+                                mat `first'[1,`m']=0
+                            }
+                            else local value
+                        }
+                        else if "``vi'_'"=="ci" {
+                            if `_`vi'_l'[`rr',`m']>=.y local value `"``vi'_vacant'"'
+                            else {
+                                local format: word `r' of ``vi'_fmt'
+                                if "`format'"=="" {
+                                    local format: word `:word count ``vi'_fmt'' of ``vi'_fmt'
+                                }
+                                local value = `_`vi'_l'[`rr',`m']
+                                local vipar: subinstr local `vi'_l_par "@modelwidth" "`modelwidthj'", all
+                                vFormat `value' `format' "`lz'" `"`macval(dmarker)'"' ///
+                                    `"`macval(msign)'"' `"`macval(vipar)'"'
+                                local temp "`macval(value)'"
+                                local value = `_`vi'_u'[`rr',`m']
+                                local vipar: subinstr local `vi'_u_par "@modelwidth" "`modelwidthj'", all
+                                vFormat `value' `format' "`lz'" `"`macval(dmarker)'"' ///
+                                    `"`macval(msign)'"' `"`macval(vipar)'"'
+                                local value `"`macval(temp)'`macval(value)'"'
+                            }
+                        }
+                        else if `_`vi''[`rr',`m']>=.y   local value `"``vi'_vacant'"'
+                        //else if `_`vi''[`rr',`m']>=.    local value .
+                        else if "``vi'_'"=="_star" {
+                            CellStars `"`macval(starlevels)'"' `_```vi'_pvalue'_tname''[`rr',`m'] `"`macval(vipar)'"'
+                        }
+                        else if "``vi'_'"=="_sign" {
+                            MakeSign `_`vi''[`rr',`m'] `"`macval(msign)'"' `"`macval(vipar)'"'
+                        }
+                        else if "``vi'_'"=="_sigsign" {
+                            MakeSign `_`vi''[`rr',`m'] `"`macval(msign)'"' `"`macval(vipar)'"' ///
+                                `"`macval(starlevels)'"' `_```vi'_pvalue'_tname''[`rr',`m']
+                        }
+                        else {
+                            local format: word `r' of ``vi'_fmt'
+                            if "`format'"=="" {
+                                local format: word `:word count ``vi'_fmt'' of ``vi'_fmt'
+                            }
+                            local value = `_`vi''[`rr',`m']
+                            vFormat `value' `format' "`lz'" `"`macval(dmarker)'"' ///
+                                `"`macval(msign)'"' `"`macval(vipar)'"'
+                        }
+                        local thevalue `"`macval(thevalue)'`macval(value)'"'
+                        if !`stardetachon' & `:word `c' of `starsrow''==1 {
+                            if `modelwidthj'>0 | `starwidth'>0 local fmt_m "%`=`modelwidthj'+`starwidth''s"
+                            local value
+                            if index("`vi'",".")!=1 & `"``vi'_star'"'!="" {
+                                local inlist: list posof `"`eqvar'"' in stardrop
+                                if !`inlist' {
+                                    Stars `"`macval(starlevels)'"' `_```vi'_pvalue'_tname''[`rr',`m']
+                                }
+                            }
+                            if "`ferest()'"=="" {
+                                local value: di `fmt_stw' `"`macval(value)'"'
+                            }
+                            local thevalue `"`macval(thevalue)'`macval(value)'"'
+                        }
+                        if "`ferest()'"!="" & index("`vi'","..")!=1  {
+                            local thevalue `"`macval(thevalue)'`macval(incelldelimiter)'"'
+                        }
+                    }
+                    if `:length local thevalue'<245 {
+                        local thevalue: di `fmt_m' `"`macval(thevalue)'"'
+                    }
+                    file write `file' `macval(delimiter)' `"`macval(thevalue)'"'
+                    if `stardetachon' & `:word `c' of `starsrow''==1 {
+                        local thevalue
+                        foreach vi of local v {
+                            if index("`vi'",".")!=1 {
+                                local inlist: list posof `"`eqvar'"' in `vi'_drop
+                                if `inlist' local vi "..`vi'"
+                            }
+                            if index("`vi'",".")!=1 & `"``vi'_star'"'!="" {
+                                local inlist: list posof `"`eqvar'"' in stardrop
+                                if `inlist' local value
+                                else {
+                                    Stars `"`macval(starlevels)'"' `_```vi'_pvalue'_tname''[`rr',`m']
+                                }
+                                local thevalue `"`macval(thevalue)'`macval(value)'"'
+                            }
+                            if "`ferest()'"!="" & index("`vi'","..")!=1  {
+                                local thevalue `"`macval(thevalue)'`macval(incelldelimiter)'"'
+                            }
+                        }
+                        if `:length local thevalue'<245 {
+                            local thevalue: di `fmt_stw' `"`macval(thevalue)'"'
+                        }
+                        file write `file' `macval(stardetach)' `"`macval(thevalue)'"'
+                    }
+                }
+                local newrow 1
+            }
+
+*End of table row
+            if "`smcltags'"!="" file write `file' "{txt}"
+            if `weqcnt'==`eqdim' & "`varlabelslast'"=="" ///
+             & !(`isref' & `"`refcatbelow'"'!="") local varlabelsend0
+            local tmpend `"`macval(end)'"'
+            if "`varlabelsreplace'"!="" {
+                if `"`macval(varlabelsend0)'"'!=""  local tmpend
+            }
+            VarInList `"`var'"' "`unstack'" `"`eqvar'"' `"`eqr'"' ///
+             `"`macval(varlabelselist)'"'
+            if `"`macval(value)'"'!="" {
+                IsInString `"""' `"`value'"' // sets local strcount
+                if `strcount'==0 {
+                    local value `"`"`macval(value)'"'"'
+                }
+                InsertAtVariables `"`macval(value)'"' 2 "`ncols'" `macval(atvars2)'
+                if "`varlabelsreplace'"!="" local varlabelsend0
+            }
+            WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(varlabelsend0)'"' ///
+             `"`macval(value)'"'
+* insert refcat() (if refcatbelow)
+            if `isref' & `"`refcatbelow'"'!="" {
+            if "`smcltags'"!="" file write `file' "{txt}"
+                if `hasrtfbrdr' & `r'==`RI' {
+                    StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrb'"'
+                    local rtfbrdron 1
+                }
+                if `weqcnt'==`eqdim' & "`varlabelslast'"=="" local varlabelsend0
+                local tmpbegin `"`macval(begin)'"'
+                local tmpend `"`macval(end)'"'
+                if "`varlabelsreplace'"!="" {
+                    if `"`macval(varlabelsbegin0)'"'!="" local tmpbegin
+                    if `"`macval(varlabelsend0)'"'!=""  local tmpend
+                }
+                if "`varlabelsnone'"=="" {
+                    local value: word `isref' of `macval(refcatnames)'
+                    Abbrev `varwidth' `"`macval(value)'"' "`abbrev'"
+                }
+                else local value
+                local value: di `fmt_v' `"`macval(varlabelsprefix)'`macval(value)'`macval(varlabelssuffix)'"'
+                WriteBegin `"`file'"' `"`macval(varlabelsbegin0)'"' `"`macval(tmpbegin)'"' ///
+                    `"`"`macval(value)'"'"'
+                if `haslabcol2' {
+                    gettoken labcol2chunk labcol2 : labcol2
+                    Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+                    if `:length local value'<245 {
+                        local value: di `fmt_l2' `"`macval(value)'"'
+                    }
+                    file write `file' `macval(delimiter)' `"`macval(value)'"'
+                }
+                if "`smcltags'"!="" file write `file' "{res}"
+                WriteStrRow `"`file'"' "`modelsrow'" `"`eqsrow'"' `"`: list sizeof eqswide'"' ///
+                    `"`macval(refcatrow)'"' `"`macval(delimiter)'"' ///
+                    `"`macval(stardetach)'"' "`starsrow'" "`abbrev'"  ///
+                    "`modelwidth'" "`delwidth'" "`starwidth'"
+                if "`smcltags'"!="" file write `file' "{txt}"
+                WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(varlabelsend0)'"'
+            }
+* end insert refcat()
+        }
+    }
+
+*Write indicator sets
+    forv i=1/`nindicate' {
+        if `hasrtfbrdr' & `i'==`nindicate' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrb'"'
+            local rtfbrdron 1
+        }
+        if `i'==`nindicate' & "`varlabelslast'"=="" local varlabelsend
+        local tmpbegin `"`macval(begin)'"'
+        local tmpend `"`macval(end)'"'
+        if "`varlabelsreplace'"!="" {
+            if `"`macval(varlabelsbegin0)'"'!="" local tmpbegin
+            if `"`macval(varlabelsend)'"'!=""  local tmpend
+        }
+        if "`varlabelsnone'"=="" {
+            Abbrev `varwidth' `"`macval(indicate`i'name)'"' "`abbrev'"
+        }
+        else local value
+        if "`smcltags'"!="" file write `file' "{txt}"
+        local value: di `fmt_v' `"`macval(varlabelsprefix)'`macval(value)'`macval(varlabelssuffix)'"'
+        WriteBegin `"`file'"' `"`macval(varlabelsbegin0)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `haslabcol2' {
+            gettoken labcol2chunk labcol2 : labcol2
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        if "`smcltags'"!="" file write `file' "{res}"
+        WriteStrRow `"`file'"' "`modelsrow'" `"`eqsrow'"' `"`: list sizeof eqswide'"' ///
+            `"`macval(indicate`i'lbls)'"' `"`macval(delimiter)'"' ///
+            `"`macval(stardetach)'"' "`starsrow'" "`abbrev'"  ///
+            "`modelwidth'" "`delwidth'" "`starwidth'"
+        if "`smcltags'"!="" file write `file' "{txt}"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(varlabelsend)'"'
+    }
+
+*Write prefoot
+    if `"`macval(prefoot)'"'!="" {
+        if index(`"`macval(prefoot)'"',`"""')==0 {
+            local prefoot `"`"`macval(prefoot)'"'"'
+        }
+    }
+    foreach line of local prefoot {
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(line)'"' 0 "`ncols'" `macval(atvars2)' `macval(atvars3)'
+        file write `file' `"`macval(value)'"' _n
+    }
+    if ((`"`vblock'"'!="" & `R'>0) | `nindicate'>0) & "`smclmidrules'"!="" {
+        if `"`macval(statsarray)'"'!="" {
+            file write `file' `"`thesmclrule'"' _n
+        }
+    }
+
+*Write foot of table (statistics)
+    InsertAtVariables `"`macval(statslabelsbegin)'"' 2 "`ncols'" `macval(atvars2)'
+    local statslabelsbegin `"`macval(value)'"'
+    InsertAtVariables `"`macval(statslabelsend)'"' 2 "`ncols'" `macval(atvars2)'
+    local statslabelsend `"`macval(value)'"'
+    local statslabelsbegin0 `"`macval(statslabelsbegin)'"'
+    local S: list sizeof statsarray
+    local eqr "__"
+    if `hasrtfbrdr' {
+        StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrt'"'
+        local rtfbrdron 1
+    }
+    forv r = 1/`S' {
+        if `r'==`S' & `hasrtfbrdr' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdefbrdrb'"'
+            local rtfbrdron 1
+        }
+        local stat: word `r' of `macval(statslabels)'
+        if `"`stat'"'=="" local stat: word `r' of `statsrowlbls'
+        if "`statslabelsnone'"!="" local stat
+        if "`smcltags'"!="" file write `file' "{txt}"
+        if `r'==1 & "`statslabelsfirst'"=="" local statslabelsbegin0
+        local tmpbegin `"`macval(begin)'"'
+        if "`statslabelsreplace'"!="" {
+            if `"`macval(statslabelsbegin0)'"'!="" local tmpbegin
+        }
+        Abbrev `varwidth' `"`macval(stat)'"' "`abbrev'"
+        local value: di `fmt_v' `"`macval(statslabelsprefix)'`macval(value)'`macval(statslabelssuffix)'"'
+        WriteBegin `"`file'"' `"`macval(statslabelsbegin0)'"' `"`macval(tmpbegin)'"' ///
+            `"`"`macval(value)'"'"'
+        if `r'==1 & "`statslabelsfirst'"=="" {
+            local statslabelsbegin0 `"`macval(statslabelsbegin)'"'
+        }
+        if `haslabcol2' {
+            gettoken labcol2chunk labcol2 : labcol2
+            Abbrev `labcol2width' `"`macval(labcol2chunk)'"' "`abbrev'"
+            if `:length local value'<245 {
+                local value: di `fmt_l2' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+        }
+        if "`smcltags'"!="" file write `file' "{res}"
+        local strow: word `r' of `statsarray'
+        local strowlay: word `r' of `macval(statslayout)'
+        local strowfmt: word `r' of  `statsrowfmt'
+        local strowstar: word `r' of  `statsrowstar'
+        local lastm
+        local lasteq
+        local c 0
+        local mpos 0
+        foreach m of local modelsrow {
+            local ++c
+            local modelwidthj: word `=1+mod(`c'-1,`nmodelwidth')' of `modelwidth'
+            if `modelwidthj'>0 local fmt_m "%`modelwidthj's"
+            else local fmt_m
+            if "`m'"=="." {
+                file write `file' `macval(delimiter)' `fmt_m' (`""')
+                continue
+            }
+            local value
+            local eq: word `:word `c' of `eqsrow'' of `eqs'
+            if "`m'"!="`lastm'" {
+                local stc 0
+                local hasmestats 0
+            }
+            if "`m'"!="`lastm'" | `"`eq'"'!="`lasteq'"  local stc_eq 0
+            local usemestats 0
+            local ++stc_eq
+            local stcell: word `++stc' of `strow'
+            local stcelllay: word `stc' of `macval(strowlay)'
+            local stcellfmt: word `stc' of `strowfmt'
+            local stcellstar: word `stc' of `strowstar'
+            local cellhasstat 0
+            foreach stat of local stcell {
+                gettoken format stcellfmt: stcellfmt
+                local rr = rownumb(`St',`"`stat'"')
+                local value = `St'[`rr',`m']
+                if `value'==.y {
+                    local value `"`return(m`m'_`stat')'"'
+                    if `"`value'"'!="" {
+                        local cellhasstat 1
+                        local stcelllay: subinstr local stcelllay `"`statspchar'"' ///
+                        `"`value'"'
+                    }
+                }
+                else if `value'==.x {
+                    local hasmestats 1
+                }
+                else if `value'<.x {
+                    local cellhasstat 1
+                    vFormat `value' "`format'" "`lz'" `"`macval(dmarker)'"' ///
+                    `"`macval(msign)'"'
+                    local stcelllay: subinstr local stcelllay `"`statspchar'"' ///
+                    `"`macval(value)'"'
+                }
+            }
+            if `cellhasstat'==0 & `hasmestats' {
+                local stcell: word `stc_eq' of `strow'
+                local stcelllay: word `stc_eq' of `macval(strowlay)'
+                local stcellfmt: word `stc_eq' of `strowfmt'
+                local stcellstar: word `stc_eq' of `strowstar'
+                local cellhasstat 0
+                foreach stat of local stcell {
+                    gettoken format stcellfmt: stcellfmt
+                    local rr = rownumb(`St',`"`eq':`stat'"')
+                    if `rr'>=. local value .z
+                    else local value = `St'[`rr',`m']
+                    if `value'!=.z {
+                        local cellhasstat 1
+                        vFormat `value' "`format'" "`lz'" `"`macval(dmarker)'"' ///
+                         `"`macval(msign)'"'
+                        local stcelllay: subinstr local stcelllay `"`statspchar'"' `"`macval(value)'"'
+                    }
+                }
+                if `cellhasstat' local usemestats 1
+            }
+            if `cellhasstat'==0 local stcelllay
+            if `:length local stcelllay'<245 {
+                local stcelllay: di `fmt_m' `"`macval(stcelllay)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(stcelllay)'"'
+            if `:word `c' of `starsrow''==1 {
+                if "`stcellstar'"=="1" & `cellhasstat' {
+                    if `usemestats' {
+                        local rr=rownumb(`St',`"`eq':p"')
+                    }
+                    else {
+                        local rr=rownumb(`St',"p")
+                    }
+                    Stars `"`macval(starlevels)'"' `St'[`rr',`m']
+                    if `:length local value'<245 {
+                        local value: di `fmt_stw' `"`macval(value)'"'
+                    }
+                    file write `file' `macval(stardetach)' `"`macval(value)'"'
+                }
+                else {
+                    file write `file' `macval(stardetach)' _skip(`starwidth')
+                }
+            }
+            local lastm "`m'"
+            local lasteq `"`eq'"'
+        }
+        if `r'==`S' & "`statslabelslast'"=="" local statslabelsend
+        local tmpend `"`macval(end)'"'
+        if "`statslabelsreplace'"!="" {
+            if `"`macval(statslabelsend)'"'!="" local tmpend
+        }
+        if "`smcltags'"!="" file write `file' "{txt}"
+        WriteEnd `"`file'"' `"`macval(tmpend)'"' `"`macval(statslabelsend)'"'
+        if `hasrtfbrdr' & `rtfbrdron' {
+            StableSubinstr begin `"`macval(rtfbeginbak)'"' "@rtfrowdefbrdr" `"`rtfrowdef'"'
+            local rtfbrdron 0
+        }
+    }
+
+*Write postfoot
+    if "`smclrules'"!="" {
+        file write `file' `"`thesmclrule'"' _n
+    }
+    local discrete: list retok discrete
+    if `"`macval(postfoot)'"'!="" {
+        if index(`"`macval(postfoot)'"',`"""')==0 {
+            local postfoot `"`"`macval(postfoot)'"'"'
+        }
+    }
+    foreach line of local postfoot {
+        if "`smcltags'"!="" file write `file' "{txt}"
+        InsertAtVariables `"`macval(line)'"' 0 "`ncols'" `macval(atvars2)' `macval(atvars3)'
+        file write `file' `"`macval(value)'"' _n
+    }
+
+*Write legend (starlevels, marginals)
+    if "`legend'"!="" {
+        if `"`macval(discrete2)'"'!="" {
+            mat `D' = `D''*`D'
+            if `D'[1,1]!=0 {
+                if "`smcltags'"!="" file write `file' "{txt}"
+                file write `file' `"`macval(discrete)'`macval(discrete2)'"' _n
+            }
+        }
+        if `"`macval(starlegend)'"'!="" {
+            if "`smcltags'"!="" file write `file' "{txt}"
+            file write `file' `"`macval(starlegend)'"' _n
+        }
+    }
+
+*Finish: copy tempfile to user file / type to screen
+    file close `file'
+    local rtfenc = ("`nortfencode'"=="") & (`hasrtf'!=0) & (c(stata_version)>=14)
+    local S: word count `macval(substitute)'
+    if `"`topfile'"'!="" {
+        confirm file `"`topfile'"'
+    }
+    if `"`bottomfile'"'!="" {
+        confirm file `"`bottomfile'"'
+    }
+    if `"`using'"'!="" {
+        tempname file2
+        file open `file2' `using', write text `replace' `append'
+    }
+    if "`type'"!="" di as res ""
+    if `"`topfile'"'!="" {
+        file open `file' using `"`topfile'"', read text
+        file read `file' temp
+        while r(eof)==0 {
+            if `"`using'"'!="" {
+                file write `file2' `"`macval(temp)'"' _n
+            }
+            if "`type'"!="" {
+                if "`showtabs'"!="" {
+                    local temp: subinstr local temp "`=char(9)'" "<T>", all
+                }
+                di `asis' `"`macval(temp)'"'
+            }
+            file read `file' temp
+        }
+        file close `file'
+    }
+    file open `file' using `"`tfile'"', read text
+    file read `file' temp
+    while r(eof)==0 {
+        forv s = 1(2)`S' {
+            local from: word `s' of `macval(substitute)'
+            local to:  word `=`s'+1' of `macval(substitute)'
+            if `"`macval(from)'`macval(to)'"'!="" {
+                local temp: subinstr local temp `"`macval(from)'"' `"`macval(to)'"', all
+            }
+        }
+        if `rtfenc' {
+            mata: estout_rtfencode("temp")
+        }
+        if `"`using'"'!="" {
+            file write `file2' `"`macval(temp)'"' _n
+        }
+        if "`type'"!="" {
+            if "`showtabs'"!="" {
+                local temp: subinstr local temp "`=char(9)'" "<T>", all
+            }
+            di `asis' `"`macval(temp)'"'
+        }
+        file read `file' temp
+    }
+    file close `file'
+    if `"`bottomfile'"'!="" {
+        file open `file' using `"`bottomfile'"', read text
+        file read `file' temp
+        while r(eof)==0 {
+            if `"`using'"'!="" {
+                file write `file2' `"`macval(temp)'"' _n
+            }
+            if "`type'"!="" {
+                if "`showtabs'"!="" {
+                    local temp: subinstr local temp "`=char(9)'" "<T>", all
+                }
+                di `asis' `"`macval(temp)'"'
+            }
+            file read `file' temp
+        }
+        file close `file'
+    }
+    if `"`using'"'!="" {
+        file close `file2'
+        gettoken junk using0 : using
+        return local fn `using0'
+        if "`outfilenoteoff'"=="" {
+            di as txt `"(output written to {browse `using0'})"'
+        }
+    }
+end
+
+program MoreOptions
+// estout has more options than -syntax- can handle; a subroutine is used
+// here (rather than a second syntax call) to preserve the 'using' macro
+// from the first syntax call
+// MoreOptions is intended for options without arguments only
+    local theoptions ///
+        NOOMITted OMITted ///
+        NOBASElevels BASElevels ///
+        NOEFORM eform ///
+        NOMargin Margin ///
+        NODIscrete ///
+        NODROPPED dropped ///
+        NOSTARDetach STARDetach ///
+        NOABbrev ABbrev ///
+        NOUNStack UNStack ///
+        NOLZ lz ///
+        NOLabel Label ///
+        NOLEgend LEgend ///
+        NONUMbers NUMbers ///
+        NOReplace Replace ///
+        NOAppend Append ///
+        NOTYpe TYpe ///
+        NOSHOWTABS showtabs ///
+        NOASIS asis ///
+        NOWRAP wrap ///
+        NOSMCLTags SMCLTags ///
+        NOSMCLRules SMCLRules ///
+        NOSMCLMIDRules SMCLMIDRules ///
+        NOSMCLEQRules SMCLEQRules ///
+        NOOUTFILENOTEOFF outfilenoteoff ///
+        NORTFENCODE rtfencode
+    syntax [, `theoptions' ]
+    foreach opt of local theoptions {
+        local opt = lower("`opt'")
+        c_local `opt' "``opt''"
+    }
+    c_local options
+end
+
+program ParseValueSubopts
+    syntax anything [ , mrow(string asis) NOTranspose Transpose ///
+        NOStar Star PVALue(string) Fmt(string) Label(string) Vacant(string) ///
+        NOPAR par PAR2(string asis) Keep(string asis) Drop(string asis) ///
+        PATtern(string) NOABS abs ]
+    local el: word 1 of `anything'
+    local elname: word 2 of `anything'
+    CheckPattern `"`pattern'"' "`elname'"
+    if `"`macval(par2)'"'!="" {
+        local par `"`macval(par2)'"'
+    }
+    else if "`par'"!="" {
+        if "`elname'"=="ci" local par "[ , ]"
+        else if "`elname'"=="ci_l" local par `"[ """'
+        else if "`elname'"=="ci_u" local par `""" ]"'
+        else local par "( )"
+    }
+    if `"`mrow'"'!="" {
+        capt confirm integer number `mrow'
+        if _rc==0 {
+            if `mrow'>=1 {
+                if `"`macval(label)'"'=="" {
+                    local label "`elname'[`mrow']"
+                }
+            }
+            else {
+                local mrow `""`mrow'""'
+                if `"`macval(label)'"'=="" {
+                    local label `mrow'
+                }
+            }
+        }
+        else {
+            gettoken trash : mrow, qed(qed)
+            if `qed'==0 {
+                local mrow `"`"`mrow'"'"'
+            }
+            if `"`macval(label)'"'=="" {
+                local label `mrow'
+            }
+        }
+    }
+    foreach opt in transpose star par abs {
+        if "`no`opt''"!="" c_local no`el'_`opt' 1
+        else c_local `el'_`opt' "``opt''"
+    }
+    foreach opt in mrow pvalue fmt label vacant keep drop pattern {
+        c_local `el'_`opt' `"`macval(`opt')'"'
+    }
+end
+
+program CheckPattern
+    args pattern option
+    foreach p of local pattern {
+        if !( "`p'"=="1" | "`p'"=="0" ) {
+            di as error `""`pattern'" invalid in `option'(... pattern())"'
+            exit 198
+        }
+    }
+end
+
+program ParseStatsSubopts
+    syntax [anything] [ , Fmt(string) Labels(string asis) ///
+     NOStar Star Star2(string) LAYout(string asis) PChar(string) ]
+    foreach opt in fmt labels layout pchar {
+        c_local stats`opt' `"`macval(`opt')'"'
+    }
+    if "`nostar'"!="" c_local nostatsstar 1
+    else if "`star2'"!="" {
+        local anything: list anything | star2
+        c_local statsstar "`star2'"
+    }
+    else if "`star'"!="" {
+        local star2: word 1 of `anything'
+        c_local statsstar "`star2'"
+    }
+    c_local stats "`anything'"
+    c_local stats2
+end
+
+prog ProcessStatslayout // returns statsarray, -rowlbls, -rowfmt, -rowstar, -colstar, -layout
+    args stats statsfmt statsstar statslayout statspchar
+    local format "%9.0g"
+    if `"`statspchar'"'=="" {
+        local statspchar "@"
+        c_local statspchar "@"
+    }
+    local statsarray
+    local statsrowlbls
+    local statsrowfmt
+    local statsrowstar
+    local space1
+    local i 0
+    local wmax 0
+    foreach row of local statslayout {
+        local statsrow
+        local statsrowlbl
+        local statsrfmt
+        local statsrstar
+        local space2
+        local w = 0
+        foreach cell of local row {
+            local ++w
+            local statscell
+            local statsclbl `"`cell'"'
+            local statscfmt
+            local statscstar 0
+            local space3
+            local trash: subinstr local cell `"`statspchar'"' "", all count(local cnt)
+            forv j=1/`cnt' {
+                local stat: word `++i' of `stats'
+                local statscell `"`statscell'`space3'`stat'"'
+                local statsclbl: subinstr local statsclbl `"`statspchar'"' "`stat'"
+                local tmp: word `i' of `statsfmt'
+                if `"`tmp'"'!="" local format `"`tmp'"'
+                local statscfmt `"`statscfmt'`space3'`format'"'
+                if `:list stat in statsstar' {
+                    local statscstar 1
+                    local statscol_`w' 1
+                }
+                local space3 " "
+            }
+            local statsrow `"`statsrow'`space2'"`statscell'""'
+            local statsrowlbl `"`statsrowlbl'`space2'`statsclbl'"'
+            local statsrfmt `"`statsrfmt'`space2'"`statscfmt'""'
+            local statsrstar "`statsrstar'`space2'`statscstar'"
+            local space2 " "
+        }
+        local statsarray `"`statsarray'`space1'`"`statsrow'"'"'
+        local statsrowlbls `"`statsrowlbls'`space1'`"`statsrowlbl'"'"'
+        local statsrowfmt `"`statsrowfmt'`space1'`"`statsrfmt'"'"'
+        local statsrowstar `"`statsrowstar'`space1'`"`statsrstar'"'"'
+        local space1 " "
+        local wmax = max(`w',`wmax')
+    }
+    while (1) {
+        local stat: word `++i' of `stats'
+        if `"`stat'"'=="" continue, break
+        local tmp: word `i' of `statsfmt'
+        if `"`tmp'"'!="" local format `"`tmp'"'
+        local statscstar: list stat in statsstar
+        if `statscstar' local statscol_1 1
+        local statsarray `"`statsarray'`space1'`"`stat'"'"'
+        local statsrowlbls `"`statsrowlbls'`space1'`"`stat'"'"'
+        local statsrowfmt `"`statsrowfmt'`space1'`"`format'"'"'
+        local statsrowstar `"`statsrowstar'`space1'`"`statscstar'"'"'
+        local statslayout `"`statslayout'`space1'`statspchar'"'
+        local space1 " "
+        local wmax = max(1,`wmax')
+    }
+    local statscolstar
+    local space
+    forv w = 1/`wmax' {
+        if "`statscol_`w''"=="" local statscol_`w' 0
+        local statscolstar "`statscolstar'`space'`statscol_`w''"
+        local space " "
+    }
+    c_local statsarray   `"`statsarray'"'
+    c_local statsrowlbls `"`statsrowlbls'"'
+    c_local statsrowfmt  `"`statsrowfmt'"'
+    c_local statsrowstar `"`statsrowstar'"'
+    c_local statscolstar `"`statscolstar'"'
+    c_local statslayout  `"`statslayout'"'
+end
+
+program ParseLabelsSubopts
+    gettoken type 0: 0
+    local lblsubopts
+    syntax [anything] [ , NONUMbers NUMbers NOTItles TItles NODEPvars DEPvars ///
+     NONONE NONE NOSPAN span Prefix(string) Suffix(string) Begin(string asis) ///
+     End(string asis) NOReplace Replace BList(string asis) EList(string asis) ///
+     ERepeat(string) NOFirst First NOLast Last lhs(string) PATtern(string) ///
+     NOMerge Merge ]
+    CheckPattern `"`pattern'"' "`type'"
+    if "`merge'"!="" & "`nomerge'`macval(suffix)'"=="" local suffix ":"
+    foreach opt in begin end {
+        if `"`macval(`opt')'"'!="" {
+            if index(`"`macval(`opt')'"', `"""')==0 {
+                local `opt' `"`"`macval(`opt')'"'"'
+            }
+        }
+    }
+    foreach opt in prefix suffix begin end blist elist erepeat lhs pattern {
+        c_local `type'`opt' `"`macval(`opt')'"'
+    }
+    foreach opt in numbers titles depvars span replace none first last merge {
+        if "`no`opt''"!="" c_local no`type'`opt' 1
+        else c_local `type'`opt' "``opt''"
+    }
+    c_local `type' `"`macval(anything)'"'
+end
+
+program ReadLine
+    args max file
+    local end 0
+    file read `file' temp1
+    local temp1: subinstr local temp1 "`=char(9)'" "    ", all
+    while r(eof)==0 {
+        local j 1
+        local temp2
+        local temp3: piece `j++' `max' of `"`macval(temp1)'"'
+        if `"`temp3'"'=="" | index(`"`temp3'"',"*")==1 ///
+         | index(`"`temp3'"',"//")==1 {
+            file read `file' temp1
+            local temp1: subinstr local temp1 "`=char(9)'" "    ", all
+            continue
+        }
+        while `"`temp3'"'!="" {
+            local comment=index(`"`macval(temp3)'"'," ///")
+            if `comment' {
+                local temp3=substr(`"`macval(temp3)'"',1,`comment')
+                local temp2 `"`macval(temp2)'`macval(temp3)'"'
+                local end 0
+                continue, break
+            }
+            local comment=index(`"`macval(temp3)'"'," //")
+            if `comment' {
+                local temp3=substr(`"`macval(temp3)'"',1,`comment')
+                local temp2 `"`macval(temp2)'`macval(temp3)'"'
+                local end 1
+                continue, break
+            }
+            local temp2 `"`macval(temp2)'`macval(temp3)'"'
+            local temp3: piece `j++' `max' of `"`macval(temp1)'"'
+            local end 1
+        }
+        if `end' {
+            local line `"`macval(line)'`macval(temp2)'"'
+            continue, break
+        }
+        else {
+            local line `"`macval(line)'`macval(temp2)'"'
+            file read `file' temp1
+            local temp1: subinstr local temp1 "`=char(9)'" "    ", all
+        }
+    }
+    c_local line `"`macval(line)'"'
+end
+
+program CellsCheck
+    args cells
+    local ncols 0
+    local nrows 0
+    local cells: subinstr local cells "& " "&", all
+    local cells: subinstr local cells " &" "&", all
+    local cells: subinstr local cells `"&""' `"& ""', all
+    local cells: subinstr local cells `""&"' `"" &"', all
+    foreach row of local cells {
+        local newrow
+        foreach col of local row {
+            local vals: subinstr local col "&" " ", all
+            //local vals: list vals - values
+            local values: list values | vals
+            local vals: list retok vals
+            local vals: subinstr local vals " " "&", all
+            //local newrow: list newrow | vals
+            local newrow `"`newrow'`vals' "'
+        }
+        local newrow: list retok newrow
+        if "`newrow'"!="" {
+            local ncols = max(`ncols',`:list sizeof newrow')
+            local newcells `"`newcells'"`newrow'" "'
+            local ++nrows
+        }
+    }
+    local newcells: list retok newcells
+    c_local cells `"`newcells'"'
+    c_local ncols `ncols'
+    c_local nrows `nrows'
+    local dot "."
+    c_local values: list values - dot
+end
+
+program Star2Cells
+    args cells star
+    local newcells
+    foreach row of local cells {
+        local newrow
+        foreach col of local row {
+            if "`col'"=="`star'" {
+                local col "`col'star"
+            }
+            local newrow: list newrow | col
+        }
+        local newcells `"`newcells'"`newrow'" "'
+    }
+    local newcells: list retok newcells
+    c_local cells `"`newcells'"'
+end
+
+prog ParseStarlevels
+    syntax [anything(equalok)] [ , Label(str) Delimiter(str) ]
+    c_local starlevels `"`macval(anything)'"'
+    c_local starlevelslabel `"`macval(label)'"'
+    c_local starlevelsdelimiter `"`macval(delimiter)'"'
+end
+
+program CheckStarvals
+    args starlevels label del
+    if `"`macval(label)'"'=="" local label " p<"
+    if `"`macval(del)'"'=="" local del ", "
+    local nstar: word count `macval(starlevels)'
+    local nstar = `nstar'/2
+    capture confirm integer number `nstar'
+    if _rc {
+        di as error "unmatched list of significance symbols and levels"
+        exit 198
+    }
+    local istar 1
+    forv i = 1/`nstar' {
+        local iistar: word `=`i'*2' of `macval(starlevels)'
+        confirm number `iistar'
+        if `iistar'>`istar' | `iistar'<=0 {
+            di as error "significance levels out of order or out of range (0,1]"
+            exit 198
+        }
+        local istar `iistar'
+        local isym: word `=`i'*2-1' of `macval(starlevels)'
+        if `"`macval(legend)'"'!="" {
+            local legend `"`macval(legend)'`macval(del)'"'
+        }
+        local ilabel: subinstr local label "@" "`istar'", count(local hasat)
+        if `hasat'==0 {
+            local ilabel `"`macval(label)'`istar'"'
+        }
+        local legend `"`macval(legend)'`macval(isym)'`macval(ilabel)'"'
+    }
+    c_local starlegend `"`macval(legend)'"'
+end
+
+program Starwidth
+    args starlevels
+    if c(stata_version)>=14 local length udstrlen
+    else                    local length length
+    local nstar: word count `macval(starlevels)'
+    forv i = 2(2)`nstar' {
+        local istar: word `=`i'-1' of `macval(starlevels)'
+        local width = max(length("`width'"),`length'(`"`macval(istar)'"'))
+    }
+    c_local value `width'
+end
+
+// Loosely based on Mkemat from est_table.ado, but with heavy modifications
+program _estout_getres, rclass
+    syntax, names(str) [ coefs(str asis) stats(str asis) equations(str) ///
+        rename(str asis) margin(str asis) meqs(str asis) ///
+        dropped(int 0) level(int 95) ///
+        transform(str asis)  transformpattern(str asis) ///
+        omitted baselevels ]
+    // coefs: coef "coef O/1 #" `"coef O/1 "rowname""' etc...
+
+    tempname bc bbc bs bbs st
+
+    local nnames : word count `names'
+    local rename : subinstr local rename "," "", all
+    if `"`stats'"' != "" {
+        local stats : subinstr local stats "," "", all
+        confirm names `stats'
+        local stats : list uniq stats
+        local nstat : list sizeof stats
+        mat `bbs' = J(`nstat', `nnames', .z)
+        mat colnames `bbs' = `: subinstr local names "." "active", all word'
+        mat rownames `bbs' = `stats'
+    }
+
+    if "`equations'" != "" {
+        MatchNames "`equations'"
+        local eqspec  `r(eqspec)'
+        local eqnames `r(eqnames)'
+    }
+
+    local ncoefs 0
+    foreach coefn of local coefs {
+        local ++ncoefs
+        gettoken coef : coefn
+        local coefnms `"`coefnms' `coef'"' // use more informative label? (coefn => error in Stata 8 and 10)
+    }
+    local bVs "b se var t z p ci_l ci_u _star _sign _sigsign"
+    local hasbVs = `"`: list coefnms & bVs'"'!=""
+    local hastransform = (`"`transform'"'!="") & `hasbVs'
+    local getbV = cond(`hasbVs' | `dropped', "b var ", "")
+
+    tempname hcurrent esample
+    local estcycle = ("`names'"!=".")
+    if `estcycle' {
+        _est hold `hcurrent', restore nullok estsystem
+    }
+
+    local ni 0
+    local hasbbc 0
+    local ccols = `ncoefs' + ("`margin'"!="") + `dropped'
+    foreach name of local names {
+        local ++ni
+        local hasbc 0
+        local hasmargin 0
+        nobreak {
+            if "`name'" != "." {
+                local eqname `name'
+                *est_unhold `name' `esample'        // (why preserve missings in esample?)
+                capt confirm new var _est_`name'    // fix e(sample) if obs have been added
+                if _rc qui replace _est_`name' = 0 if _est_`name' >=.
+                _est unhold `name'
+            }
+            else    {
+                local eqname active
+                if `estcycle' {
+                    _est unhold `hcurrent'
+                }
+            }
+
+            // get coefficients
+            capture noisily break {
+                CheckEqs `"`getbV'`coefs'"'                 // sets local seqmerge
+                GetCoefs `bc' `seqmerge' `"`getbV'`coefs'"' // sets local hasbc
+                if `hasbc' {
+                    mat coln `bc' = `getbV'`coefnms'
+                    SubstEmptyEqname `bc' // replace empty eqname "_" by "__"
+                }
+            }
+            local rc = _rc
+
+            // set equation names and get marginal effects
+            if `hasbc' & `rc'==0 {
+                capture noisily break {
+                    if `dropped' {
+                        DroppedCoefs `bc'
+                    }
+                    if "`equations'"!="" {
+                        AdjustRowEq `bc' `ni' `nnames' "`eqspec'" "`eqnames'"
+                    }
+                    if "`margin'"!="" & `hasbVs' {
+                        GetMarginals `bc' "`margin'" `"`meqs'"' // resets local hasmargin
+                    }
+                    if `hasbVs' {
+                        ComputeCoefs `bc' `hasmargin' `"`coefnms'"' `level'
+                    }
+                    if `hastransform' & `hasbVs' {
+                        if `"`transformpattern'"'!="" {
+                            local transformthis: word `ni' of `transformpattern'
+                        }
+                        else local transformthis 1
+                        if `"`transformthis'"'=="1" {
+                            TransformCoefs `bc' `"`coefnms'"' `"`transform'"'
+                        }
+                    }
+                    if "`getbV'"!="" {
+                        mat `bc' = `bc'[1...,3...] // remove b and var
+                    }
+                }
+                local rc = _rc
+            }
+
+            // get stats
+            if `rc'==0 {
+                capture noisily break {
+                    if "`stats'" != "" {
+                        GetStats "`stats'" `bbs' `ni'
+                        if `hasbc'>0 & inlist(`"`e(cmd)'"', "reg3", "sureg", "mvreg") {
+                            GetEQStats "`stats'" `bbs' `ni' `bc'
+                        }
+                        return add
+                    }
+                }
+                local rc = _rc
+            }
+
+            local depname: word 1 of `e(depvar)'
+            return local m`ni'_depname "`depname'"
+
+            local title `"`e(estimates_title)'"'
+            if `"`title'"'=="" local title `"`e(_estimates_title)'"'  // prior to Stata 10
+            return local m`ni'_estimates_title `"`title'"'
+
+            if "`name'" != "." {
+                *est_hold `name' `esample'
+                _est hold `name', estimates varname(_est_`name')
+            }
+            else {
+                if `estcycle' {
+                    _est hold `hcurrent', restore nullok estsystem
+                }
+            }
+        }
+
+        if `rc' {
+            exit `rc'
+        }
+        
+        if (c(stata_version)>=11) & (`hasbc'>0) {
+            mata: estout_omitted_and_base() // sets local hasbc
+        }
+
+        if `hasbc'>0 {
+            mat coleq `bc' = `eqname'
+            if `"`rename'"'!="" {
+                RenameCoefs `bc' `"`rename'"'
+            }
+            if `hasbbc' {
+                _estout_mat_capp `bbc' : `bbc' `bc', miss(.z) cons ts
+            }
+            else {
+                mat `bbc' = `bc'
+                if `ni'>1 { // add previous empty models
+                    mat `bc' = (1, `bc'[1,1...]) \ ( `bc'[1...,1], J(rowsof(`bc'), colsof(`bc'), .z))
+                    mat `bc' = `bc'[2...,2...]
+                    forv nj = 1/`ni' {
+                        if `nj'==`ni' continue
+                        local eqname: word `nj' of `names'
+                        if `"`eqname'"'=="." {
+                            local eqname active
+                        }
+                        mat coleq `bc' = `eqname'
+                        mat `bbc' = `bc', `bbc'
+                    }
+                }
+            }
+            local hasbbc 1
+        }
+        else {
+            if `hasbbc' { // add empty model if bbc exists
+                mat `bc' = `bbc'[1...,1..`ccols']
+                mat `bc' = (1, `bc'[1,1...]) \ ( `bc'[1...,1], J(rowsof(`bc'), colsof(`bc'), .z))
+                mat `bc' = `bc'[2...,2...]
+                mat coleq `bc' = `eqname'
+                mat `bbc' = `bbc', `bc'
+            }
+        }
+    }
+
+    if `hasbbc' {
+        return matrix coefs = `bbc'
+        return scalar ccols = `ccols'
+    }
+    else {
+        return scalar ccols = 0  // indicates that r(coefs) is missing
+    }
+    if "`stats'" != "" {
+        return matrix stats = `bbs'
+    }
+    return local names `names'
+    return scalar nmodels = `ni'
+end
+
+program _estout_mat_capp
+    // variant of mat_capp that is robust against blanks in coefficient names
+    if c(stata_version)<11 { // requires Stata 11 or newer
+        mat_capp `0'
+        exit
+    }
+    syntax anything [, * ]
+    gettoken m1 m3 : anything, parse(":") // mat1
+    gettoken m2 m3 : m3, parse(":")       // :
+    gettoken m2 m3 : m3                   // mat2
+    gettoken m3    : m3                   // mat3
+    local hasblanks 0
+    mata: estout_rown_hasblanks("hasblanks", ("`m2'", "`m3'"))
+    if `hasblanks'==0 {
+        mat_capp `0'
+        exit
+    }
+    mata: estout_mat_capp("`m1'", ("`m2'", "`m3'"))
+end
+
+program DroppedCoefs // identify dropped coeffficients
+    args bc
+    tempname tmp
+    mat `tmp' = `bc'[1..., 1] * 0
+    mat coln `tmp' = "_dropped"
+    local r = rowsof(`bc')
+    forv i = 1/`r' {
+        if `bc'[`i',1]==0 & `bc'[`i',2]==0 { // b=0 and var=0
+            mat `tmp'[`i',1] = 1
+        }
+    }
+    mat `bc' = `bc', `tmp'
+end
+
+program RenameCoefs
+    args bc rename
+    local Stata11 = cond(c(stata_version)>=11, "version 11:", "")
+    tempname tmp
+    local eqs: roweq `bc', q
+    local eqs: list clean eqs
+    local eqs: list uniq eqs
+    local newnames
+    foreach eq of local eqs {
+        mat `tmp' = `bc'[`"`eq':"',1]
+        QuotedRowNames `tmp'
+        local vars `"`value'"'
+        local rest `"`rename'"'
+        while (`"`rest'"'!="") {
+            gettoken from rest : rest
+            gettoken to   rest : rest
+            if `"`from'`to'"'=="" continue
+            gettoken equ x : from, parse(:)
+            local equ: list clean equ
+            if `"`equ'"'==":" {   // case 1: ":varname"
+                local equ
+                local x: list clean x
+            }
+            else if `"`x'"'=="" { // case 2: "varname"
+                local x `"`equ'"'
+                local equ
+            }
+            else {                // case 3. "eqname:varname"
+                if `"`equ'"'=="_" local equ "__"
+                gettoken colon x : x, parse(:)
+                local x: list clean x
+            }
+            if `"`x'"'=="" {
+                di as err "invalid rename()"
+                exit 198
+            }
+            if index(`"`to'"',":") | `"`to'"'=="" {
+                di as err "invalid rename()"
+                exit 198
+            }
+            if `"`equ'"'!="" {
+                if `"`equ'"'!=`"`eq'"' continue // different equation
+            }
+            local x `"`"`x'"'"'
+            local x: list clean x
+            local vars: subinstr local vars `"`x'"' `"`"`to'"'"', word
+        }
+        local newnames `"`newnames'`vars' "'
+    }
+    `Stata11' mat rown `bc' = `newnames'
+end
+
+// Source: est_table.ado  version 1.1.4  09oct2008  (unmodified)
+program MatchNames, rclass
+    args eqspec
+
+    local eqspec  : subinstr local eqspec ":" " ", all
+    local eqspec0 : subinstr local eqspec "#" "" , all
+
+    local iterm 0
+    gettoken term eqspec : eqspec0 , parse(",")
+    while "`term'" != "" {
+        local ++iterm
+
+        // term = [name =] { # | #-list }
+        gettoken eqname oprest: term, parse("=")
+        gettoken op rest : oprest, parse("=")
+        if trim(`"`op'"') == "=" {
+            confirm name `eqname'
+            local term `rest'
+        }
+        else {
+            local eqname #`iterm'
+        }
+        local eqnames `eqnames' `eqname'
+
+        if "`eqspec'" == "" {
+            continue, break
+        }
+        gettoken term eqspec: eqspec , parse(",")
+        assert "`term'" == ","
+        gettoken term eqspec: eqspec , parse(",")
+    }
+
+    if `"`:list dups eqnames'"' != "" {
+        dis as err "duplicate matched equation names"
+        exit 198
+    }
+
+    return local eqspec   `eqspec0'
+    return local eqnames  `eqnames'
+end
+
+// Source: est_table.ado  version 1.1.4  09oct2008
+// 02oct2013: added -version 11: matrix roweq- to support new eqnames
+program AdjustRowEq
+    args b ni nmodel eqspec eqnames
+
+    local beqn : roweq `b', quote
+    local beqn : list clean beqn
+    local beq  : list uniq beqn
+
+    if `"`:list beq & eqnames'"' != "" {
+        dis as err "option equations() invalid"
+        dis as err "specified equation name already occurs in model `ni'"
+        exit 198
+    }
+
+    local iterm 0
+    gettoken term eqspec : eqspec , parse(",")
+    while "`term'" != "" {
+        // dis as txt "term:|`term'|"
+        local ++iterm
+
+        // term = [name =] { # | #-list }
+        gettoken eqname oprest: term, parse("=")
+        gettoken op rest : oprest, parse("=")
+        if trim(`"`op'"') == "=" {
+            local term `rest'
+        }
+        else {
+            local eqname #`iterm'
+        }
+
+        local nword : list sizeof term
+        if !inlist(`nword', 1, `nmodel') {
+            dis as err "option equations() invalid"
+            dis as err "a term should consist of either 1 or `nmodel' equation numbers"
+            exit 198
+        }
+        if `nword' > 1 {
+            local term  : word `ni' of `term'
+        }
+
+        if trim("`term'") != "." {
+            capt confirm integer number `term'
+            if _rc {
+                dis as err "option equations() invalid"
+                dis as err "`term' was found, while an integer equation number was expected"
+                exit 198
+            }
+            if !inrange(`term',1,`:list sizeof beq') {
+                dis as err "option equations() invalid"
+                dis as err "equation number `term' for model `ni' out of range"
+                exit 198
+            }
+            if `:list posof "`eqname'" in beq' != 0 {
+                dis as err "impossible to name equation `eqname'"
+                dis as err "you should provide (another) equation name"
+                exit 198
+            }
+
+            local beqn : subinstr local beqn  ///
+                `"`:word `term'  of `beq''"'    ///
+                "`eqname'" , word all
+        }
+
+        if "`eqspec'" == "" {
+            continue, break
+        }
+        gettoken term eqspec: eqspec , parse(",")
+        assert "`term'" == ","
+        gettoken term eqspec: eqspec , parse(",")
+    }
+    if c(stata_version)>=11 { // similar to RenameCoefs
+        version 11: matrix roweq `b' = `beqn'
+    }
+    else {
+        matrix roweq `b' = `beqn'
+    }
+end
+
+// Source: est_table.ado  version 1.1.4  09oct2008  (modified)
+// Modification: returns string scalars in r(m`ni'_name) (and sets `bbs' = .y)
+program GetStats, rclass
+    args stats bbs ni
+    tempname rank st V
+    local escalars : e(scalars)
+    local emacros : e(macros)
+    local is 0
+    foreach stat of local stats {
+        local ++is
+        if inlist("`stat'", "aic", "bic", "rank") {
+            if "`hasrank'" == "" {
+                capt mat `V' = syminv(e(V))
+                local rc = _rc
+                if `rc' == 0 {
+                    scalar `rank' = colsof(`V') - diag0cnt(`V')
+                }
+                else if `rc' == 111 {
+                    scalar `rank' = 0
+                }
+                else {
+                    // rc<>0; show error message
+                    mat `V' = syminv(e(V))
+                }
+                local hasrank 1
+            }
+            if "`stat'" == "aic" {
+                scalar `st' = -2*e(ll) + 2*`rank'
+            }
+            else if "`stat'" == "bic" {
+                scalar `st' = -2*e(ll) + log(e(N)) * `rank'
+            }
+            else if "`stat'" == "rank" {
+                scalar `st' = `rank'
+            }
+        }
+        else {
+            if `:list stat in escalars' > 0 {
+                scalar `st' = e(`stat')
+            }
+            else if "`stat'"=="p" {
+                if `"`e(F)'"'!="" {
+                    scalar `st' = Ftail(e(df_m), e(df_r), e(F))
+                }
+                else if `"`e(chi2)'"'!="" {
+                    scalar `st' = chi2tail(e(df_m), e(chi2))
+                }
+                else {
+                    scalar `st' = .z
+                }
+            }
+            else if `:list stat in emacros' > 0 {
+                scalar `st' = .y
+                capt return local m`ni'_`stat' `"`e(`stat')'"'  // name might be too long
+            }
+            else {
+                scalar `st' = .z
+            }
+        }
+        mat `bbs'[`is',`ni'] = `st'
+    }
+end
+
+program GetEQStats, rclass  // eq-specific stats for reg3, sureg, and mvreg (sets `bbs' = .x)
+    args stats bbs ni bc
+    return add
+    tempname addrow
+    local ic "aic bic rank"
+    local eqs: roweq `bc', q
+    local eqs: list clean eqs
+    local eqs: list uniq eqs
+    local s 0
+    foreach stat of local stats {
+        local ++s
+        if inlist(`"`stat'"', "aic", "bic", "rank") continue
+        if `bbs'[`s',`ni']<.y  continue
+        local e 0
+        local found 0
+        foreach eq of local eqs {
+            local ++e
+            if e(cmd)=="mvreg" {
+                if "`stat'"=="p" local value: word `e' of `e(p_F)'
+                else local value: word `e' of `e(`stat')'
+            }
+            else if "`stat'"=="df_m" {
+                local value `"`e(`stat'`e')'"'
+            }
+            else {
+                local value `"`e(`stat'_`e')'"'
+            }
+            capture confirm number `value'
+            if _rc==0 {
+                local found 1
+                local r = rownumb(`bbs', `"`eq':`stat'"')
+                if `r'>=. {
+                    mat `addrow' = J(1, colsof(`bbs'), .z)
+                    mat rown `addrow' = `"`eq':`stat'"'
+                    mat `bbs' = `bbs' \ `addrow'
+                    local r = rownumb(`bbs', `"`eq':`stat'"')
+                }
+                mat `bbs'[`r',`ni'] = `value'
+            }
+        }
+        if `found' {
+            if `bbs'[`s',`ni']==.y {
+                capt return local m`ni'_`stat' ""
+            }
+            mat `bbs'[`s',`ni'] = .x
+        }
+    }
+end
+
+program CheckEqs
+    args coefs
+    tempname tmp
+    local j 0
+    local bVs "b _star _sign _sigsign"
+    local seqmerge 0
+    local hasseqs 0
+    foreach coefn in `coefs' {
+        local ++j
+        gettoken coef row : coefn
+        gettoken transpose row : row
+        gettoken row : row, q
+        if `"`coef'"'=="b" & `j'==1 {
+            capt confirm mat e(`coef')
+            if _rc continue
+            mat `tmp' = e(`coef')
+            local eqs: coleq `tmp', q
+            if `:list posof "_" in eqs'==0 {
+                local seqmerge 1
+            }
+            else continue, break
+        }
+        if `:list coef in bVs' continue
+        capt confirm mat e(`coef')
+        if _rc continue
+        mat `tmp' = e(`coef')
+        if `transpose' {
+            mat `tmp' = `tmp''
+        }
+        if `"`row'"'=="" local row 1
+        capt confirm number `row'
+        if _rc {
+            local row = rownumb(`tmp',`row')
+        }
+        if `row'>rowsof(`tmp') continue
+        local eqs: coleq `tmp', q
+        if `:list posof "_" in eqs' {
+            local eqs: list uniq eqs
+            local eqs: list clean eqs
+            if `"`eqs'"'!="_" { // => contains "_" but also others
+                local local seqmerge 0
+                continue, break
+            }
+            else local hasseqs 1
+        }
+        else {
+            local seqmerge 1
+        }
+    }
+    if `hasseqs'==0 local seqmerge 0
+    c_local seqmerge `seqmerge'
+end
+
+program SubstEmptyEqname // replace empty equation name "_" by "__"
+    args M
+    local eqs: roweq `M', q
+    if `: list posof "_" in eqs' {
+        local eqs: subinstr local eqs `""_""' `""__""', all
+        mat roweq `M' = `eqs'
+    }
+end
+
+program RestoreEmptyEqnames // replace equation name "__" by "_"
+    args M
+    local eqs: roweq `M', q
+    if `: list posof "__" in eqs' {
+        local eqs: subinstr local eqs `""__""' `""_""', all
+        mat roweq `M' = `eqs'
+    }
+end
+
+program GetCoefs
+    args bc seqmerge coefs
+    tempname tmp
+    local hasbc 0
+    local j 0
+    local bVs "b _star _sign _sigsign"
+    foreach coefn of local coefs {
+        local ++j
+        gettoken coef row : coefn
+        gettoken transpose row : row
+        gettoken row : row, q
+        local isinbVs: list coef in bVs
+        if `isinbVs' & `j'>2 {
+            if `hasbc'==0  continue
+            mat `bc' = `bc', J(rowsof(`bc'),1, .y)
+            continue
+        }
+        if `j'==2 & `"`coef'"'=="var" {
+            local isinbVs 1
+            capt mat `tmp' = vecdiag(e(V))
+            if _rc {
+                capt confirm mat e(se)
+                if _rc==0 {
+                    mat `tmp' = e(se)
+                    forv i = 1/`=colsof(`tmp')' {
+                        mat `tmp'[1, `i'] = `tmp'[1, `i']^2
+                    }
+                }
+            }
+        }
+        else {
+            capt confirm mat e(`coef')
+            if _rc==0 {
+                mat `tmp' = e(`coef')
+            }
+        }
+        if _rc {
+            if `hasbc'==0  continue
+            mat `bc' = `bc', J(rowsof(`bc'),1, .y)
+            continue
+        }
+        if `isinbVs'==0 { // => not b or var
+            if `transpose' {
+                mat `tmp' = `tmp''
+            }
+            if `"`row'"'=="" local row 1
+            capt confirm number `row'
+            if _rc {
+                local row = rownumb(`tmp',`row')
+            }
+            if `row'>rowsof(`tmp') {
+                if `hasbc'==0  continue
+                mat `bc' = `bc', J(rowsof(`bc'),1, .y)
+                continue
+            }
+            mat `tmp' = `tmp'[`row', 1...]
+        }
+        local bcols = colsof(`tmp')
+        if `bcols'==0 {
+            if `hasbc'==0  continue
+            mat `bc' = `bc', J(rowsof(`bc'),1, .y)
+            continue
+        }
+        mat `tmp' = `tmp''
+        if `seqmerge' & `isinbVs'==0 {
+            local eqs: roweq `tmp', q
+            local eqs: list uniq eqs
+            local eqs: list clean eqs
+            if `"`eqs'"'=="_" {
+                local seqmergejs `seqmergejs' `j'
+                local seqmergecoefs `"`seqmergecoefs'`"`coefn'"' "'
+                if `hasbc'==0  continue
+                mat `bc' = `bc', J(rowsof(`bc'),1, .y)
+                continue
+            }
+        }
+        if `hasbc'==0 {
+            mat `bc' = `tmp'
+            local hasbc 1
+            if `j'>1 {
+                mat `bc' = `bc', J(`bcols',`j'-1, .y), `bc'
+                mat `bc' = `bc'[1...,2...]
+            }
+        }
+        else {
+            _estout_mat_capp `bc' : `bc' `tmp', miss(.y) cons ts
+        }
+    }
+    foreach coefn of local seqmergecoefs {
+        gettoken j seqmergejs : seqmergejs
+        gettoken coef row : coefn
+        gettoken transpose row : row
+        gettoken row : row, q
+        mat `tmp' = e(`coef')
+        if `transpose' {
+            mat `tmp' = `tmp''
+        }
+        if `"`row'"'=="" local row 1
+        capt confirm number `row'
+        if _rc {
+            local row = rownumb(`tmp',`row')
+        }
+        mat `tmp' = `tmp'[`row', 1...]
+        SEQMerge `bc' `j' `tmp'
+    }
+    c_local hasbc `hasbc'
+end
+
+program SEQMerge
+    args bc j x
+    tempname tmp
+    local r = rowsof(`bc')
+    forv i = 1/`r' {
+        mat `tmp' = `bc'[`i',1...]
+        local v: rown `tmp'
+        local c = colnumb(`x', `"`v'"')
+        if `c'<. {
+            mat `bc'[`i',`j'] = `x'[1,`c']
+        }
+    }
+end
+
+program ComputeCoefs
+    args bc hasmargin coefs level
+    local bVs1 "b _star _sign _sigsign"
+    local bVs2 "se var t z p ci_l ci_u"
+    local c = colsof(`bc')
+    forv j = 3/`c' {
+        gettoken v coefs : coefs
+        if `"`v'"'=="" continue, break
+        if `: list v in bVs1' {
+            ComputeCoefs_`v' `bc' `j' `level'
+            continue
+        }
+        if `: list v in bVs2' {
+            if `hasmargin' {
+                ComputeCoefs_`v' `bc' `j' `level'
+                continue
+            }
+            capt confirm matrix e(`v')
+            if _rc {
+                ComputeCoefs_`v' `bc' `j' `level'
+            }
+        }
+    }
+end
+
+program CopyColFromTo
+    args m from to cname
+    tempname tmp
+    mat `tmp' = `m'[1...,`from']
+    mat coln `tmp' = `cname'
+    local c = colsof(`m')
+    if `to'==`c' {
+        mat `m' = `m'[1...,1..`c'-1], `tmp'
+        exit
+    }
+    mat `m' = `m'[1...,1..`to'-1], `tmp', `m'[1...,`to'+1..`c']
+end
+
+program ComputeCoefs_b
+    args bc j
+    CopyColFromTo `bc' 1 `j' "b"
+end
+
+program ComputeCoefs_se
+    args bc j
+    local r = rowsof(`bc')
+    forv i = 1/`r' {
+            local var `bc'[`i',2]
+            local res `bc'[`i',`j']
+            if `var'>=.      mat `res' = `var'
+            else if `var'==0 mat `res' = .
+            else             mat `res' = sqrt(`var')
+    }
+end
+
+program ComputeCoefs_var
+    args bc j
+    CopyColFromTo `bc' 2 `j' "var"
+end
+
+program ComputeCoefs_t
+    args bc j
+    local r = rowsof(`bc')
+    forv i = 1/`r' {
+            local b   `bc'[`i',1]
+            local var `bc'[`i',2]
+            local res `bc'[`i',`j']
+            if `b'>=.        mat `res' = `b'
+            else if `var'>=. mat `res' = `var'
+            else             mat `res' = `b'/sqrt(`var')
+    }
+end
+
+program ComputeCoefs_z
+    ComputeCoefs_t `0'
+end
+
+program ComputeCoefs_p
+    args bc j
+    local r = rowsof(`bc')
+    local df_r = e(df_r)
+    if `"`e(mi)'"'=="mi" { // get df_mi
+        capt confirm matrix e(df_mi)
+        if _rc==0 {
+            tempname dfmi
+            matrix `dfmi' = e(df_mi)
+        }
+    }
+    if c(stata_version)<10 local dfmax 1e12
+    else                   local dfmax 2e17
+    forv i = 1/`r' {
+            local b   `bc'[`i',1]
+            local var `bc'[`i',2]
+            local res `bc'[`i',`j']
+            if `b'>=.        mat `res' = `b'
+            else if `var'>=. mat `res' = `var'
+            else if "`dfmi'"!="" {
+                if `dfmi'[1,`i']<=`dfmax' {
+                    mat `res' = ttail(`dfmi'[1,`i'],abs(`b'/sqrt(`var'))) * 2
+                }
+                else {
+                    mat `res' = (1 - norm(abs(`b'/sqrt(`var')))) * 2
+                }
+            }
+            else if `df_r'<=`dfmax' mat `res' = ttail(`df_r',abs(`b'/sqrt(`var'))) * 2
+            else                    mat `res' = (1 - norm(abs(`b'/sqrt(`var')))) * 2
+    }
+end
+
+program ComputeCoefs_ci_l
+    args bc j
+    ComputeCoefs_ci - `0'
+end
+
+program ComputeCoefs_ci_u
+    args bc j
+    ComputeCoefs_ci + `0'
+end
+
+program ComputeCoefs_ci
+    args sign bc j level
+    local r = rowsof(`bc')
+    local df_r = e(df_r)
+    if `"`e(mi)'"'=="mi" { // get df_mi
+        capt confirm matrix e(df_mi)
+        if _rc==0 {
+            tempname dfmi
+            matrix `dfmi' = e(df_mi)
+        }
+    }
+    if c(stata_version)<10 local dfmax 1e12
+    else                   local dfmax 2e17
+    forv i = 1/`r' {
+            local b   `bc'[`i',1]
+            local var `bc'[`i',2]
+            local res `bc'[`i',`j']
+            if `b'>=.        mat `res' = `b'
+            else if `var'>=. mat `res' = `var'
+            else if "`dfmi'"!="" {
+                if `dfmi'[1,`i']<=`dfmax' {
+                    mat `res' = `b' `sign' ///
+                        invttail(`dfmi'[1,`i'],(100-`level')/200) * sqrt(`var')
+                }
+                else {
+                    mat `res' = `b' `sign' ///
+                        invnorm(1-(100-`level')/200) * sqrt(`var')
+                }
+            }
+            else if `df_r'<=`dfmax' ///
+                 mat `res' = `b' `sign' invttail(`df_r',(100-`level')/200) * sqrt(`var')
+            else mat `res' = `b' `sign' invnorm(1-(100-`level')/200) * sqrt(`var')
+    }
+end
+
+program ComputeCoefs__star
+    args bc j
+    CopyColFromTo `bc' 1 `j' "_star"
+end
+
+program ComputeCoefs__sign
+    args bc j
+    CopyColFromTo `bc' 1 `j' "_sign"
+end
+
+program ComputeCoefs__sigsign
+    args bc j
+    CopyColFromTo `bc' 1 `j' "_sigsign"
+end
+
+program GetMarginals
+    args bc margin meqs
+    tempname D dfdx
+    mat `D' = `bc'[1...,1]*0
+    mat coln `D' = "_dummy"
+    local type `e(Xmfx_type)'
+    if "`type'"!="" {
+        mat `dfdx' = e(Xmfx_`type')
+        capture confirm matrix e(Xmfx_se_`type')
+        if _rc==0 {
+            mat `dfdx' = `dfdx' \ e(Xmfx_se_`type')
+        }
+        if "`e(Xmfx_discrete)'"=="discrete" local dummy `e(Xmfx_dummy)'
+    }
+    else if "`e(cmd)'"=="dprobit" {
+        mat `dfdx' = e(dfdx) \ e(se_dfdx)
+        local dummy `e(dummy)'
+    }
+    else if "`e(cmd)'"=="tobit" & inlist("`margin'","u","c","p") {
+        capture confirm matrix e(dfdx_`margin')
+        if _rc==0 {
+            mat `dfdx' = e(dfdx_`margin') \ e(se_`margin')
+        }
+        local dummy `e(dummy)'
+    }
+    else if "`e(cmd)'"=="truncreg" {
+        capture confirm matrix e(dfdx)
+        if _rc==0 {
+            tempname V se
+            mat `V' = e(V_dfdx)
+            forv k= 1/`=rowsof(`V')' {
+                mat `se' = nullmat(`se') , sqrt(`V'[`k',`k'])
+            }
+            mat `dfdx' = e(dfdx) \ `se'
+        }
+    }
+    capture confirm matrix `dfdx'
+    if _rc==0 {
+        QuotedRowNames `bc'
+        local rnames `"`value'"'
+        if `"`meqs'"'!="" local reqs: roweq `bc', q
+        local i 1
+        foreach row of loc rnames {
+            if `"`meqs'"'!="" {
+                local eq: word `i' of `reqs'
+            }
+            local col = colnumb(`dfdx',"`row'")
+            if `col'>=. | !`:list eq in meqs' {
+                mat `bc'[`i',1] = .y
+                mat `bc'[`i',2] = .y
+                mat `D'[`i',1]  = .y
+            }
+            else {
+                mat `bc'[`i',1] =`dfdx'[1,`col']
+                mat `bc'[`i',2] = (`dfdx'[2,`col'])^2
+                if "`:word `col' of `dummy''"=="1" mat `D'[`i',1] = 1
+            }
+            local ++i
+        }
+        c_local hasmargin 1
+    }
+    mat `bc' = `bc', `D'
+end
+
+program TransformCoefs
+    args bc coefs transform
+    local c = colsof(`bc')
+    forv j = 3/`c' {
+        gettoken v coefs : coefs
+        if inlist("`v'", "b", "ci_l", "ci_u") {
+            _TransformCoefs `bc' `j' 0 "" "" `"`transform'"'
+        }
+        else if "`v'"=="se" {
+            _TransformCoefs `bc' `j' 1 "abs" "" `"`transform'"'
+        }
+        else if "`v'"=="var" {
+            _TransformCoefs `bc' `j' 1 "" "^2" `"`transform'"'
+        }
+    }
+end
+
+program _TransformCoefs
+    args bc j usedf abs sq transform
+    local r = rowsof(`bc')
+    gettoken coef rest : transform
+    gettoken f rest : rest
+    gettoken df rest : rest
+    while `"`coef'`f'`df'"'!="" {
+        if `"`df'`rest'"'=="" { // last element of list may be without coef
+            local df   `"`f'"'
+            local f    `"`coef'"'
+            local coef ""
+        }
+        local trcoefs `"`trcoefs'`"`coef'"' "'
+        if `usedf' {
+            local trs `"`trs'`"`df'"' "'
+        }
+        else {
+            local trs `"`trs'`"`f'"' "'
+        }
+        gettoken coef rest : rest
+        gettoken f rest : rest
+        gettoken df rest : rest
+    }
+    local trs : subinstr local trs  "@" "\`b'", all
+    forv i = 1/`r' {
+        gettoken coef coefrest : trcoefs
+        gettoken tr trrest : trs
+        while `"`coef'`tr'"'!="" {
+            MatchCoef `"`coef'"' `bc' `i'
+            if `match' {
+                if `usedf' {
+                    local b   `bc'[`i',1]
+                    local res `bc'[`i',`j']
+                    if `res'<. {
+                        mat `res' = `res' * `abs'(`tr')`sq'
+                    }
+                }
+                else {
+                    local b `bc'[`i',`j']
+                    if `b'<. {
+                        mat `b' = (`tr')
+                    }
+                }
+                continue, break
+            }
+            gettoken coef coefrest : coefrest
+            gettoken tr trrest : trrest
+        }
+    }
+end
+
+program MatchCoef
+    args eqx b i
+    if inlist(trim(`"`eqx'"'),"","*") {
+        c_local match 1
+        exit
+    }
+    tempname tmp
+    mat `tmp' = `b'[`i',1...]
+    local eqi: roweq `tmp'
+    local xi: rown `tmp'
+    gettoken eq x : eqx, parse(:)
+    local eq: list clean eq
+    if `"`eq'"'==":" {    // case 1: ":[varname]"
+        local x: list clean x
+        local eq
+    }
+    else if `"`x'"'=="" { // case 2: "varname"
+        local x `"`eq'"'
+        local eq
+    }
+    else {                // case 3. "eqname:[varname]"
+        if `"`eq'"'=="_" local eq "__"
+        gettoken colon x : x, parse(:)
+        local x: list clean x
+    }
+    if `"`eq'"'=="" local eq "*"
+    if `"`x'"'=="" local x "*"
+    c_local match = match(`"`eqi'"', `"`eq'"') & match(`"`xi'"', `"`x'"')
+end
+
+program NumberMlabels
+    args M mlabels
+    forv m = 1/`M' {
+        local num "(`m')"
+        local lab: word `m' of `macval(mlabels)'
+        if `"`macval(lab)'"'!="" {
+            local lab `"`num' `macval(lab)'"'
+        }
+        else local lab `num'
+        local labels `"`macval(labels)'`"`macval(lab)'"' "'
+    }
+    c_local mlabels `"`macval(labels)'"'
+end
+
+program ModelEqCheck
+    args B eq m ccols
+    tempname Bsub
+    local a = (`m'-1)*`ccols'+1
+    local b = `a' + `ccols'-1
+    mat `Bsub' = `B'["`eq':",`a'..`b']
+    local R = rowsof(`Bsub')
+    local value 0
+    forv c = 1/`ccols' {
+        forv r = 1/`R' {
+            if `Bsub'[`r',`c']<. {
+                local value 1
+                continue, break
+            }
+        }
+    }
+    c_local value `value'
+end
+
+program Add2Vblock
+    args block col
+    foreach v of local col {
+        gettoken row block: block
+        local row "`row' `v'"
+        local row: list retok row
+        local vblock `"`vblock'"`row'" "'
+    }
+    c_local vblock `"`vblock'"'
+end
+
+program CountNofEqs
+    args ms es
+    local m0 0
+    local e0 0
+    local i 0
+    local eqs 0
+    foreach m of local ms {
+        local ++i
+        local e: word `i' of `es'
+        if `m'!=`m0' | `e'!=`e0' {
+            local ++eqs
+        }
+        local m0 `m'
+        local e0 `e'
+    }
+    c_local value `eqs'
+end
+
+program InsertAtVariables
+    args value type span M E width hline rtf rtfrowdefbrdrt rtfrowdefbrdrb rtfrowdef rtfemptyrow ///
+        title note discrete starlegend
+    if `type'==1 local atvars span
+    else {
+        local atvars span M E width hline
+        if `rtf' local atvars `atvars' rtfrowdefbrdrt rtfrowdefbrdrb rtfrowdef rtfemptyrow
+        if `type'!=2  local atvars `atvars' title note discrete starlegend
+    }
+    foreach atvar of local atvars {
+        StableSubinstr value `"`macval(value)'"' "@`atvar'" `"`macval(`atvar')'"' all
+    }
+    c_local value `"`macval(value)'"'
+end
+
+program Abbrev
+    args width value abbrev
+    if c(stata_version)>=14 {
+        local substr udsubstr
+        local length udstrlen
+    }
+    else {
+        local substr substr
+        local length length
+    }
+    if "`abbrev'"!="" {
+        if `width'>32 {
+            local value = `substr'(`"`macval(value)'"',1,`width')
+        }
+        else if `width'>0 {
+            if `length'(`"`macval(value)'"')>`width' {
+                local value = abbrev(`"`macval(value)'"',`width')
+            }
+        }
+    }
+    c_local value `"`macval(value)'"'
+end
+
+program MgroupsPattern
+    args mrow pattern
+    local i 0
+    local m0 0
+    local j 0
+    foreach m of local mrow {
+        if `m'>=. {
+            local newpattern `newpattern' .
+            continue
+        }
+        if `m'!=`m0' {
+            local p: word `++i' of `pattern'
+            if `i'==1 local p 1
+            if "`p'"=="1" local j = `j' + 1
+        }
+        local newpattern `newpattern' `j'
+        local m0 `m'
+    }
+    c_local mgroupspattern `newpattern'
+end
+
+program WriteCaption
+    args file delimiter stardetach row rowtwo labels starsrow span  ///
+     abbrev colwidth delwidth starwidth repeat prefix suffix haslabcol2
+    local c 0
+    local nspan 0
+    local c0 = 2 + `haslabcol2'
+    local spanwidth -`delwidth'
+    local spanfmt
+    local ncolwidth: list sizeof colwidth
+    foreach r of local row {
+        local rtwo: word `++c' of `rowtwo'
+        local colwidthj: word `=1+mod(`c'-1,`ncolwidth')' of `colwidth'
+        if `colwidthj'>0 local colfmt "%`colwidthj's"
+        else local colfmt
+        if "`r'"=="." {
+            local ++c0
+            file write `file' `macval(delimiter)' `colfmt' (`""')
+        }
+        else if `"`span'"'=="" {
+            if ( "`r'"!="`lastr'" | "`rtwo'"!="`lastrtwo'" | `"`rowtwo'"'=="" ) {
+                local value: word `r' of `macval(labels)'
+                Abbrev `colwidthj' `"`macval(value)'"' "`abbrev'"
+                local value `"`macval(prefix)'`macval(value)'`macval(suffix)'"'
+                InsertAtVariables `"`macval(value)'"' 1 "1"
+            }
+            else local value
+            if `:length local value'<245 {
+                local value: di `colfmt' `"`macval(value)'"'
+            }
+            file write `file' `macval(delimiter)' `"`macval(value)'"'
+            if `:word `c' of `starsrow''==1 {
+                file write `file' `macval(stardetach)' _skip(`starwidth')
+            }
+            local lastr "`r'"
+            local lastrtwo "`rtwo'"
+        }
+        else {
+            local ++nspan
+            local spanwidth=`spanwidth'+`colwidthj'+`delwidth'
+            if `:word `c' of `starsrow''==1 {
+                local spanwidth = `spanwidth' + `starwidth'
+                if `"`macval(stardetach)'"'!="" {
+                    local ++nspan
+                    local spanwidth = `spanwidth' + `delwidth'
+                }
+            }
+            local nextrtwo: word `=`c'+1' of `rowtwo'
+            local nextr: word `=`c'+1' of `row'
+            if "`r'"!="." & ///
+             ("`r'"!="`nextr'" | "`rtwo'"!="`nextrtwo'" | `"`rowtwo'"'=="") {
+                local value: word `r' of `macval(labels)'
+                Abbrev `spanwidth' `"`macval(value)'"' "`abbrev'"
+                local value `"`macval(prefix)'`macval(value)'`macval(suffix)'"'
+                InsertAtVariables `"`macval(value)'"' 1 "`nspan'"
+                if `spanwidth'>0 local spanfmt "%-`spanwidth's"
+                if `:length local value'<245 {
+                    local value: di `spanfmt' `"`macval(value)'"'
+                }
+                file write `file' `macval(delimiter)' `"`macval(value)'"'
+                InsertAtVariables `"`macval(repeat)'"' 1 "`c0'-`=`c0'+`nspan'-1'"
+                local repeatlist `"`macval(repeatlist)'`macval(value)'"'
+                local c0 = `c0' + `nspan'
+                local nspan 0
+                local spanwidth -`delwidth'
+            }
+        }
+    }
+    c_local value `"`macval(repeatlist)'"'
+end
+
+program WriteBegin
+    args file pre begin post
+    foreach line of local pre {
+        file write `file' `newline' `"`macval(line)'"'
+        local newline _n
+    }
+    file write `file' `macval(begin)' `macval(post)'
+end
+
+program WriteEnd
+    args file end post post2
+    file write `file' `macval(end)'
+    WriteStrLines `"`file'"' `"`macval(post)'"'
+    WriteStrLines `"`file'"' `"`macval(post2)'"'
+    file write `file' _n
+end
+
+program WriteStrLines
+    args file lines
+    foreach line of local lines {
+        file write `file' `newline' `"`macval(line)'"'
+        local newline _n
+    }
+end
+
+program WriteEqrow
+    args file delimiter stardetach value row span vwidth fmt_v ///
+     abbrev mwidth delwidth starwidth prefix suffix ///
+     haslabcol2 labcolwidth fmt_l2
+    local nspan 1
+    local spanwidth `vwidth'
+    local spanfmt
+    local c 0
+    local nmwidth: list sizeof mwidth
+    if `"`span'"'=="" {
+        Abbrev `vwidth' `"`macval(value)'"' "`abbrev'"
+        local value `"`macval(prefix)'`macval(value)'`macval(suffix)'"'
+        InsertAtVariables `"`macval(value)'"' 1 "1"
+        if `:length local value'<245 {
+            local value: di `fmt_v' `"`macval(value)'"'
+        }
+        file write `file' `"`macval(value)'"'
+        if `haslabcol2' {
+            file write `file' `macval(delimiter)' `fmt_l2' ("")
+        }
+        foreach r of local row {
+            local mwidthj: word `=1+mod(`c++',`nmwidth')' of `mwidth'
+            if `mwidthj'>0 local fmt_m "%`mwidthj's"
+            else local fmt_m
+            file write `file' `macval(delimiter)' `fmt_m' ("")
+            if `r'==1 {
+                file write `file' `macval(stardetach)' _skip(`starwidth')
+            }
+        }
+    }
+    else {
+        if `haslabcol2' {
+            local ++nspan
+            local spanwidth = `spanwidth' + `delwidth' + `labcolwidth'
+        }
+        foreach r of local row {
+            local mwidthj: word `=1+mod(`c++',`nmwidth')' of `mwidth'
+            local ++nspan
+            local spanwidth = `spanwidth' + `delwidth' + `mwidthj'
+            if `r'==1 {
+                local spanwidth = `spanwidth' + `starwidth'
+                if `"`macval(stardetach)'"'!="" {
+                    local ++nspan
+                    local spanwidth = `spanwidth' + `delwidth'
+                }
+            }
+        }
+        Abbrev `spanwidth' `"`macval(value)'"' "`abbrev'"
+        local value `"`macval(prefix)'`macval(value)'`macval(suffix)'"'
+        InsertAtVariables `"`macval(value)'"' 1 "`nspan'"
+        if `spanwidth'>0 local spanfmt "%-`spanwidth's"
+        if `:length local value'<245 {
+            local value: di `spanfmt' `"`macval(value)'"'
+        }
+        file write `file' `"`macval(value)'"'
+    }
+end
+
+prog WriteStrRow
+    args file mrow eqrow neq labels delimiter stardetach starsrow  ///
+     abbrev colwidth delwidth starwidth
+    local c 0
+    local ncolwidth: list sizeof colwidth
+    foreach mnum of local mrow {
+        local eqnum: word `++c' of `eqrow'
+        local colwidthj: word `=1+mod(`c'-1,`ncolwidth')' of `colwidth'
+        if `colwidthj'>0 local colfmt "%`colwidthj's"
+        else local colfmt
+        if "`mnum'"=="." {
+            file write `file' `macval(delimiter)' `colfmt' (`""')
+            continue
+        }
+        if ( "`mnum'"!="`lastmnum'" | "`eqnum'"!="`lasteqnum'" ) {
+            local value: word `=(`mnum'-1)*`neq'+`eqnum'' of `macval(labels)'
+            Abbrev `colwidthj' `"`macval(value)'"' "`abbrev'"
+        }
+        else local value
+        if `:length local value'<245 {
+            local value: di `colfmt' `"`macval(value)'"'
+        }
+        file write `file' `macval(delimiter)' `"`macval(value)'"'
+        if `:word `c' of `starsrow''==1 {
+            file write `file' `macval(stardetach)' _skip(`starwidth')
+        }
+        local lastmnum "`mnum'"
+        local lasteqnum "`eqnum'"
+    }
+end
+
+program VarInList
+    args var unstack eqvar eq list
+    local value
+    local L: word count `macval(list)'
+    forv l = 1(2)`L' {
+        local lvar: word `l' of `macval(list)'
+        local lab: word `=`l'+1' of `macval(list)'
+        if "`unstack'"!="" {
+            if `"`var'"'==`"`lvar'"' {
+                local value `"`macval(lab)'"'
+                continue, break
+            }
+        }
+        else {
+            if substr(`"`lvar'"', 1, 2)=="_:" local lvar `"_`lvar'"'
+            if inlist(`"`lvar'"',`"`var'"',`"`eqvar'"',`"`eq':"') {
+                local value `"`macval(lab)'"'
+                continue, break
+            }
+        }
+    }
+    c_local value `"`macval(value)'"'
+end
+
+program vFormat
+    args value fmt lz dmarker msign par
+    if substr(`"`fmt'"',1,1)=="a" {
+        SignificantDigits `fmt' `value'
+    }
+    else {
+        capt confirm integer number `fmt'
+        if !_rc {
+            local fmt %`=`fmt'+9'.`fmt'f
+        }
+    }
+    else if `"`fmt'"'=="%g" | `"`fmt'"'=="g" local fmt "%9.0g"
+    else if substr(`"`fmt'"',1,1)!="%" {
+        di as err `"`fmt': invalid format"'
+        exit 198
+    }
+    local value: di `fmt' `value'
+    local value: list retok value
+    if "`lz'"=="" {
+        if index("`value'","0.")==1 | index("`value'","-0.") {
+            local value: subinstr local value "0." "."
+        }
+    }
+    if `"`macval(dmarker)'"'!="" {
+        if "`: set dp'"=="comma" local dp ,
+        else local dp .
+        local val: subinstr local value "`dp'" `"`macval(dmarker)'"'
+    }
+    else local val `"`value'"'
+    if `"`msign'"'!="" {
+        if index("`value'","-")==1 {
+            local val: subinstr local val "-" `"`macval(msign)'"'
+        }
+    }
+    if `"`par'"'!="" {
+        tokenize `"`macval(par)'"'
+        local val `"`macval(1)'`macval(val)'`macval(2)'"'
+    }
+    c_local value `"`macval(val)'"'
+end
+
+program SignificantDigits // idea stolen from outreg2.ado
+    args fmt value
+    local d = substr("`fmt'", 2, .)
+    if `"`d'"'=="" local d 3
+    capt confirm integer number `d'
+    if _rc {
+        di as err `"`fmt': invalid format"'
+        exit 198
+    }
+// missing: format does not matter
+    if `value'>=. local fmt "%9.0g"
+// integer: print no decimal places
+    else if (`value'-int(`value'))==0 {
+        local fmt "%12.0f"
+    }
+// value in (-1,1): display up to 9 decimal places with d significant
+// digits, then switch to e-format with d-1 decimal places
+    else if abs(`value')<1 {
+        local right = -int(log10(abs(`value'-int(`value')))) // zeros after dp
+        local dec = max(1,`d' + `right')
+        if `dec'<=9 {
+            local fmt "%12.`dec'f"
+        }
+        else {
+            local fmt "%12.`=min(9,`d'-1)'e"
+        }
+    }
+// |values|>=1: display d+1 significant digits or more with at least one
+// decimal place and up to nine digits before the decimal point, then
+// switch to e-format
+    else {
+        local left = int(log10(abs(`value'))+1) // digits before dp
+        if `left'<=9 {
+            local fmt "%12.`=max(1,`d' - `left' + 1)'f"
+        }
+        else {
+            local fmt "%12.0e" // alternatively: "%12.`=min(9,`d'-1)'e"
+        }
+    }
+    c_local fmt "`fmt'"
+end
+
+program Stars
+    args starlevels P
+    if inrange(`P',0,1) {
+        local nstar: word count `macval(starlevels)'
+        forv i=1(2)`nstar' {
+            local istarsym: word `i' of `macval(starlevels)'
+            local istar: word `=`i'+1' of `macval(starlevels)'
+            if `istar'<=`P' continue, break
+            local value "`macval(istarsym)'"
+        }
+    }
+    c_local value `"`macval(value)'"'
+end
+
+program CellStars
+    args starlevels P par
+    Stars `"`macval(starlevels)'"' `P'
+    if `"`par'"'!="" {
+        tokenize `"`macval(par)'"'
+        local value `"`macval(1)'`macval(value)'`macval(2)'"'
+    }
+    c_local value `"`macval(value)'"'
+end
+
+prog MakeSign
+    args value msign par starlevels P
+    if "`P'"!="" {
+        local factor = 0
+        while 1 {
+            gettoken istar starlevels : starlevels
+            gettoken istar starlevels : starlevels
+            if `"`istar'"'=="" continue, break
+            if `P'<`istar' local factor = `factor' + 1
+            else if `istar'==1 local factor = 1
+        }
+    }
+    else local factor 1
+    if `"`macval(msign)'"'=="" local msign "-"
+    if `value'<0 {
+        local val: di _dup(`factor') `"`macval(msign)'"'
+    }
+    else if `value'==0 local val: di _dup(`factor') "0"
+    else if `value'>0 & `value'<. local val: di _dup(`factor') "+"
+    else local val `value'
+    if `"`par'"'!="" {
+        tokenize `"`macval(par)'"'
+        local val `"`macval(1)'`macval(val)'`macval(2)'"'
+    }
+    c_local value `"`macval(val)'"'
+end
+
+program DropOrKeep
+    args type b spec // type=0: drop; type=1: keep
+    capt confirm matrix `b'
+    if _rc {
+        exit
+    }
+    tempname res bt
+    local R = rowsof(`b')
+    forv i=1/`R' {
+        local hit 0
+        mat `bt' = `b'[`i',1...]
+        foreach sp of local spec {
+            if rownumb(`bt', `"`sp'"')==1 {
+                local hit 1
+                continue, break
+            }
+        }
+        if `hit'==`type' mat `res' = nullmat(`res') \ `bt'
+    }
+    capt mat drop `b'
+    capt mat rename `res' `b'
+end
+
+program Order
+    args b spec
+    capt confirm matrix `b'
+    if _rc {
+        exit
+    }
+    tempname bt res
+    local eqlist: roweq `b', q
+    local eqlist: list uniq eqlist
+    mat `bt' = `b'
+    gettoken spi rest : spec
+    while `"`spi'"'!="" {
+        gettoken spinext rest : rest
+        if !index(`"`spi'"',":") {
+            local vars `"`vars'`"`spi'"' "'
+            if `"`spinext'"'!="" & !index(`"`spinext'"',":") {
+                local spi `"`spinext'"'
+                continue
+            }
+            foreach eq of local eqlist {
+                foreach var of local vars {
+                    local splist `"`splist'`"`eq':`var'"' "'
+                }
+                local splist `"`splist'`"`eq':"' "' // rest
+            }
+            local vars
+        }
+        else local splist `"`spi'"'
+        gettoken sp splist : splist
+        while `"`sp'"'!="" {
+            local isp = rownumb(`bt', "`sp'")
+            if `isp' >= . {
+                gettoken sp splist : splist
+                continue
+            }
+            while `isp' < . {
+                mat `res' = nullmat(`res') \ `bt'[`isp',1...]
+                local nb = rowsof(`bt')
+                if `nb' == 1 { // no rows left in `bt'
+                    capt mat drop `b'
+                    capt mat rename `res' `b'
+                    exit
+                }
+                if `isp' == 1 {
+                    mat `bt' = `bt'[2...,1...]
+                }
+                else if `isp' == `nb' {
+                    mat `bt' = `bt'[1..`=`nb'-1',1...]
+                }
+                else {
+                    mat `bt' = `bt'[1..`=`isp'-1',1...] \ `bt'[`=`isp'+1'...,1...]
+                }
+                local isp = rownumb(`bt', "`sp'")
+            }
+            gettoken sp splist : splist
+        }
+        local spi `"`spinext'"'
+    }
+    capt mat `res' = nullmat(`res') \ `bt'
+    capt mat drop `b'
+    capt mat rename `res' `b'
+end
+
+prog MakeQuotedFullnames
+    args names eqs
+    foreach name of local names {
+        gettoken eq eqs : eqs
+        local value `"`value'`"`eq':`name'"' "'
+    }
+    c_local value: list clean value
+end
+
+program define QuotedRowNames
+    args matrix
+    capt confirm matrix `matrix'
+    if _rc {
+        c_local value ""
+        exit
+    }
+    tempname extract
+    if substr(`"`matrix'"',1,2)=="r(" {
+        local matrix0 `"`matrix'"'
+        tempname matrix
+        mat `matrix' = `matrix0'
+    }
+    local R = rowsof(`matrix')
+    forv r = 1/`R' {
+        mat `extract' = `matrix'[`r',1...]
+        local name: rownames `extract'
+        local value `"`value'`"`name'"' "'
+    }
+    c_local value: list clean value
+end
+
+prog EqReplaceCons
+    args names eqlist eqlabels varlabels
+    local skip 0
+    foreach v of local varlabels {
+        if `skip' {
+            local skip 0
+            continue
+        }
+        local vlabv `"`vlabv'`"`v'"' "'
+        local skip 1
+    }
+    local deqs: list dups eqlist
+    local deqs: list uniq deqs
+    local i 0
+    foreach eq of local eqlist {
+        local ++i
+        if `"`eq'"'!=`"`last'"' {
+            gettoken eqlab eqlabels : eqlabels
+        }
+        local last `"`eq'"'
+        if `:list eq in deqs' | `"`eq'"'=="__" continue
+        local name: word `i' of `names'
+        local isinvlabv: list posof `"`eq':`name'"' in vlabv
+        if `"`name'"'=="_cons" & `isinvlabv'==0 {
+            local value `"`value'`space'`"`eq':`name'"' `"`eqlab'"'"'
+            local space " "
+        }
+    }
+    c_local value `"`value'"'
+end
+
+prog UniqEqsAndDims
+    local n 0
+    foreach el of local 1 {
+        if `"`macval(el)'"'!=`"`macval(last)'"' {
+            if `n'>0 local eqsdims "`eqsdims' `n'"
+            local eqs `"`macval(eqs)' `"`macval(el)'"'"'
+            local n 0
+        }
+        local ++n
+        local last `"`macval(el)'"'
+    }
+    local eqsdims "`eqsdims' `n'"
+    c_local eqsdims: list clean eqsdims
+    c_local eqs: list clean eqs
+end
+
+prog RerrangeEqs
+    args B eqlist eqs
+    local equ: list uniq eqlist
+    if `: list sizeof equ'==`: list sizeof eqs' exit // equations are in order
+    tempname C
+    foreach eq of local equ {
+        local i 0
+        foreach eqi of local eqlist {
+            local ++i
+            if `"`eq'"'!="`eqi'" continue
+            mat `C' = nullmat(`C') \ `B'[`i',1...]
+        }
+    }
+    matrix drop `B'
+    matrix rename `C' `B'
+    local eqlist: roweq `B', q
+    local eqlist: list clean eqlist
+    UniqEqsAndDims `"`eqlist'"'
+    c_local eqlist  `"`eqlist'"'
+    c_local eqs     `"`eqs'"'
+    c_local eqsdims `"`eqsdims'"'
+end
+
+prog InsertAtCols
+    args colnums row symb
+    if `"`symb'"'=="" local symb .
+    gettoken c rest : colnums
+    local i 0
+    foreach r of local row {
+        local ++i
+        while `"`c'"'!="" {
+            if `c'<=`i' {
+                local value `"`value' `symb'"'
+                gettoken c rest : rest
+            }
+            else continue, break
+        }
+        local value `"`value' `"`r'"'"'
+    }
+    while `"`c'"'!="" {
+        local value `"`value' `symb'"'
+        gettoken c rest : rest
+    }
+    c_local value: list clean value
+end
+
+prog GetVarnamesFromOrder
+    foreach sp of local 1 {
+        if index(`"`sp'"', ":") {
+            gettoken trash sp: sp, parse(:)
+            if `"`trash'"'!=":" {
+                gettoken trash sp: sp, parse(:)
+            }
+        }
+        local value `"`value'`space'`sp'"'
+        local space " "
+    }
+    c_local value `"`value'"'
+end
+
+prog ParseIndicateOpts
+    syntax [anything(equalok)] [, Labels(str asis) ]
+    gettoken tok rest : anything, parse(" =")
+    while `"`macval(tok)'"'!="" {
+        if `"`macval(tok)'"'=="=" {
+            local anything `"`"`macval(anything)'"'"'
+            continue, break
+        }
+        gettoken tok rest : rest, parse(" =")
+    }
+    c_local indicate `"`macval(anything)'"'
+    c_local indicatelabels `"`macval(labels)'"'
+end
+
+prog ProcessIndicateGrp
+    args i B nmodels ccols unstack yesno indicate
+    gettoken yes no : yesno
+    gettoken no : no
+    gettoken tok rest : indicate, parse(=)
+    while `"`macval(tok)'"'!="" {
+        if `"`macval(rest)'"'=="" {
+            local vars `"`indicate'"'
+            continue, break
+        }
+        if `"`macval(tok)'"'=="=" {
+            local vars `"`rest'"'
+            continue, break
+        }
+        local name `"`macval(name)'`space'`macval(tok)'"'
+        local space " "
+        gettoken tok rest : rest, parse(=)
+    }
+    if `"`macval(name)'"'=="" {
+        local name: word 1 of `"`vars'"'
+    }
+    ExpandEqVarlist `"`vars'"' `B'
+    local evars `"`value'"'
+    IsInModels `B' `nmodels' `ccols' "`unstack'" `"`macval(yes)'"' `"`macval(no)'"' `"`evars'"'
+    local lbls `"`macval(value)'"'
+    DropOrKeep 0 `B' `"`evars'"'
+    c_local indicate`i'name `"`macval(name)'"'
+    c_local indicate`i'lbls `"`macval(lbls)'"'
+    c_local indicate`i'eqs `"`eqs'"'
+end
+
+prog IsInModels
+    args B nmodels ccols unstack yes no vars
+    capt confirm matrix `B'
+    if _rc {
+        forv i = 1/`nmodels' {
+            local lbls `"`macval(lbls)' `"`macval(no)'"'"'
+        }
+        c_local value `"`macval(lbls)'"'
+        if `"`unstack'"'!="" {
+            c_local eqs "__"
+        }
+        exit
+    }
+    local eqs: roweq `B', q
+    local eqs: list uniq eqs
+    tempname Bt Btt Bttt
+    forv j = 1/`nmodels' {
+        local stop 0
+        mat `Bt' = `B'[1..., (`j'-1)*`ccols' + 1]
+        foreach eq of local eqs {
+            mat `Btt' = `Bt'[`"`eq':"',1]
+            if `"`unstack'"'!="" local stop 0
+            foreach var of local vars {
+                if !index(`"`var'"',":") {
+                    local var `"`eq':`var'"'
+                }
+                capt mat `Bttt' = `Btt'["`var'",1]
+                if _rc continue
+                forv i = 1/`= rowsof(`Bttt')' {
+                    if `Bttt'[`i',1]<.z {
+                        local lbls `"`macval(lbls)' `"`macval(yes)'"'"'
+                        local stop 1
+                        continue, break
+                    }
+                }
+                if `stop' continue, break
+            }
+            if `"`unstack'"'!="" {
+                if `stop'==0 {
+                    local lbls `"`macval(lbls)' `"`macval(no)'"'"'
+                }
+            }
+            else if `stop' continue, break
+        }
+        if `"`unstack'"'=="" & `stop'==0 {
+            local lbls `"`macval(lbls)' `"`macval(no)'"'"'
+        }
+    }
+    c_local value `"`macval(lbls)'"'
+    if `"`unstack'"'!="" {
+        c_local eqs `"`eqs'"'
+    }
+end
+
+prog ReorderEqsInIndicate
+    args nmodels eqs ieqs lbls
+    local neq: list sizeof ieqs
+    foreach eq of local eqs {
+        local i: list posof `"`eq'"' in ieqs
+        if `i' {
+            local pos `pos' `i'
+        }
+    }
+    forv m=1/`nmodels' {
+        foreach i of local pos {
+            local mi = (`m'-1)*`neq' + `i'
+            local lbl: word `mi' of `macval(lbls)'
+            local value `"`macval(value)'`"`macval(lbl)'"' "'
+        }
+    }
+    c_local value `"`macval(value)'"'
+end
+
+prog ParseRefcatOpts
+    syntax [anything(equalok)] [, NOLabel Label(str) Below ]
+    c_local refcatbelow "`below'"
+    c_local norefcatlabel "`nolabel'"
+    c_local refcatlabel `"`macval(label)'"'
+    c_local refcat `"`macval(anything)'"'
+end
+
+prog PrepareRefcat
+    gettoken coef rest : 1
+    gettoken name rest : rest
+    while `"`macval(coef)'"'!="" {
+        local coefs `"`coefs'`"`coef'"' "'
+        local names `"`macval(names)'`"`macval(name)'"' "'
+        gettoken coef rest : rest
+        gettoken name rest : rest
+    }
+    c_local refcatcoefs `"`coefs'"'
+    c_local refcatnames `"`macval(names)'"'
+end
+
+prog GenerateRefcatRow
+    args B ccols var eqs label
+    local models: coleq `B', q
+    local models: list uniq models
+    local col 1
+    foreach model of local models {
+        foreach eq of local eqs {
+            local eqvar `"`eq':`var'"'
+            local row = rownumb(`B',"`eqvar'")
+            if `B'[`row', `col']<.z {
+                local value `"`macval(value)'`"`macval(label)'"' "'
+            }
+            else {
+                local value `"`macval(value)'`""' "'
+            }
+        }
+        local col = `col' + `ccols'
+    }
+    c_local value `"`macval(value)'"'
+end
+
+prog ParseTransformSubopts
+    syntax anything(equalok) [, Pattern(string) ]
+    c_local transform `"`anything'"'
+    c_local transformpattern "`pattern'"
+end
+
+prog MakeTransformList
+    args B transform
+    local R = rowsof(`B')
+    if `:list sizeof transform'<=2 {
+        gettoken f rest : transform
+        gettoken df : rest
+        forv i = 1/`R' {
+            local valuef `"`valuef'`f' "'
+            local valuedf `"`valuedf'`df' "'
+        }
+        c_local valuef: list retok valuef
+        c_local valuedf: list retok valuedf
+        exit
+    }
+    gettoken coef rest : transform
+    gettoken f rest : rest
+    gettoken df rest : rest
+    while (`"`coef'"'!="") {
+        if (`"`df'`rest'"'!="") { // last element of list may be without coef
+            ExpandEqVarlist `"`coef'"' `B'
+            local coef `"`value'"'
+        }
+        local coefs `"`coefs'`"`coef'"' "'
+        local fs `"`fs'`"`f'"' "'
+        local dfs `"`dfs'`"`df'"' "'
+        gettoken coef rest : rest
+        gettoken f rest : rest
+        gettoken df rest : rest
+    }
+    tempname b
+    local value
+    forv i = 1/`R' {
+        mat `b' = `B'[`i',1...]
+        local i 0
+        local hit 0
+        foreach coef of local coefs {
+            local f: word `++i' of `fs'
+            local df: word `i' of `dfs'
+            if (`"`df'`rest'"'=="") {
+                local valuef `"`valuef'`"`coef'"' "'  // sic! (see above)
+                local valuedf `"`valuedf'`"`f'"' "'
+                local hit 1
+                continue, break
+            }
+            foreach c of local coef {
+                if rownumb(`b', `"`c'"')==1 {
+                    local valuef `"`valuef'`"`f'"' "'
+                    local valuedf `"`valuedf'`"`df'"' "'
+                    local hit 1
+                    continue, break
+                }
+            }
+            if `hit' continue, break
+        }
+        if `hit'==0 {
+            local valuef `"`valuef'"" "'
+            local valuedf `"`valuedf'"" "'
+        }
+    }
+    c_local valuef: list retok valuef
+    c_local valuedf: list retok valuedf
+end
+
+prog TableIsAMess
+    local ccols = r(ccols)
+    local eq: roweq r(coefs), q
+    local eq: list uniq eq
+    if `: list sizeof eq'<=1 {
+        c_local value 0
+        exit
+    }
+    tempname b bt
+    mat `b' = r(coefs)
+    gettoken eq : eq
+    mat `b' = `b'[`"`eq':"', 1...]
+    local R = rowsof(`b')
+    local models: coleq `b', q
+    local models: list uniq models
+    local value 0
+    local i = 1 - `ccols'
+    foreach model of local models {
+        local i = `i' + `ccols'
+        if `i'==1 continue // skip first model
+        mat `bt' = `b'[1...,`i']
+        local allz 1
+        forv r = 1/`R' {
+            if `bt'[`r',1]<.z {
+                local allz 0
+                continue, break
+            }
+        }
+        if `allz' {
+            local value 1
+            continue, break
+        }
+    }
+    c_local value `value'
+end
+
+prog ExpandEqVarlist
+    args list B append
+    ParseEqVarlistRelax `list'
+    QuotedRowNames `B'
+    local coefs `"`value'"'
+    local value
+    local ucoefs: list uniq coefs
+    capt confirm matrix `B'
+    if _rc==0 {
+        local eqs: roweq `B', q
+    }
+    else local eqs "__"
+    local ueqs: list uniq eqs
+    while `"`list'"'!="" {
+// get next element
+        local eq0
+        gettoken eqx list : list
+// separate eq and x
+        gettoken eq x : eqx, parse(:)
+        local eq: list clean eq
+        if `"`eq'"'==":" {    // case 1: ":[varname]"
+            local x: list clean x
+            local eq
+        }
+        else if `"`x'"'=="" { // case 2: "varname"
+            local x `"`eq'"'
+            local eq
+        }
+        else {                // case 3. "eqname:[varname]"
+            local eq0 `"`eq'"' // eq specified by user
+            if `"`eq'"'=="_" local eq "__"
+            gettoken colon x : x, parse(:)
+            local x: list clean x
+        }
+// match equations
+        local eqmatch
+        if `:list eq in ueqs' { // (note: evaluates to 1 if eq empty)
+            local eqmatch `"`eq'"'
+        }
+        else {
+            foreach e of local ueqs {
+                if match(`"`e'"', `"`eq'"') {
+                    local eqmatch `"`eqmatch' `"`e'"'"'
+                }
+            }
+            if `"`eqmatch'"'=="" & "`relax'"=="" {
+                if !("`append'"!="" & `"`x'"'!="") {
+                    di as err `"equation `eq0' not found"'
+                    exit 111
+                }
+            }
+            local eqmatch: list clean eqmatch
+        }
+        if `"`x'"'=="" {
+            foreach e of local eqmatch {
+                local value `"`value' `"`e':"'"'
+            }
+            continue
+        }
+// match coefficients
+        local vlist
+// - without equation
+        if `"`eq'"'=="" {
+            if `:list x in ucoefs' {
+                local value `"`value' `"`x'"'"'
+                continue
+            }
+            foreach coef of local ucoefs {
+                if match(`"`coef'"', `"`x'"') {
+                    local vlist `"`vlist' `"`coef'"'"'
+                }
+            }
+            if `"`vlist'"'=="" {
+                if "`append'"!="" {
+                    local appendlist `"`appendlist' `"__:`x'"'"'
+                    local value `"`value' `"`x'"'"'
+                }
+                else if "`relax'"=="" {
+                    di as err `"coefficient `x' not found"'
+                    exit 111
+                }
+            }
+            else {
+                local value `"`value' `vlist'"'
+            }
+            continue
+        }
+// - within equations
+        local rest `"`eqs'"'
+        foreach coef of local coefs {
+            gettoken e rest : rest
+            if !`:list e in eqmatch' {
+                continue
+            }
+            if match(`"`coef'"', `"`x'"') {
+                local vlist `"`vlist' `"`e':`coef'"'"'
+            }
+        }
+        if `"`vlist'"'=="" {
+            if "`append'"!="" {
+                local appendlist `"`appendlist' `"`eq':`x'"'"'
+                local value `"`value' `"`eq':`x'"'"'
+            }
+            else if "`relax'"=="" {
+                di as err `"coefficient `eq0':`x' not found"'
+                exit 111
+            }
+        }
+        else {
+            local value `"`value' `vlist'"'
+        }
+    }
+    if "`append'"!="" {
+        local nappend : list sizeof appendlist
+        if `nappend'>0 {
+            capt confirm matrix `B'
+            if _rc==0 {
+                tempname tmp
+                mat `tmp' = J(`nappend', colsof(`B'), .z)
+                mat rown `tmp' = `appendlist'
+                matrix `B' = `B' \ `tmp'
+            }
+        }
+    }
+    c_local value: list clean value
+end
+
+program ParseEqVarlistRelax
+    syntax [anything] [, Relax ]
+    c_local list `"`anything'"'
+    c_local relax `relax'
+end
+
+program IsInString //, rclass
+    args needle haystack
+    local trash: subinstr local haystack `"`needle'"' "", count(local count)
+    c_local strcount = `count'
+end
+
+program MakeRtfRowdefs
+    args str srow sdetach vwidth mwidth haslc2 lc2width
+    local factor 120
+    ParseRtfcmdNum `"`str'"' "trgaph" 0
+    ParseRtfcmdNum `"`str'"' "trleft" 0
+    if `vwidth'<=0 local vwidth 12
+    if real(`"`trgaph'"')>=. local trgaph 0
+    if real(`"`trleft'"')>=. local trleft 0
+    local swidth = 3
+    local vtwips = `vwidth'*`factor'
+    local stwips = `swidth'*`factor'
+    local ipos = `vtwips' + 2*`trgaph' + (`trleft')
+    local brdrt "\clbrdrt\brdrw10\brdrs"
+    local brdrb "\clbrdrb\brdrw10\brdrs"
+    local emptycell "\pard\intbl\ql\cell"
+    local rtfdef "\cellx`ipos'"
+    local rtfdefbrdrt "`brdrt'\cellx`ipos'"
+    local rtfdefbrdrb "`brdrb'\cellx`ipos'"
+    local rtfrow "`emptycell'"
+    if `haslc2' {
+        if `lc2width'<=0 local lc2width 12
+        local lc2twips = `lc2width'*`factor'
+        local ipos = `ipos' + `lc2twips' + 2*`trgaph'
+        local rtfdef "`rtfdef'\cellx`ipos'"
+        local rtfdefbrdrt "`rtfdefbrdrt'`brdrt'\cellx`ipos'"
+        local rtfdefbrdrb "`rtfdefbrdrb'`brdrb'\cellx`ipos'"
+        local rtfrow "`rtfrow'`emptycell'"
+    }
+    local j 0
+    local nmwidth: list sizeof mwidth
+    foreach i of local srow {
+        local mwidthj: word `=1 + mod(`j++',`nmwidth')' of `mwidth'
+        if `mwidthj'<=0 local mwidthj 12
+        local mtwips = `mwidthj'*`factor'
+        local ipos = `ipos' + `mtwips' + 2*`trgaph'
+        if `i' & "`sdetach'"=="" local ipos = `ipos' + `stwips'
+        local rtfdef "`rtfdef'\cellx`ipos'"
+        local rtfdefbrdrt "`rtfdefbrdrt'`brdrt'\cellx`ipos'"
+        local rtfdefbrdrb "`rtfdefbrdrb'`brdrb'\cellx`ipos'"
+        local rtfrow "`rtfrow'`emptycell'"
+        if `i' & "`sdetach'"!="" {
+            local ipos = `ipos' + `stwips' + 2*`trgaph'
+            local rtfdef "`rtfdef'\cellx`ipos'"
+            local rtfdefbrdrt "`rtfdefbrdrt'`brdrt'\cellx`ipos'"
+            local rtfdefbrdrb "`rtfdefbrdrb'`brdrb'\cellx`ipos'"
+            local rtfrow "`rtfrow'`emptycell'"
+        }
+    }
+    c_local rtfrowdef "`rtfdef'"
+    c_local rtfrowdefbrdrt "`rtfdefbrdrt'"
+    c_local rtfrowdefbrdrb "`rtfdefbrdrb'"
+    c_local rtfemptyrow "`rtfdef'`rtfrow'"
+end
+
+prog ParseRtfcmdNum
+    args str cmd default
+    local pos = index(`"`str'"', `"\\`cmd'"')
+    if `pos' {
+        local pos = `pos' + strlen(`"`cmd'"') + 1
+        local digit = substr(`"`str'"',`pos',1)
+        if `"`digit'"'=="-" {
+            local value "`digit'"
+            local digit = substr(`"`str'"',`++pos',1)
+        }
+        while real(`"`digit'"')<. {
+            local value "`value'`digit'"
+            local digit = substr(`"`str'"',`++pos',1)
+        }
+    }
+    local value = real(`"`value'"')
+    if `value'>=. local value = `default'
+    c_local `cmd' `"`value'"'
+end
+
+prog ParseLabCol2
+    syntax [anything(equalok)] [ , Title(str asis) Width(numlist max=1 int >=0) ]
+    c_local labcol2 `"`macval(anything)'"'
+    c_local labcol2title `"`macval(title)'"'
+    c_local labcol2width `"`width'"'
+end
+
+prog StableSubinstr
+    // use mata in stata>=9 because -:subinstr- breaks if length of <to>
+    // is more than 502 characters
+    args new old from to all word
+    if c(stata_version)>=9 {
+        if "`all'"=="all"   local cnt .
+        else if "`all'"=="" local cnt 1
+        else error 198
+        if "`word'"=="" local word str
+        else if "`word'"!="word" error 198
+        mata: st_local("tmp", subin`word'(st_local("old"), ///
+                   st_local("from"), st_local("to"), `cnt'))
+        c_local `new' `"`macval(tmp)'"'
+    }
+    else {
+        capt local tmp: subinstr local old `"`macval(from)'"' ///
+            `"`macval(to)'"', `all' `word'
+        if _rc==0 {
+             c_local `new' `"`macval(tmp)'"'
+        }
+    }
+end
+
+prog MakeMMDdef
+    args varw labcol2 labcol2w modelw starsrow stardetachon starw
+    if "`varw'"=="0"     | "`varw'"==""     local varw 1
+    if "`labcol2w'"=="0" | "`labcol2w'"=="" local labcol2w 1
+    if "`modelw'"=="0"   | "`modelw'"==""   local modelw 1
+    if "`starw'"=="0"    | "`starw'"==""    local starw 1
+    local varw      = max(1,`varw')
+    local labcol2w  = max(1,`labcol2w'-2)
+    if "`stardetachon'"=="1" local starw = max(1,`starw'-2)
+    else                     local starw = max(1,`starw')
+
+    local mmddef `"| `:di _dup(`varw') "-"'"'
+    if "`labcol2'"=="1" {
+        local mmddef `"`mmddef' | :`:di _dup(`labcol2w') "-"':"'
+    }
+    local nmodelw: list sizeof modelw
+    local c 0
+    foreach col of local starsrow {
+        local modelwj: word `=1+mod(`c++',`nmodelw')' of `modelw'
+        local modelwj = max(1,`modelwj'-2)
+        local mmddef `"`mmddef' | :`:di _dup(`modelwj') "-"'"'
+        if "`col'"=="1" {
+            if "`stardetachon'"=="1" {
+                local mmddef `"`mmddef': | :"'
+            }
+            local mmddef `"`mmddef'`:di _dup(`starw') "-"'"'
+        }
+        local mmddef `"`mmddef':"'
+    }
+    c_local value `"`mmddef' |"'
+end
+
+program MatrixMode, rclass
+    capt syntax [, Matrix(str asis) e(str asis) r(str asis) rename(str asis) ]
+    if _rc | `"`matrix'`e'`r'"'=="" {
+        c_local matrixmode 0
+        exit
+    }
+    if ((`"`matrix'"'!="") + (`"`e'"'!="") + (`"`r'"'!=""))>1 {
+        di as err "only one of matrix(), e(), or r() allowed"
+        exit 198
+    }
+    ParseMatrixOpt `matrix'`e'`r'
+    if `"`e'"'!="" {
+        local name "e(`name')"
+    }
+    else if `"`r'"'!="" {
+        local name "r(`name')"
+    }
+    confirm matrix `name'
+    tempname bc
+    if "`transpose'"=="" {
+        mat `bc' = `name''
+    }
+    else {
+        mat `bc' = `name'
+    }
+    QuotedRowNames `bc'
+    local rnames `"`value'"'
+    local eqs: roweq `bc', q
+    mat `bc' = `bc''
+    local cols = colsof(`bc')
+    local cells
+    local space
+    gettoken fmti fmtrest : fmt, match(par)
+    gettoken rname rnames : rnames
+    gettoken eq eqs : eqs
+    forv i = 1/`cols' {
+        if `"`fmti'"'!="" {
+            local fmtopt `"f(`fmti') "'
+            gettoken fmti fmtrest : fmtrest, match(par)
+            if `"`fmti'"'=="" & `"`fmtrest'"'=="" { // recycle
+                gettoken fmti fmtrest : fmt, match(par)
+            }
+        }
+        else local fmtopt
+        if `"`eq'"'=="_" {
+            local lbl `"l(`"`rname'"')"'
+        }
+        else {
+            local lbl `"l(`"`eq':`rname'"')"'
+        }
+        local cells `"`cells'`space'c`i'(`fmtopt'`lbl')"'
+        local space " "
+        gettoken rname rnames : rnames
+        gettoken eq eqs : eqs
+    }
+    SubstEmptyEqname `bc' // replace empty eqname "_" by "__"
+    if `"`rename'"'!="" {
+        local rename : subinstr local rename "," "", all
+        RenameCoefs `bc' `"`rename'"'
+    }
+    return local names      "`name'"
+    return scalar nmodels   = 1
+    return scalar ccols     = `cols'
+    return matrix coefs     = `bc'
+    c_local matrixmode      1
+    c_local cells           (`cells')
+end
+
+program ParseMatrixOpt
+    syntax name [, Fmt(str asis) Transpose ]
+    c_local name `"`namelist'"'
+    c_local fmt `"`fmt'"'
+    c_local transpose `"`transpose'"'
+end
+
+program CompileVarl
+    syntax [, vname(str asis) interaction(str) ]
+    gettoken vi vname: vname, parse("#")
+    while (`"`vi'"') !="" {
+        local xlabi
+        if `"`vi'"'=="#" {
+            local xlabi `"`macval(interaction)'"'
+        }
+        else if strpos(`"`vi'"',".")==0 {
+            capt confirm variable `vi', exact
+            if _rc==0 {
+                local xlabi: var lab `vi'
+            }
+        }
+        else {
+            gettoken li vii : vi, parse(".")
+            gettoken dot vii : vii, parse(".")
+            capt confirm variable `vii', exact
+            if _rc==0 {
+                capt confirm number `li'
+                if _rc {
+                    local xlabi: var lab `vii'
+                    if (`"`macval(xlabi)'"'=="") local xlabi `"`vii'"'
+                    if substr(`"`li'"',1,1)=="c" ///
+                                         local li = substr(`"`li'"',2,.)
+                    if (`"`li'"'!="")    local xlabi `"`li'.`macval(xlabi)'"'
+                }
+                else {
+                    local viilab : value label `vii'
+                    if `"`viilab'"'!="" {
+                        local xlabi: label `viilab' `li'
+                    }
+                    else {
+                        local viilab: var lab `vii'
+                        if (`"`macval(viilab)'"'=="") local viilab `"`vii'"'
+                        local xlabi `"`macval(viilab)'=`li'"'
+                    }
+                }
+            }
+        }
+        if `"`macval(xlabi)'"'=="" {
+            local xlabi `"`vi'"'
+        }
+        local xlab `"`macval(xlab)'`macval(xlabi)'"'
+        gettoken vi vname: vname, parse("#")
+    }
+    c_local varl `"`macval(xlab)'"'
+end
+
+if c(stata_version)<11 exit
+version 11
+mata:
+mata set matastrict on
+
+void estout_omitted_and_base()
+{
+    real colvector      p
+    real matrix         bc
+    string matrix       rstripe, cstripe
+    string colvector    coefnm
+    
+    bc = st_matrix(st_local("bc"))
+    rstripe = st_matrixrowstripe(st_local("bc"))
+    cstripe = st_matrixcolstripe(st_local("bc"))
+    coefnm = rstripe[,2]
+    //coefnm = subinstr(coefnm,"bn.", ".")                              // *bn.
+    //coefnm = subinstr(coefnm,"bno.", "o.")                            // *bno.
+    p = J(rows(bc), 1, 1)
+    if (st_local("omitted")=="") {
+        p = p :* (!strmatch(coefnm, "*o.*"))
+    }
+    else {
+        coefnm = substr(coefnm, 1:+2*(substr(coefnm, 1, 2):=="o."), .)  // o.
+        coefnm = subinstr(coefnm, "o.", ".")                            // *o.
+    }
+    if (st_local("baselevels")=="") {
+        p = p :* (!strmatch(coefnm, "*b.*"))
+    }
+    else {
+        coefnm = subinstr(coefnm, "b.", ".")                            // *b.
+    }
+    if (any(p)) {
+        st_matrix(st_local("bc"), select(bc, p))
+        st_matrixrowstripe(st_local("bc"), select((rstripe[,1], coefnm), p))
+        st_matrixcolstripe(st_local("bc"), cstripe)
+        st_local("hasbc", "1")
+    }
+    else {
+        st_local("hasbc", "0")
+    }
+}
+
+void estout_rown_hasblanks(string scalar lnm, string rowvector m)
+{
+    real scalar j
+    
+    for (j=1;j<=2;j++) {
+        if (m[j]=="") return
+        if (any(strpos(st_matrixrowstripe(m[j])[,2], " "))) {
+            st_local(lnm, "1")
+            return
+        }
+    }
+}
+
+void estout_mat_capp(string scalar m1, string rowvector m)
+{
+    real scalar      i, j
+    string scalar    key, val
+    string colvector rown
+    transmorphic     A
+    
+    // replace rownames that contain blanks
+    A = asarray_create()
+    asarray_notfound(A, "")
+    for (j=1;j<=2;j++) {
+        rown = st_matrixrowstripe(m[j])[,2]
+        for (i=rows(rown);i;i--) {
+            val = rown[i]
+            if (strpos(val, " ")) {
+                key = subinstr(val, " ", "_")
+                asarray(A, key, val)
+                rown[i] = key
+            }
+            st_matrixrowstripe(m[j], (st_matrixrowstripe(m[j])[,1],rown))
+        }
+    }
+    // apply mat_capp
+    stata("mat_capp " + st_local("0"))
+    // restore original names
+    rown = st_matrixrowstripe(m1)[,2]
+    for (i=rows(rown);i;i--) {
+        val = asarray(A, rown[i])
+        if (val!="") rown[i] = val
+    }
+    st_matrixrowstripe(m1, (st_matrixrowstripe(m1)[,1], rown))
+}
+end
+
+if c(stata_version)<14 exit
+version 14
+mata:
+mata set matastrict on
+
+void estout_rtfencode(string scalar lname)
+{   // non-ASCII characters are translated to "\u#?" where # is the base 10 code
+    // (up to code 65535; replacement character is used for larger codes)
+    real scalar      n, l, i, ci
+    real rowvector   c
+    string scalar    s, snew
+    string rowvector S
+    
+    s = st_local(lname)
+    if (isascii(s)) return
+    l = ustrlen(s)
+    snew = ""
+    for (n=1;n<=l;n=n+200) {
+        c = frombase(16, /// possible hex formats: \uhhhh or \Uhhhhhhhh
+            substr(tokens(subinstr(ustrtohex(s, n), "\", " ")), 2, .))
+        i = length(c)
+        S = J(1,i,"")
+        for (;i;i--) {
+            ci = c[i]
+            if      (ci<=127)   S[i] = char(ci)
+            else if (ci<=32767) S[i] = "\u" + strofreal(ci) + "?"
+            else if (ci<=65535) S[i] = "\u" + strofreal(ci-65536) + "?"
+            else S[i] = "\u65533?" // unicode replacement character \ufffd
+        }
+        snew = snew + invtokens(S, "")
+    }
+    st_local(lname, snew)
+}
+end
+

--- a/analysis/extra_ados/estout.hlp
+++ b/analysis/extra_ados/estout.hlp
@@ -1,0 +1,2452 @@
+{smcl}
+{* 01feb2017}{...}
+{cmd:help estout}{right:also see: {helpb esttab}, {helpb eststo}, {helpb estadd}, {helpb estpost}}
+{right: {browse "http://repec.sowi.unibe.ch/stata/estout/"}}
+{hline}
+
+{title:Title}
+
+{p 4 4 2}{hi:estout} {hline 2} Making regression tables from stored estimates
+
+
+{title:Table of contents}
+
+    {help estout##syn:Syntax}
+    {help estout##des:Description}
+    {help estout##opt:Options}
+    {help estout##exa:Examples}
+    {help estout##rem:Remarks}
+    {help estout##ret:Saved results}
+    {help estout##ref:Backmatter}
+
+{marker syn}
+{title:Syntax}
+
+{p 8 15 2}
+{cmd:estout} [ {help estout##what:{it:what}} ]
+    [ {cmd:using} {it:filename} ]
+    [ {cmd:,} {help estout##opt0:{it:options}} ]
+
+{marker what}
+    {it:what}{col 30}description
+    {hline 70}
+    {it:namelist}{col 30}{...}
+tabulate stored estimation sets; {it:namelist} is
+{col 32}a name, a list of names, or {cmd:_all}; the {cmd:*} and
+{col 32}{cmd:?} wildcards are allowed; a name may also be
+{col 32}{cmd:.}, meaning the current (active) estimates
+
+    {cmdab:m:atrix:(}{it:name}[{cmd:,} {it:subopts}]{cmd:)}{col 30}{...}
+tabulate matrix {it:name}
+    {cmd:e(}{it:name}[{cmd:,} {it:subopts}]{cmd:)}{col 30}{...}
+tabulate matrix {cmd:e(}{it:name}{cmd:)}
+    {cmd:r(}{it:name}[{cmd:,} {it:subopts}]{cmd:)}{col 30}{...}
+tabulate matrix {cmd:r(}{it:name}{cmd:)}
+      {it:subopts}:
+        {helpb estout##mfmt:{ul:f}mt}{cmd:(}{it:fmtlist}{cmd:)}{col 30}{...}
+set the display format(s)
+        {helpb estout##mtranspose:{ul:t}ranspose}{col 30}{...}
+tabulate transposed matrix
+    {hline 70}
+
+{marker opt0}
+    {it:options}{col 38}description
+    {hline 70}
+    Parameter statistics
+      {helpb estout##cells:{ul:c}ells}{cmd:(}{it:elements and subopts}{cmd:)}{col 38}{...}
+contents of the table cells, where
+{col 40}an {it:element}'s {it:subopts} are in paren-
+{col 40}theses, i.e. {it:element}[{cmd:(}{it:subopts}{cmd:)}]
+          {it:elements}:
+          {cmd:b}{col 38}raw coefficient (point estimate)
+          {cmd:se}{col 38}standard error
+          {cmd:var}{col 38}variance
+          {cmd:t}{col 38}t or z statistic
+          {cmd:z}{col 38}t or z statistic (synonym for {cmd:t})
+          {cmd:p}{col 38}p-value
+          {cmd:ci}{col 38}confidence interval
+          {cmd:ci_l}{col 38}lower bound of confidence interval
+          {cmd:ci_u}{col 38}upper bound of confidence interval
+          {cmd:_star}{col 38}"significance stars"
+          {cmd:_sign}{col 38}sign of point estimate
+          {cmd:_sigsign}{col 38}sign and significance of estimate
+          {cmd:.}{col 38}null element (empty cell)
+          {cmd:&}{col 38}combine elements in single cell
+          {it:myel}{col 38}results from {cmd:e(}{it:myel}{cmd:)}
+          {it:myel}{cmd:[}{it:#}{cmd:]}{col 38}results from row {it:#} in {cmd:e(}{it:myel}{cmd:)}
+          {it:myel}{cmd:[}{it:rowname}{cmd:]}{col 38}results from row {it:rowname} in {cmd:e(}{it:myel}{cmd:)}
+
+
+          {it:subopts} (for each {it:element},
+                except for {cmd:.} and {cmd:&}):
+          [{cmdab:no:}]{helpb estout##cstar:{ul:s}tar}{col 38}{...}
+attach "significance stars"
+          {helpb estout##cfmt:{ul:f}mt}{cmd:(}{it:{help estout##fmt:fmt}} [{it:{help estout##fmt:fmt}} ...]{cmd:)}{col 38}{...}
+set the display format(s)
+          {helpb estout##clabel:{ul:l}abel}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+define a label for {it:element}
+          {helpb estout##cpar:par}[{cmd:(}{it:l} {it:r}{cmd:)}] | {cmd:nopar}{col 38}{...}
+place results in parentheses
+          {helpb estout##cvacant:{ul:v}acant}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+print {it:string} if coefficient is absent
+          {helpb estout##cdrop:{ul:d}rop}{cmd:(}{it:droplist}{cmd:)}{col 38}{...}
+drop certain individual results
+          {helpb estout##ckeep:{ul:k}eep}{cmd:(}{it:keeplist}{cmd:)}{col 38}{...}
+keep certain individual results
+          {helpb estout##cpattern:{ul:pat}tern}{cmd:(}{it:pattern}{cmd:)}{col 38}{...}
+model selection
+          {helpb estout##cpvalue:{ul:pval}ue}{cmd:(}{it:name}{cmd:)}{col 38}{...}
+set p-values for {cmd:star} (default: {cmd:p})
+          [{cmd:no}]{helpb estout##cabs:abs}{col 38}{...}
+use absolute t-statistics
+          [{cmdab:no:}]{helpb estout##ctranspose:{ul:t}ranspose}{col 38}{...}
+transpose {cmd:e(}{it:myel}{cmd:)} for tabulation
+
+      {helpb estout##drop:{ul:d}rop}{cmd:(}{it:droplist}{cmd:)}{col 38}{...}
+drop individual coefficients
+      [{cmdab:no:}]{helpb estout##omitted:{ul:omit}ted}{col 38}{...}
+include omitted coefficients
+      [{cmdab:no:}]{helpb estout##baselevels:{ul:base}levels}{col 38}{...}
+include base levels
+      {helpb estout##keep:{ul:k}eep}{cmd:(}{it:keeplist}{cmd:)}{col 38}{...}
+keep individual coefficients
+      {helpb estout##order:{ul:o}rder}{cmd:(}{it:orderlist}{cmd:)}{col 38}{...}
+change order of coefficients
+      {helpb estout##indicate:{ul:i}ndicate}{cmd:(}{it:groups} [{cmd:,} {it:subopt}]{cmd:)}{col 38}{...}
+indicate presence of parameters
+        {it:subopt}: {cmdab:l:abels(}{it:yes} {it:no}{cmd:)}{col 38}{...}
+redefine "Yes" and "No" labels
+      {helpb estout##rename:{ul:ren}ame}{cmd:(}{it:old} {it:new} [{it:old} {it:new} ...]{cmd:)}{col 38}{...}
+rename individual coefficients
+      {helpb estout##equations:{ul:eq}uations}{cmd:(}{it:eqmatchlist}{cmd:)}{col 38}{...}
+match the models' equations
+      {helpb estout##eform:eform}[{cmd:(}{it:pattern}{cmd:)}] | {cmd:noeform}{col 38}{...}
+report exponentiated coefficients
+      {helpb estout##transform:{ul:tr}ansform}{cmd:(}{it:list} [{cmd:,} {it:subopt}]{cmd:)}{col 38}{...}
+apply transformations to coefficients
+        {it:subopt}: {cmdab:p:attern:(}{it:pattern}{cmd:)}]{cmd:)}{col 38}{...}
+select models
+      {helpb estout##margin:{ul:m}argin}[{cmd:(}{cmd:u}|{cmd:c}|{cmd:p}{cmd:)}] | {cmdab:nom:argin}{col 38}{...}
+report marginal effects after {helpb mfx}
+      {helpb estout##discrete:{ul:di}screte}{cmd:(}{it:string}{cmd:)} | {cmdab:nodi:screte}{col 38}{...}
+identify 0/1 variables (if {cmd:margin})
+      {helpb estout##meqs:{ul:meq}s}{cmd:(}{it:eq_list}{cmd:)}{col 38}{...}
+select equations for marginal effects
+      {helpb estout##dropped:dropped}[{cmd:(}{it:string}{cmd:)}] | {cmd:nodropped}{col 38}{...}
+indicate null coefficients as dropped
+      {helpb estout##level:level}{cmd:(}{it:#}{cmd:)}{col 38}{...}
+set level for confidence intervals
+
+    Summary statistics
+      {helpb estout##stats:{ul:s}tats}{cmd:(}{it:scalarlist}[{cmd:,} {it:subopts}]{cmd:)}{col 38}{...}
+display summary statistics at the
+{col 38}bottom of the table
+        {it:subopts}:
+          {helpb estout##statsfmt:{ul:f}mt}{cmd:(}{it:{help estout##fmt:fmt}} [{it:{help estout##fmt:fmt}} ...]{cmd:)}{col 38}{...}
+set the display formats
+          {helpb estout##statslabels:{ul:l}abels}{cmd:(}{it:strlist}[{cmd:,} {col 38}{...}
+label the summary statistics
+             {it:{help estout##lsub0:label_subopts}}]{cmd:)}
+          {helpb estout##statsstar:{ul:s}tar}[{cmd:(}{it:sca'list}{cmd:)}] | {cmdab:nos:tar}{col 38}{...}
+denote the model significance
+          {helpb estout##statslayout:{ul:lay}out}{cmd:(}{it:array}{cmd:)}{col 38}{...}
+arrange the summary statistics
+          {helpb estout##statspchar:{ul:pc}har}{cmd:(}{it:symbol}{cmd:)}{col 38}{...}
+placeholder in {cmdab:layout()}; default is {cmd:@}
+
+    Significance stars
+      {helpb estout##starlevels:{ul:starl}evels}{cmd:(}{it:levelslist}{cmd:)}{col 38}{...}
+define thresholds and symbols,
+{col 40}where '{it:levelslist}' is '{it:symbol} {it:#}
+{col 40}[{it:symbol} {it:#} ...]' with {it:#} in (0,1] and
+{col 40}listed in descending order
+      {helpb estout##stardrop:{ul:stard}rop}{cmd:(}{it:droplist}{cmd:)}{col 38}{...}
+drop stars for individual coefs
+      {helpb estout##starkeep:{ul:stark}eep}{cmd:(}{it:keeplist}{cmd:)}{col 38}{...}
+keep stars for individual coefs
+      [{cmdab:no:}]{helpb estout##stardetach:{ul:stard}etach}{col 38}{...}
+display the stars in their own column
+
+    Layout
+      {helpb estout##varwidth:{ul:var}width}{cmd:(}{it:#}{cmd:)}{col 38}{...}
+set width of the table's left stub
+      {helpb estout##modelwidth:{ul:model}width}{cmd:(}{it:#} [{it:#} ...]{cmd:)}{col 38}{...}
+set width of the results columns
+      [{cmdab:no:}]{helpb estout##unstack:{ul:uns}tack}{col 38}{...}
+place equations from multiple-
+{col 40}equation models in separate columns
+      {helpb estout##begin:{ul:beg}in}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify the beginning of the rows
+      {helpb estout##delimiter:{ul:del}imiter}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify the column delimiter
+      {helpb estout##end:end}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify the ending of the table rows
+      {helpb estout##incelldel:{ul:incell}delimiter}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify delimiter within cell
+      {helpb estout##dmarker:{ul:dm}arker}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+define the decimal marker
+      {helpb estout##msign:{ul:ms}ign}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+define the minus sign
+      [{cmd:no}]{helpb estout##lz:lz}{col 38}{...}
+print the leading zero of fixed
+{col 40}format numbers in (-1,1)
+      {helpb estout##extracols:{ul:extra}cols}{cmd:(}{it:numlist}{cmd:)}{col 38}{...}
+add empty column to the table
+      {helpb estout##substitute:{ul:sub}stitute}{cmd:(}{it:subst}{cmd:)}{col 38}{...}
+apply end-of-pipe substitutions, where
+{col 40}'{it:subst}' is '{it:from} {it:to} [{it:from} {it:to} ... ]'
+
+    Labeling
+      [{cmdab:no:}]{helpb estout##label:{ul:l}abel}{col 38}{...}
+make use of variable labels
+      [{cmdab:no:}]{helpb estout##abbrev:{ul:ab}brev}{col 38}{...}
+abbreviate long names and labels
+      [{cmdab:no:}]{helpb estout##wrap:wrap}{col 38}{...}
+wrap long labels (if space permits)
+      {helpb estout##interaction:{ul:interact}ion}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify interaction operator
+      {helpb estout##title:{ul:ti}tle}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify a title for the table
+      {helpb estout##note:note}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify a note for the table
+      [{cmdab:no:}]{helpb estout##legend:{ul:le}gend}{col 38}{...}
+add a significance symbols legend
+      {helpb estout##prehead:{ul:preh}ead}{cmd:(}{it:strlist}{cmd:)}{col 38}{...}
+add text before the table heading
+      {helpb estout##prehead:{ul:posth}ead}{cmd:(}{it:strlist}{cmd:)}{col 38}{...}
+add text after the table heading
+      {helpb estout##prehead:{ul:pref}oot}{cmd:(}{it:strlist}{cmd:)}{col 38}{...}
+add text before the table footer
+      {helpb estout##prehead:{ul:postf}oot}{cmd:(}{it:strlist}{cmd:)}{col 38}{...}
+add text after the table footer
+      {helpb estout##hlinechar:{ul:hl}inechar}{cmd:(}{it:string}{cmd:)}{col 38}{...}
+specify look of {cmd:@hline}
+      {helpb estout##varlabels:{ul:varl}abels}{cmd:(}{it:matchlist}[{cmd:,} {it:sub.}]{cmd:)} {col 38}{...}
+relabel the parameters
+        {it:subopts}:
+          {cmdab:bl:ist:(}{it:matchlist}{cmd:)}{col 38}{...}
+assign prefixes to certain rows
+          {cmdab:el:ist:(}{it:matchlist}{cmd:)}{col 38}{...}
+assign suffixes to certain rows
+          {it:{help estout##lsub0:label_subopts}}
+      {helpb estout##labcol2:{ul:labcol}2}{cmd:(}{it:strlist}[{cmd:,} {it:subopts}]{cmd:)} {col 38}{...}
+add a second labeling column
+        {it:subopts}:
+          {cmdab:t:itle:(}{it:strlist}{cmd:)}{col 38}{...}
+add column title in table header
+          {cmdab:w:idth:(}{it:#}{cmd:)}{col 38}{...}
+set width of column
+      {helpb estout##refcat:{ul:ref}cat}{cmd:(}{it:matchlist}[{cmd:,} {it:subopts}]{cmd:)} {col 38}{...}
+add reference category information
+        {it:subopts}:
+          {cmdab:l:abel:(}{it:string}{cmd:)} | {cmdab:nol:abel}{col 38}{...}
+redefine the "ref." label
+          {cmdab:b:elow}{col 38}{...}
+change positioning of refcat
+      {helpb estout##mlabels:{ul:ml}abels}{cmd:(}{it:strlist}[{cmd:,} {it:subopts}]{cmd:)}{col 38}{...}
+label the models
+        {it:subopts}:
+          [{cmdab:no:}]{cmdab:dep:vars}{col 38}{...}
+use the name/label of the dependent
+{col 42}variable as model label
+          [{cmdab:no:}]{cmdab:ti:tles}{col 38}{...}
+use estimates title as model label
+          [{cmdab:no:}]{cmdab:num:bers}{col 38}{...}
+number models labels consecutively
+          {it:{help estout##lsub0:label_subopts}}
+      {helpb estout##collabels:{ul:coll}abels}{cmd:(}{it:strlist}[{cmd:,} {col 38}{...}
+label the columns within models
+        {it:{help estout##lsub0:label_subopts}}]{cmd:)}
+      {helpb estout##eqlabels:{ul:eql}abels}{cmd:(}{it:strlist}[{cmd:,} {it:subopts}]{cmd:)}{col 38}{...}
+label the equations
+        {it:subopts}:
+          [{cmdab:no:}]{cmdab:m:erge}{col 38}{...}
+merge equation and parameter labels
+          {it:{help estout##lsub0:label_subopts}}
+      {helpb estout##mgroups:{ul:mgr}oups}{cmd:(}{it:strlist}[{cmd:,} {it:subopts}]{cmd:)}{col 38}{...}
+define and label groups of models
+        {it:subopts}:
+          {cmdab:pat:tern:(}{it:pattern}{cmd:)}{col 38}{...}
+define the grouping of the models
+          {it:{help estout##lsub0:label_subopts}}
+      {helpb estout##numbers:{ul:num}bers}[{cmd:(}{it:l} {it:r}{cmd:)}] | {cmdab:nonum:bers}{col 38}{...}
+add a row containing model numbers
+
+    Output
+      [{cmdab:no:}]{helpb estout##replace:{ul:r}eplace}{col 38}{...}
+overwrite an existing file
+      [{cmdab:no:}]{helpb estout##append:{ul:a}ppend}{col 38}{...}
+append the output to an existing file
+      [{cmdab:no:}]{helpb estout##type:{ul:ty}pe}{col 38}{...}
+print the table in the results window
+      [{cmd:no}]{helpb estout##showtabs:showtabs}{col 38}{...}
+display tabs as {cmd:<T>}s
+      {helpb estout##topfile:{ul:top}file}{cmd:(}{it:filename}{cmd:)}{col 38}{...}
+insert file contents above table
+      {helpb estout##topfile:{ul:bot}tomfile}{cmd:(}{it:filename}{cmd:)}{col 38}{...}
+insert file contents below table
+
+    Defaults
+      {helpb estout##style:{ul:sty}le}{cmd:(}{it:style}{cmd:)}{col 38}{...}
+specify a style for the output table
+
+        {it:styles}:
+          {cmd:smcl}{col 38}SMCL formatted table (screen default)
+          {cmd:tab}{col 38}tab delimited table (export default)
+          {cmd:fixed}{col 38}fixed format table
+          {cmd:tex}{col 38}table for use with LaTeX
+          {cmd:html}{col 38}table for use with HTML
+          {it:mystyle}{col 38}user defined addition
+    {hline 70}
+
+{marker lsub0}
+    {it:{help estout##lsub:label_subopts}}{col 38}Description
+    {hline 70}
+      [{cmd:no}]{cmd:none}{col 38}{...}
+suppress the labels
+      {cmdab:p:refix:(}{it:string}{cmd:)}{col 38}{...}
+add a common prefix
+      {cmdab:s:uffix:(}{it:string}{cmd:)}{col 38}{...}
+add a common suffix
+      {cmdab:b:egin:(}{it:strlist}{cmd:)}{col 38}{...}
+add an overall prefix
+      [{cmdab:no:}]{cmdab:f:irst}{col 38}{...}
+print the first occurrence of {cmd:begin()}
+      {cmdab:e:nd:(}{it:strlist}{cmd:)}{col 38}{...}
+add an overall suffix
+      [{cmdab:no:}]{cmdab:l:ast}{col 38}{...}
+print the last occurrence of {cmd:end()}
+      {cmdab:r:eplace}{col 38}{...}
+replace global {cmd:begin()}/{cmd:end()}
+      [{cmd:no}]{cmd:span}{col 38}{...}
+span columns if appropriate
+      {cmdab:er:epeat:(}{it:string}{cmd:)}{col 38}{...}
+add a "span" suffix
+      {cmd:lhs(}{it:string}{cmd:)}{col 38}{...}
+label the table's left stub
+    {hline 70}
+
+{marker des}
+{title:Description}
+
+{p 4 4 2}
+    {cmd:estout} assembles a table of coefficients, "significance
+    stars", summary statistics, standard errors, t- or z-statistics, p-values,
+    confidence intervals, and other statistics for one or more models
+    previously fitted and stored by {helpb estimates store} or {helpb eststo}.
+    It then displays the table in Stata's results window or writes it to a text
+    file specified by {cmd:using}. The default is to use {help smcl:SMCL}
+    formatting tags and horizontal lines to structure the table. However,
+    if {cmd:using} is specified, a tab-delimited table without lines
+    is produced.
+
+{p 4 4 2}
+    {it:namelist} provides the names of the stored estimation
+    sets to be tabulated. You may use the {cmd:*} and {cmd:?} wildcards in
+    {it:namelist}. The results estimated last may be indicated by a period
+    ({cmd:.}), even if they have not yet been stored. If no model is
+    specified, {cmd:estout} tabulates the estimation sets stored by
+    {cmd:eststo} (see help {helpb eststo}) or, if no such estimates are
+    present, the currently active estimates (i.e. the model fit last).
+    {cmd:estout} may be used after any estimation command that
+    returns its results in {cmd:e()}.
+
+{p 4 4 2}
+    See the {help estout##intro:Introduction} in the
+    {help estout##exa:Examples} section for an introduction on using
+    {cmd:estout}. See help {helpb estimates} for general information
+    about managing estimation results. Furthermore, see help {helpb eststo}
+    for an alternative to the {cmd:estimates store} command.
+
+{p 4 4 2}
+    The default for {cmd:estout} is to produce a plain
+    table containing point estimates. Producing a fully formatted
+    end-product may involve specifying many options. However, note that a
+    simple-to-use {cmd:estout} wrapper producing pre-formatted
+    publication style tables is available as {helpb esttab}. Furthermore,
+    use {helpb estadd} to make additional results available for
+    tabulation (such as the standardized coefficients or the means and
+    standard deviations of the regressors) and {helpb estpost} to
+    tabulate results from non-estimation commands such as {helpb summarize}
+    or {helpb tabulate}.
+
+{p 4 4 2}
+    {cmd:estout} can also be used to tabulate the contents of a Stata
+    matrix (see help {helpb matrix}). Type {cmd:estout marix(}{it:name}{cmd:)},
+    where {it:name} is the name of the matrix, instead of providing a
+    {it:namelist} of stored estimation sets. See the
+    {help estout##ex7:examples} below. Alternatively, you may also specify
+    {cmd:e(}{it:name}{cmd:)} or {cmd:r(}{it:name}{cmd:)} to tabulate an
+    {cmd:e()}-matrix or an {cmd:r()}-matrix. The {cmd:cells()} option is
+    disabled if tabulating a matrix.
+
+{p 4 4 2}
+    Programms similar to {cmd:estout} include {cmd:outreg} by John Luke
+    Gallup, {cmd:outreg2} by Roy Wada, {cmd:modltbl} by John H. Tyler,
+    {cmd:mktab} by Nicholas Winter, {cmd:outtex} by Antoine Terracol, or
+    {cmd:est2tex} by Marc Muendler. Also see Newson (2003) for a very
+    appealing approach.
+
+{marker opt}
+{title:Options}
+
+    Contents
+
+        {help estout##par:Parameter statistics}
+        {help estout##sum:Summary statistics}
+        {help estout##sig:Significance stars}
+        {help estout##lay:Layout}
+        {help estout##lab:Labeling}
+        {help estout##out:Output}
+        {help estout##def:Defaults}
+        {it:{help estout##lsub:label_subopts}}
+        {it:{help estout##msub:matrix_subopts}}
+{marker par}
+{dlgtab:Parameter statistics}
+{marker cells}
+{p 4 8 2}
+    {cmd:cells(}{it:array}{cmd:)} specifies the parameter statistics to be
+    reported and how they are to be arranged. The default is for cells to
+    report point estimates only, i.e. {cmd:cells(b)}. {cmd:cells(none)} may
+    be used to completely suppress the printing of parameter statistics.
+    Alternatively, {cmd:cells(b se)} would result in the reporting of point
+    estimates and standard errors. Multiple statistics are placed in
+    separate rows beneath one another by default. However, elements of
+    {it:array} that are listed in quotes or in parentheses, e.g.
+    {bind:{cmd:"b se"}} or {bind:{cmd:`"b se"'}} or {bind:{cmd:(b se)}},
+    are placed beside one another. For example, {bind:{cmd:cells("b p" se)}}
+    or, equivalently, {bind:{cmd:cells((b p) se)}} would produce a
+    table with point estimates and p-values beside one another in first row
+    and standard errors in the second row beneath the point estimates.
+
+{p 8 8 2}
+    The parameter statistics available are {cmd:b} (point estimates),
+    {cmd:se} (standard errors), {cmd:var} (variance), {cmd:t}
+    (t/z-statistics), {cmd:z} (synonym for {cmd:t}), {cmd:p} (p-values), and
+    {cmd:ci} (confidence
+    intervals; to display the lower and upper bounds in separate cells use
+    {cmd:ci_l} and {cmd:ci_u}). Any additional parameter statistics
+    included in the {cmd:e()}-returns for the models can be tabulated as
+    well. If, for example, {cmd:e(beta)} contains the standardized
+    coefficients, type {cmd:cells(beta)} to tabulate them (use
+    {helpb estadd} to add statistics such as the standardized coefficients to the
+    {cmd:e()}-returns of a model). The syntax {it:name}{cmd:[}{it:#}{cmd:]}
+    or {it:name}{cmd:[}{it:rowname}{cmd:]} can be used to refer to specific
+    rows in {cmd:e(}{it:name}{cmd:)}. For example, type {cmd:cell(ci_bc[1] ci_bc[2])}
+    or {cmd:cell(ci_bc[ll] ci_bc[ul])} to tabulate the lower and upper
+    bounds of the bias-corrected confidence intervals after {helpb bootstrap}.
+    The default is to report the results from the first row.
+    Also see the {cmd:eform} and {cmd:transform()} options for more information
+    on the kinds of statistics that can be displayed.
+
+{p 8 8 2}
+    Further available elements in {it:array} are {cmd:_star},
+    {cmd:_sign}, and {cmd:_sigsign}. {cmd:_star} causes stars denoting the
+    significance of the coefficients to be printed (* for p<.05, ** for p<.01,
+    and *** for p<.001; customizable via the {cmd:starlevels()} option below).
+    {cmd:_star} places the significance stars in their own cells. See the
+    {cmd:star} suboption below if you want to attach the stars to another
+    element. {cmd:_sign} prints the signs of the coefficients ("+", "-", or
+    "0"). {cmd:_sigsign}, a combination of {cmd:_star} and {cmd:_sign}, repeats
+    the signs of the coefficients where the number of repetitions reflects the
+    level of significance (non-significant coefficients are left empty;
+    however, you may set the first level to 1 in the {cmd:starlevels()}
+    option).
+
+{p 8 8 2}
+    Finally, {cmd:.} and {cmd:&} may be used in {it:array}. {cmd:.} inserts a
+    "null" element. Use this to add empty cells. For example,
+    {cmd:cells("b p" ". se")} would produce a table with point estimates in the
+    first column and p-values and standard errors beneath one another in the
+    second column. {cmd:&} is used to combine elements in the same cell. Use
+    the {helpb estout##incelldel:incelldelimiter()} option to specify the text to
+    be printed between the combined elements (the default is to print a
+    single blank). For example, in HTML, use {cmd:cell(b & se)} and
+    {cmd:incelldelimiter(<br>)} to include point estimates and standard
+    errors in a single cell and insert a line break between them.
+
+{p 8 8 2}
+    A set of suboptions may be specified in parentheses for each
+    element named in {it:array} (except for {cmd:.} and {cmd:&}). For example,
+    to add significance stars to the coefficients and place the standard errors
+    in parentheses, specify {bind:{cmd:cells(b(star) se(par))}}. The following
+    suboptions are available. Use:
+    {p_end}
+{marker cstar}
+{p 12 16 2}
+        {cmd:star} to specify that stars denoting the significance of the
+        coefficients be attached to the statistic: {cmd:*} for p<.05,
+        {cmd:**} for p<.01, and {cmd:***} for p<.001. The symbols and the
+        values for the thresholds and the number of levels are fully customizable
+        (see the {help estout##sig:Significance stars} options).
+        {p_end}
+{marker cfmt}
+{p 12 16 2}
+        {cmd:fmt(}{it:{help estout##fmt:fmt}} [{it:{help estout##fmt:fmt}} ...]{cmd:)}
+        to specify the display format(s) of a statistic. It
+        defaults to {cmd:%9.0g} or the format for the first statistic in
+        {cmd:cells()}. If only one format is specified, it is used for all
+        occurrences of the statistic. For example, type
+
+{p 20 20 2}
+            {inp:. estout} {it:...}{inp:, cells("b(fmt(3)) t(fmt(2))")}
+
+{p 16 16 2}
+        to print coefficients and t-values beside one another using three
+        decimal places for coefficients and two decimal places for
+        t-values. If multiple formats are specified, the first format is
+        used for the first regressor in the estimates table, the second
+        format for the second regressor, and so on. The last format is used
+        for the remaining regressors if the number of regressors in the
+        table is greater than the number of specified formats.  For
+        instance, type
+
+{p 20 20 2}
+            {inp:. estout} {it:...}{inp:, cells(b(fmt(3 4 2)))}
+
+{p 16 16 2}
+        to use three decimal places for the first coefficient, four decimal
+        places for the second, and two decimal places for all remaining
+        coefficients. Note that, regardless of the display format chosen,
+        leading and trailing blanks are removed from the numbers. White
+        space can be added by specifying a {cmd:modelwidth()} (see the
+        {help estout##lay:Layout} options). {it:{help estout##fmt:fmt}} may
+        be any of Stata's numerical display formats, e.g., {cmd:%9.0g} or
+        {cmd:%8.2f}, an integer {it:#} such as {cmd:1} or {cmd:3} to use a
+        fixed format with {it:#} decimal places, or {cmd:a}{it:#} such as
+        {cmd:a1} or {cmd:a3} to use {cmd:estout}'s adaptive display format
+        (see {help estout##fmt:Numerical formats} in the
+        {help estout##rem:Remarks} section for details).
+        {p_end}
+{marker clabel}
+{p 12 16 2}
+        {cmd:label(}{it:string}{cmd:)} to specify a label to appear in the
+        column heading. The default is the name of the statistic.
+        {p_end}
+{marker cpar}
+{p 12 16 2}
+        {cmd:par}[{cmd:(}{it:l} {it:r}{cmd:)}] to specify that the
+        statistic in question be placed in parentheses. It is also possible
+        to specify custom "parentheses". For example, {cmd:se(par({ }))}
+        would display the standard errors in curly brackets. Or,
+        {cmd:se(par(`"="("' `")""'))} will write parentheses in a way that
+        Excel can recognize. For {cmd:ci} the syntax is:
+
+{p 20 20 2}
+            {cmd:ci(par}[{cmd:(}{it:l} {it:m} {it:r}{cmd:)}]{cmd:)}
+        {p_end}
+{marker cvacant}
+{p 12 16 2}
+        {cmd:vacant(}{it:string}{cmd:)} to print {it:string} if a
+        coefficient is not in the model. The default is to leave such cells
+        empty.
+        {p_end}
+{marker cdrop}
+{p 12 16 2}
+        {cmd:drop(}{it:droplist} [{cmd:, relax}]{cmd:)} to cause certain
+        individual statistics to be dropped. For example, specifying
+        {cmd:t(drop(_cons))} suppresses the t-statistics for the constants.
+        {it:droplist} is specified as in the global
+        {helpb estout##drop:drop()} option (see below).
+        {p_end}
+{marker ckeep}
+{p 12 16 2}
+        {cmd:keep(}{it:keeplist} [{cmd:, relax}]{cmd:)} to cause certain
+        individual statistics to be kept. For example, the specification
+        {cmd:t(keep(mpg))} would display the t-statistics exclusively for
+        the variable {cmd:mpg}. {it:keeplist} is specified analogous to
+        {it:droplist} in {helpb estout##drop:drop()} (see below).
+        {p_end}
+{marker cpattern}
+{p 12 16 2}
+        {cmd:pattern(}{it:pattern}{cmd:)} to designate a pattern of models
+        for which the statistics are to be reported, where the {it:pattern}
+        consists of zeros and ones. A {cmd:1} indicates that the statistic
+        be printed; {cmd:0} indicates that it be suppressed. For example
+        {cmd:beta(pattern(1 0 1))} would result in {cmd:beta} being
+        reported for the first and third models, but not for the second.
+        {p_end}
+{marker cpvalue}
+{p 12 16 2}
+        {cmd:pvalue(}{it:name}{cmd:)} to specify the p-values used to
+        determine the significance stars (see {cmd:star} above). The
+        default is {cmd:pvalue(p)}, indicating that the standard p-values
+        are to be used (i.e. the p-values computed form the coefficients
+        vector and the variance matrix). Alternatively, specify
+        {cmd:pvalue(}{it:mypvalue}{cmd:)}, in which case the significance
+        stars will be determined from the values in
+        {cmd:e(}{it:mypvalue}{cmd:)}. Values outside [0,1] will be ignored.
+        {p_end}
+{marker cabs}
+{p 12 16 2}
+        {cmd:abs} to specify that absolute t-statistics be used instead of
+        regular t-statistics (relevant only if used with {cmd:t()}).
+        {p_end}
+{marker ctranspose}
+{p 12 16 2}
+        {cmd:transpose} to specify that {cmd:e(}{it:myel}{cmd:)} be transposed
+        for tabulation.
+        {p_end}
+{marker drop}
+{p 4 8 2}
+    {cmd:drop(}{it:droplist} [{cmd:, relax}]{cmd:)} identifies the coefficients
+    to be dropped from the table. A {it:droplist} comprises one or more
+    specifications, separated by white space. A specification can be either a
+    parameter name (e.g. {cmd:price}), an equation name followed by a colon
+    (e.g. {cmd:mean:}), or a full name (e.g. {cmd:mean:price}). You may use the
+    {cmd:*} and {cmd:?} wildcards in equation names and parameter names. Be sure
+    to refer to the matched equation names, and not to the original equation names
+    in the models, when using the {cmd:equations()} option to match equations.
+    Specify the {cmd:relax} suboption to allow {it:droplist} to contain elements
+    for which no match can be found.
+    {p_end}
+{marker omitted}
+{p 4 8 2}
+    {cmd:omitted} includes omitted coefficients (only relevant in Stata 11 or 
+    newer). This is the default. Type {cmd:noomitted} to drop omitted 
+    coefficients.
+    {p_end}
+{marker baselevels}
+{p 4 8 2}
+    {cmd:baselevels} includes base levels of factor variables (only relevant 
+    in Stata 11 or newer). This is the default. Type {cmd:nobaselevels} to drop 
+    base levels of factor variables.
+    {p_end}
+{marker keep}
+{p 4 8 2}
+    {cmd:keep(}{it:keeplist} [{cmd:, relax}]{cmd:)} selects the coefficients to
+    be included in the table. {it:keeplist} is specified analogous to {it:droplist} in
+    {helpb estout##drop:drop()} (see above). Note that {cmd:keep()} does {it:not} change the
+    the order of the coefficients. Use {cmd:order()} to change the order
+    of coefficients.
+    {p_end}
+{marker order}
+{p 4 8 2}
+    {cmd:order(}{it:orderlist}{cmd:)} changes the order of the
+    coefficients and equations within the table. {it:orderlist} is specified
+    analogous to {it:droplist} in {cmd:drop()} (see above). Reordering of
+    coefficients is performed equation by equation, unless equations are
+    explicitly specified. Coefficients and equations that do not appear in
+    {it:orderlist} are placed last (in their original order). Extra table rows
+    are inserted for elements in {it:orderlist} that are not found in the
+    table.
+    {p_end}
+{marker indicate}
+{p 4 8 2}
+    {cmd:indicate(}{it:groups} [{cmd:,} {cmdab:l:abels(}{it:yes}
+    {it:no}{cmd:)}]{cmd:)} indicates for each model (or, if {cmd:unstack}
+    is specified, for each equation) the presence of certain groups of
+    coefficients at the end of the table body. The syntax for {it:groups}
+    is
+
+            "{it:group}" [ "{it:group}" {it:...} ]
+
+{p 8 8 2}
+    where a {it:group} is
+
+            [{it:name} = ] {it:list}
+
+{p 8 8 2}
+    and {it:list} is a list of coefficient specifications as defined in
+    {cmd:drop()} above. The single groups should be enclosed in quotes
+    unless there is only one group and {it:name} is specified. Note that 
+    {it:name} may contain spaces.
+
+{p 8 8 2}
+    For example, if some of the models contain a set of year
+    dummies, say {cmd:y1 y2 y3}, specify
+
+            {com}estout{txt} {it:...}{com}, indicate(year effects = y1 y2 y3){txt}
+
+{p 8 8 2}
+    to drop the dummies from the table and add a "year effects" row
+    containing "Yes" for models in which {it:at least one} of the dummies
+    is present, and "No" for the other models. Furthermore, if some models 
+    also contain a set of region dummies, say {cmd:reg_1} through 
+    {cmd:reg_17}, you could type
+    
+            {com}estout{txt} {it:...}{com}, indicate("years = y1 y2 y3" "regions = reg_*"){txt}
+
+{p 8 8 2}
+    Use the {cmd:labels()} suboption to redefine the indication labels to
+    be printed in the table. The default is {cmd:labels(Yes No)}. Use
+    quotes if the labels include spaces,
+    e.g. {bind:{cmd:labels("in model"  "not in model")}}.
+    {p_end}
+{marker rename}
+{p 4 8 2}
+    {cmd:rename(}{it:matchlist}{cmd:)} changes the names of individual
+    coefficients, where {it:matchlist} is
+
+{p 12 12 2}
+        {it:oldname} {it:newname} [{it:oldname} {it:newname} ...]
+
+{p 8 8 2}
+    {it:oldname} can be a parameter name (e.g. {cmd:price}) or a full
+    name including an equation specification (e.g. {cmd:mean:price})
+    (abbreviation and wildcards not allowed); {it:newname} is a name without
+    equation specification and must not already occur in a model's equation.
+    {cmd:rename()} is applied before matching the models and equations and can
+    therefore be used to merge different coefficients across models (or
+    equations if {cmd:unstack} is specified) into a single table row. See the
+    {cmd:varlabels()} option if you are interested in relabeling coefficients
+    after matching models and equations.
+    {p_end}
+{marker equations}
+{p 4 8 2}
+    {cmd:equations(}{it:matchlist}{cmd:)} specifies how the models' equations are
+    to be matched. The default is to match all first equations into one equation
+    (named {cmd:main}, if the equations have different names) and match the remaining
+    equations by name. Specify {cmd:equations("")} to match all equations by
+    name. Alternatively, specify {it:matchlist}, which has the syntax
+
+                {it:term} [{cmd:,} {it:term} ... ]
+
+{p 8 8 2}
+    where {it:term} is
+
+                [{it:eqname} {cmd:=}] {it:#}{cmd::}{it:#}...{cmd::}{it:#}{col 50}(syntax 1)
+
+                [{it:eqname} {cmd:=}] {it:#}{col 50}(syntax 2)
+
+{p 8 8 2}
+    In syntax 1, each {it:#} is a number or a period ({cmd:.}).  If a number, it
+    specifies the position of the equation in the corresponding model;
+    {cmd:1:3:1} would indicate that equation 1 in the first model matches equation
+    3 in the second, which matches equation 1 in the third.  A period indicates
+    that there is no corresponding equation in the model; {cmd:1:.:1} indicates
+    that equation 1 in the first matches equation 1 in the third.
+
+{p 8 8 2}
+    In syntax 2, you specify just one number, say, {cmd:1} or {cmd:2}, and that
+    is shorthand for {cmd:1:1}...{cmd::1} or {cmd:2:2}...{cmd::2}, meaning that
+    equation 1 matches across all models specified or that equation 2 matches
+    across all models specified.
+
+{p 8 8 2}
+    {it:eqname} is used to name the matched equations. If it is suppressed,
+    a name such as {cmd:#1} or {cmd:#2} etc. is used, depending on the position
+    of the {it:term}. For example, {cmd:equations(1)}
+    indicates that all first equations are to be matched into one equation
+    named {cmd:#1}. All equations not matched by position are
+    matched by name.
+    {p_end}
+{marker eform}
+{p 4 8 2}
+    {cmd:eform}[{cmd:(}{it:pattern}{cmd:)}] displays the coefficient table in
+    exponentiated form. The exponent of {cmd:b} is displayed in lieu of the
+    untransformed coefficient; standard errors and confidence intervals are
+    transformed as well. Specify a {it:pattern} if the exponentiation is to be
+    applied only for certain models. For instance, {cmd:eform(1 0 1)} would
+    transform the statistics for Models 1 and 3, but not for Model 2. Note that,
+    unlike {cmd:regress} and {cmd:estimates table}, {cmd:estout} in
+    eform-mode does not suppress the display of the intercept. To drop the
+    intercept in eform-mode, specify {cmd:drop(_cons)}. Note: {cmd:eform} is
+    implemented via the {cmd:transform()} option. If both options are specified,
+    {cmd:transform()} takes precedence over {cmd:eform}.
+    {p_end}
+{marker transform}
+{p 4 8 2}
+    {cmd:transform(}{it:list} [, {cmd:pattern(}{it:pattern}{cmd:)}]{cmd:)}
+    displays transformed coefficients, standard errors and
+    confidence intervals. {it:list} may be
+
+            {it:fx} {it:dfx}
+
+{p 8 8 2}
+    where {it:fx} is the transformation function and {it:dfx} is its first
+    derivative. {it:fx} is applied to coefficients and confidence
+    intervals, that is, {it:fx}({cmd:b}) and {it:fx}({cmd:ci}) is displayed
+    instead of {cmd:b} and {cmd:ci}. {it:dfx} is used to delta transform
+    standard errors, i.e. {cmd:se}*{it:dfx}({cmd:b}) is displayed instead
+    of {cmd:se}. Use {cmd:@} as a placeholder for the function's argument
+    in {it:fx} and {it:dfx}. For example, type
+
+            {com}estout{txt} {it:...}{com}, transform(exp(@) exp(@)){txt}
+
+{p 8 8 2}
+    to report exponentiated results (this is equivalent to specifying
+    the {cmd:eform} option).
+
+{p 8 8 2}
+    Alternatively, {it:list} may be specified as
+
+{p 12 12 2}
+        {it:coefs} {it:fx} {it:dfx} [ {it:...} [{it:coefs}] {it:fx} {it:dfx} ]
+
+{p 8 8 2}
+    where {it:coefs} identifies the coefficients
+    to be transformed. Syntax for {it:coefs} is as explained above in the
+    description of the {cmd:drop()} option (however, include {it:coefs}
+    in quotes if it contains multiple elements). Say, a model has
+    two equations, {cmd:price} and {cmd:select}, and you want to
+    exponentiate the {cmd:price} equation but not the {cmd:select}
+    equation. You could then type
+
+            {com}estout{txt} {it:...}{com}, transform(price: exp(@) exp(@)){txt}
+
+{p 8 8 2}
+    Note that omitting {it:coef} in the last transformation
+    specification causes the last transformation to be applied to
+    all remaining coefficients.
+
+{p 8 8 2}
+    Specify the {cmd:pattern()} suboption if the transformations are to be
+    applied only for certain models. For instance, {cmd:pattern(1 0 1)} would
+    apply the transformation to Models 1 and 3, but not Model 2.
+    {p_end}
+{marker margin}
+{p 4 8 2}
+    {cmd:margin}[{cmd:(}{cmd:u}|{cmd:c}|{cmd:p}{cmd:)}] indicates that the
+    marginal effects or elasticities be reported instead of the raw
+    coefficients. This option has an effect only if {cmd:mfx} has been
+    applied to a model before its results were stored (see help {helpb mfx}) or if a
+    {cmd:dprobit} (see help {helpb probit}), {cmd:truncreg,marginal}
+    (help {helpb truncreg}), or {cmd:dtobit} (Cong 2000) model is estimated. One
+    of the parameters {cmd:u}, {cmd:c}, or {cmd:p}, corresponding to the
+    unconditional, conditional, and probability marginal effects, respectively,
+    is required for {cmd:dtobit}. Note that the standard errors, confidence
+    intervals, t-statistics, and p-values are transformed as well.
+
+{p 8 8 2}
+    Using the {cmd:margin} option with multiple-equation models can be tricky.
+    The marginal effects of variables that are used in several equations are
+    printed repeatedly for each equation because the equations per se are
+    meaningless for {cmd:mfx}. To display the effects for certain equations only,
+    specify the {cmd:meqs()} option. Alternatively, use the {cmd:keep()} and
+    {cmd:drop()} options to eliminate redundant rows. The {cmd:equations()}
+    option might also be of help here.
+    
+{p 8 8 2}
+    As of Stata 11, the use of {helpb mfx} is no longer suggested, since 
+    {helpb mfx} has been superseded by {helpb margins}. Results from 
+    {helpb margins} can directly be tabulated by {cmd:estout} as long as
+    the {cmd:post} option is specified with {helpb margins}. Alternatively, 
+    you may add results from {helpb margins} to an existing 
+    model using {helpb estadd:estadd margins} or 
+    {helpb estpost:estpost margins}. See 
+    {browse "http://repec.sowi.unibe.ch/stata/estout/coefficients.html#002"} for
+    an example on tabulating results from {helpb margins}.
+    {p_end}
+{marker discrete}
+{p 4 8 2}
+    {cmd:discrete(}{it:string}{cmd:)} may be used to override the default symbol and
+    explanatory text used to identify dummy variables when applying the 
+    {helpb estout##margin:margin} option. The first token in {it:string} is 
+    used as the symbol. The default is:
+
+{p 12 12 2}
+        {inp:discrete(" (d)" for discrete change of dummy variable from 0 to 1)}
+
+{p 8 8 2}
+    To display explanatory text, specify either the {cmd:legend} option or use
+    the {cmd:@discrete} variable (see the
+    {help estout##atvar:Remarks on using @-variables}).
+
+{p 8 8 2}
+    Use {cmd:nodiscrete} to disable the identification of dummy variables as
+    such. The default is to indicate the dummy variables unless they have been
+    interpreted as continuous variables in all of the models for which results are
+    reported (for {cmd:dprobit} and {cmd:dtobit}, however, dummy variables will
+    always be listed as discrete variables unless {cmd:nodiscrete} is specified).
+    {p_end}
+{marker meqs}
+{p 4 8 2}
+    {cmd:meqs(}{it:eq_list}{cmd:)} specifies that marginal effects requested 
+    by the {helpb estout##margin:margin} option be printed only for the
+    equations in {it:eq_list}. Specifying this option does not affect how the
+    marginal effects are calculated.  An {it:eq_list} comprises one or more equation
+    names (without colons) separated by white space. If you use the
+    {cmd:equations()} option to match equations, be sure to refer to the matched
+    equation names and not to the original equation names in the models.
+    {p_end}
+{marker dropped}
+{p 4 8 2}
+    {cmd:dropped}[{cmd:(}{it:string}{cmd:)}] causes null coefficients
+    (coefficients for which {cmd:e(b)} and {cmd:e(V)} is zero) to be indicated
+    as dropped. {it:string} specifies the text to be printed in place of
+    the estimates. The default text is "(dropped)".
+    {p_end}
+{marker level}
+{p 4 8 2}
+    {cmd:level(}{it:#}{cmd:)} assigns the confidence level, in percent, for
+    the confidence intervals of the coefficients (see help {help level}).
+
+{marker sum}
+{dlgtab:Summary statistics}
+{marker stats}
+{p 4 8 2}
+    {cmd:stats(}{it:scalarlist}[{cmd:,} {it:stats_subopts}]{cmd:)} specifies
+    one or  more scalar statistics - separated by white space - to be displayed
+    at the bottom of the table. The {it:scalarlist} may contain numeric
+    {cmd:e()}-scalars such as, e.g., {cmd:N}, {cmd:r2}, or {cmd:chi2}, but also
+    string {cmd:e()}-macros such as {cmd:cmd} or {cmd:depvar}. In
+    addition, the following statistics are available:
+
+{p 12 24 2}
+        {cmd:aic}{space 5}Akaike's information criterion{p_end}
+{p 12 24 2}
+        {cmd:bic}{space 5}Schwarz's information criterion{p_end}
+{p 12 24 2}
+        {cmd:rank}{space 4}rank of {cmd:e(V)}, i.e. the number of free
+        parameters in model{p_end}
+{p 12 24 2}
+        {cmd:p}{space 7}the p-value of the model (overall model significance)
+
+{p 8 8 2}
+    See {bf:[R] estimates table} for details on the {cmd:aic} and {cmd:bic} statistics.
+    The rules for the determination of {cmd:p} are as follows (note that although
+    the procedure outlined below is appropriate for most models, there might be
+    some models for which it is not):
+
+{p 12 15 2}
+        1) p-value provided: If the {cmd:e(p)} scalar is provided by the
+        estimation command, it will be interpreted as indicating the p-value
+        of the model.
+
+{p 12 15 2}
+        2) F test: If {cmd:e(p)} is not provided, {cmd:estout} checks for the
+        presence of the {cmd:e(df_m)}, {cmd:e(df_r)}, and {cmd:e(F)}
+        scalars and, if they are present, the p-value of the model will be
+        calculated as {cmd:Ftail(df_m,df_r,F)}. This p-value corresponds to
+        the standard overall  F test of linear regression.
+
+{p 12 15 2}
+        3) chi2 test: Otherwise, if neither {cmd:e(p)} nor {cmd:e(F)} is
+        provided, {cmd:estout} checks for the presence of {cmd:e(df_m)} and
+        {cmd:e(chi2)} and, if they are present, calculates the p-value as
+        {cmd:chi2tail(df_m,chi2)}. This p-value corresponds to the
+        Likelihood-Ratio or Wald chi2 test.
+
+{p 12 15 2}
+        4) If neither {cmd:e(p)}, {cmd:e(F)}, nor {cmd:e(chi2)}
+        is available, no p-value will be reported.
+
+{p 8 8 2}
+    Type {cmd:ereturn list} after estimating a model to see a list of
+    the returned {cmd:e()}-scalars and macros (see help {helpb ereturn}). Use
+    the {helpb estadd} command to add extra statistics and
+    other information to the {cmd:e()}-returns.
+
+{p 8 8 2}
+    The following {it:stats_subopts} are available. Use:
+    {p_end}
+{marker statsfmt}
+{p 12 16 2}
+        {cmd:fmt(}{it:{help estout##fmt:fmt}} [{it:{help estout##fmt:fmt}} {it:...}]{cmd:)}
+        to set the display formats for the scalars statistics in {it:scalarlist}.
+        {it:{help estout##fmt:fmt}} may be any of Stata's numerical display
+        formats, e.g., {cmd:%9.0g} or {cmd:%8.2f}, an integer {it:#} such as
+        {cmd:1} or {cmd:3} to use a fixed format with {it:#} decimal places, or
+        {cmd:a}{it:#} such as {cmd:a1} or {cmd:a3} to use {cmd:estout}'s adaptive
+        display format (see {help estout##fmt:Numerical formats} in the {help
+        estout##rem:Remarks} section for details). For example, {cmd:fmt(3 0)}
+        would be suitable for {cmd:stats(r2_a N)}. Note that the last specified
+        format is used for the remaining scalars if the list of scalars is longer
+        than the list of formats. Thus, only one format needs to be specified if
+        all scalars are to be displayed in the same format. If no format is
+        specified, the default format is the display format of the coefficients.
+        {p_end}
+{marker statslabels}
+{p 12 16 2}
+        {cmd:labels(}{it:strlist}[{cmd:,} {it:{help estout##lsub:label_subopts}}]{cmd:)}
+        to specify labels for rows containing the scalar statistics. If
+        specified, the labels are used instead of the scalar names. For example:
+
+{p 20 20 2}
+            {inp:. estout} {it:...}{inp:, stats(r2_a N, labels("Adj. R-Square" "Number of Cases"))}
+
+{p 16 16 2}
+        Note that names like {cmd:r2_a} produce an error in LaTeX because the
+        underscore character has a special meaning in LaTeX (to print the
+        underscore in LaTeX, type {cmd:\_}). Use the {cmd:label()} suboption to
+        rename such statistics, e.g. {cmd:stats(r2_a, labels(r2\_a))}. An alternative
+        approach is to use {cmd:estout}'s {cmd:substitute()} option (see the
+        {help estout##lay:Layout} options).
+        {p_end}
+{marker statsstar}
+{p 12 16 2}
+        {cmd:star}[{cmd:(}{it:scalarlist}{cmd:)}] to specify that the overall
+        significance of the model be denoted by stars. The stars are attached to
+        the scalar statistics specified in {it:scalarlist}. If
+        {it:scalarlist} is omitted, the stars are attached to the first
+        reported scalar statistic. The printing of the stars is suppressed in
+        empty results cells (i.e. if the scalar statistic in question is missing
+        for a certain model). The determination of the model significance is
+        based on the p-value of the model (see above).
+
+{p 16 16 2}
+        Hint: It is possible to attach the stars to different scalar statistics
+        within the same table. For example, specify
+        {cmd:stats(,star(r2_a r2_p))}
+        when tabulating OLS estimates and, say, probit estimates. For
+        the OLS models, the F test will be carried out and the significance
+        stars will be attached to the {cmd:r2_a}; for the probit models, the
+        chi2 test will be used and the stars will appear next to the
+        {cmd:r2_p}.
+        {p_end}
+{marker statslayout}
+{p 12 16 2}
+        {cmd:layout(}{it:array}{cmd:)} to rearrange the summary statistics. The default
+        is to print the statistics in separate rows beneath one another (in
+        each model's first column). The syntax for {it:array} is
+
+                    <{it:row}> [ <{it:row}> ... ]
+
+{p 16 16 2}
+        where {it:row} is
+
+                    <{it:cell}> [ <{it:cell}> ... ]
+
+{p 16 16 2}
+        and {cmd:@} is used as a placeholder for the statistics, one
+        after another. Rows and cells that contain blanks
+        have to be embraced in quotes. For example,
+
+                    {com} ... stats(chi2 df_m N, layout("@ @" @)){txt}
+
+{p 16 16 2}
+        prints for each model in row 1/column 1 the chi-squared, in
+        row1/column 2 the degrees of freedom, and in row 2/column 1 the number of
+        observations. Cells may contain multiple statistics and text other than
+        the placeholder symbol is printed as is (provided the cells' statistics are part
+        of the model). For example,
+
+                    {com} ... stats(chi2 df_m N, layout(`""@ (@)""' @)){txt}
+
+{p 16 16 2}
+        prints a cell containing "chi2 (df_m)" in the first row and the
+        number of observations in the second row. Note that the number of columns
+        in the table only depends on the {cmd:cells()} option (see above) and not
+        on the {cmd:layout()} suboption. If, for example, the table has two columns
+        per model and you specify three columns of summary statistics, the summary statistics
+        in the third column are not printed.
+        {p_end}
+{marker statspchar}
+{p 12 16 2}
+        {cmd:pchar(}{it:symbol}{cmd:)} to specify the placeholder symbol
+        used in {cmdab:layout()}. The default placeholder is {cmd:@}.
+
+{marker sig}
+{dlgtab:Significance stars}
+{marker starlevels}
+{p 4 8 2}
+    {cmd:starlevels(}{it:levelslist}{cmd:)} overrides the default thresholds and
+    symbols for "significance stars". For instance,
+    {bind:{cmd:starlevels(+ 0.10 * 0.05)}}
+    sets the following thresholds: {cmd:+} for p<.10 and {cmd:*} for
+    p<.05. Note that the thresholds must lie in the (0,1] interval and must be
+    specified in descending order. To, for example, denote insignificant
+    results, type {bind:{cmd:starlevels(* 1 "" 0.05)}}.
+    {p_end}
+{marker stardrop}
+{p 4 8 2}
+    {cmd:stardrop(}{it:droplist} [{cmd:, relax}]{cmd:)}
+    identifies the coefficients for which the significance stars be
+    suppressed. {it:droplist} is specified as in
+    {helpb estout##drop:drop()} (see above).
+    {p_end}
+{marker starkeep}
+{p 4 8 2}
+    {cmd:starkeep(}{it:keeplist} [{cmd:, relax}]{cmd:)} selects the coefficients
+    for which the significance stars, if requested, be printed. {it:keeplist}
+    is specified analogous to {it:droplist} in
+    {helpb estout##drop:drop()} (see above).
+    {p_end}
+{marker stardetach}
+{p 4 8 2}
+    {cmd:stardetach} specifies that a delimiter be placed between the statistics
+    and the significance stars (i.e. that the stars are to be displayed in their
+    own column).
+
+{marker lay}
+{dlgtab:Layout}
+{marker varwidth}
+{p 4 8 2}
+    {cmd:varwidth(}{it:#}{cmd:)} specifies the number of characters used to display
+    the names (labels) of regressors and statistics (i.e. {cmd:varwidth}
+    specifies the width of the table's left stub). Long names (labels) are
+    abbreviated (depending on the {cmd:abbrev} option) and short or empty
+    cells are padded out with blanks to fit the width specified by the user.
+    {cmd:varwidth} set to 0 means that the names are not
+    abbreviated and no white space is added. Specifying low values may cause
+    misalignment.
+    {p_end}
+{marker modelwidth}
+{p 4 8 2}
+    {cmd:modelwidth(}{it:#} [{it:#} ...]{cmd:)} designates the number of characters
+    used to display the results columns. If a non-zero {cmd:modelwidth} is
+    specified, model names are abbreviated if necessary (depending on the
+    {cmd:abbrev} option) and short or empty results cells are padded out
+    with blanks. In contrast, {cmd:modelwidth} does not shorten or truncate
+    the display of the results themselves (coefficients, t-statistics,
+    summary statistics, etc.) although it may add blanks if needed.
+    {cmd:modelwidth} set to 0 means that the model names are not
+    abbreviated and no white space is added. Specifying low values may
+    cause misalignment. Specify a list of numbers in {cmd:modelwidth()} to
+    assign individual widths to the different results columns (the list is
+    recycled if there are more columns than numbers).
+
+{p 8 8 2}
+    The purpose of {cmd:modelwidth} is to be able to construct a fixed-format
+    table and thus make the raw table more readable. Be aware, however, that the
+    added blanks may cause problems with the conversion to a table in word
+    processors or spreadsheets.
+    {p_end}
+{marker unstack}
+{p 4 8 2}
+    {cmd:unstack} specifies that the individual equations from multiple-equation
+    models (e.g. {cmd:mlogit}, {cmd:reg3}, {cmd:heckman}) be placed in
+    separate columns. The default is to place the equations below one another in a
+    single column. Summary statistics will be reported for each equation if
+    {cmd:unstack} is specified and the estimation command is either {cmd:reg3},
+    {cmd:sureg}, or {cmd:mvreg} (see help {helpb reg3}, help {helpb sureg},
+    help {helpb mvreg}).
+    {p_end}
+{marker begin}
+{p 4 8 2}
+    {cmd:begin(}{it:string}{cmd:)} specifies a string to be printed at the
+    beginning of every table row. It is possible to
+    use special functions such as {cmd:_tab} or {cmd:_skip} in
+    {cmd:begin()}. For more information on using such functions, see the
+    description of the functions in help {helpb file}.
+    {p_end}
+{marker delimiter}
+{p 4 8 2}
+    {cmd:delimiter(}{it:string}{cmd:)} designates the delimiter used between the
+    table columns. See the {cmd:begin} option above for further details.
+    {p_end}
+{marker end}
+{p 4 8 2}
+    {cmd:end(}{it:string}{cmd:)} specifies a string to be printed at the end of
+    every table row. See the {cmd:begin} option above for further details.
+    {p_end}
+{marker incelldel}
+{p 4 8 2}
+    {cmd:incelldelimiter(}{it:string}{cmd:)} specifies text to be printed
+    between parameter statistics that have been combined in a single cell
+    by the {cmd:&} operator. See the {helpb estout##par:cells()} option
+    for details. The default string is a single blank.
+    {p_end}
+{marker dmarker}
+{p 4 8 2}
+    {cmd:dmarker(}{it:string}{cmd:)} specifies the form of the decimal marker. The
+    standard decimal symbol (a period or a comma, depending on the input provided
+    to {cmd:set dp}; see help {help format}) is replaced by {it:string}.
+    {p_end}
+{marker msign}
+{p 4 8 2}
+    {cmd:msign(}{it:string}{cmd:)} determines the form of the minus sign. The
+    standard minus sign ({cmd:-}) is replaced by {it:string}.
+    {p_end}
+{marker lz}
+{p 4 8 2}
+    {cmd:lz} specifies that the leading zero of fixed format numbers in the
+    interval (-1,1) be printed. This is the default. Use {cmd:nolz} to advise
+    {cmd:estout} to omit the leading zeros (that is, to print numbers like
+    {cmd:0.021} or {cmd:-0.33} as {cmd:.021} and {cmd:-.33}).
+    {p_end}
+{marker extracols}
+{p 4 8 2}
+    {cmd:extracols(}{it:{help numlist}}{cmd:)} inserts empty table columns
+    at the indicated positions. For example, {cmd:extracols(1)} adds
+    an extra column between the left stub of the table and the first
+    column.
+    {p_end}
+{marker substitute}
+{p 4 8 2}
+    {cmd:substitute(}{it:subst_list}{cmd:)} specifies that the substitutions
+    specified in {it:subst_list} be applied to the estimates table after it has
+    been created. Specify {it:subst_list} as a list of substitution pairs, that
+    is:
+
+{p 12 12 2}
+        {it:from} {it:to} [{it:from} {it:to} ...]
+
+{p 8 8 2}
+    For example, specify {cmd:substitute(_ \_)} to replace the underscore
+    character (as in {cmd:_cons} or {cmd:F_p}) with it's LaTeX equivalent {cmd:\_}.
+
+{marker lab}
+{dlgtab:Labeling}
+{marker label}
+{p 4 8 2}
+    {cmd:label} specifies that variable labels be displayed instead of variable
+    names in the left stub of the table.
+    {p_end}
+{marker abbrev}
+{p 4 8 2}
+    {cmd:abbrev} specifies that long names and labels be abbreviated if
+    a {cmd:modelwidth()} and/or a {cmd:varwidth()} is specified.
+    {p_end}
+{marker wrap}
+{p 4 8 2}
+    {cmd:wrap} causes long variable labels to be wrapped if space permits and
+    a {cmd:varwidth()} is specified. The {cmd:wrap} option is only useful if
+    several parameter statistics are printed beneath one another and, therefore,
+    white space is available beneath the labels.
+    {p_end}
+{marker interaction}
+{p 4 8 2}
+    {cmd:interaction(}{it:string}{cmd:)} specifies the string to be used 
+    as delimiter for interaction terms (only relevant in Stata 11 or newer). The
+    default is {cmd:interaction(" # ")}. For {cmd:style(tex)} the default is 
+    {cmd:interaction(" $\times$ ")}.
+    {p_end}
+{marker title}
+{p 4 8 2}
+    {cmd:title(}{it:string}{cmd:)} may be used to specify a title for the table.
+    The {it:string} is printed at the top of the table unless {cmd:prehead()},
+    {cmd:posthead()}, {cmd:prefoot()}, or {cmd:postfoot()} is specified. In
+    the latter case, the variable {cmd:@title} can be used to insert the title.
+    {p_end}
+{marker note}
+{p 4 8 2}
+    {cmd:note(}{it:string}{cmd:)} may be used to specify a note for the table.
+    The {it:string} is printed at the bottom, of the table unless {cmd:prehead()},
+    {cmd:posthead()}, {cmd:prefoot()}, or {cmd:postfoot()} is specified. In
+    the latter case, the variable {cmd:@note} can be used to insert the note.
+    {p_end}
+{marker legend}
+{p 4 8 2}
+    {cmd:legend} adds a legend explaining the significance symbols and
+    thresholds.
+    {p_end}
+{marker prehead}
+{p 4 8 2}
+    {cmd:prehead(}{it:strlist}{cmd:)}, {cmd:posthead(}{it:strlist}{cmd:)},
+    {cmd:prefoot(}{it:strlist}{cmd:)}, and {cmd:postfoot(}{it:strlist}{cmd:)} may
+    be used to define lists of text lines to appear before and after the table
+    heading or the table footer. For example, the specification
+
+{p 12 12 2}
+        {inp:. estout} {it:...}{inp:, prehead("\S_DATE \S_TIME" "")}
+
+{p 8 8 2}
+    would add a line containing the current date and time followed by
+    an empty line before the table. Various substitution functions can be used
+    as part of the text lines specified in {it:strlist} (see the
+    {help estout##atvar:Remarks on using @-variables}). For example,
+    {cmd:@hline} plots a horizontal "line" (series of dashes, by default; see
+    the {cmd:hlinechar()} option) or {cmd:@M} inserts the number of models
+    in the table. {cmd:@M} could be used in a LaTeX table heading
+    as follows:
+
+{p 12 12 2}
+        {inp:. estout} {it:...}{inp:, prehead(\begin{tabular}{l*{@M}{r}})}
+    {p_end}
+{marker hlinechar}
+{p 4 8 2}
+    {cmd:hlinechar(}{it:string}{cmd:)} specifies the character(s) to be
+    used in {cmd:@hline}. The default is {cmd:hlinechar(-)}, resulting in a
+    dashed line. To produce a solid line, specify {cmd:hlinechar(`=char(151)')}
+    (Windows only; other systems may use other codes).
+    {p_end}
+{marker varlabels}
+{p 4 8 2}
+    {cmd:varlabels(}{it:matchlist}[{cmd:,} {it:suboptions}]{cmd:)} may be used to
+    relabel the regressors from the models, where {it:matchlist} is
+
+{p 12 12 2}
+        {it:name} {it:label} [{it:name} {it:label} ...]
+
+{p 8 8 2}
+    A {it:name} is a parameter name (e.g. {cmd:price}) or a full name
+    (e.g. {cmd:mean:price}) (abbreviation and wildcards
+    not allowed). For example, specify {cmd:varlabels(_cons Constant)} to replace
+    each occurrence of {cmd:_cons} with {cmd:Constant}. (Note that, in LaTeX,
+    the underscore character produces an error unless it is specified as
+    {cmd:\_}. Thus, names such as {cmd:_cons} should always be changed if
+    the estimates table is to be used with LaTeX. The {cmd:substitute()} may also be
+    helpful; see the {help estout##lay:Layout} options.) The {it:suboptions} are:
+
+{p 12 16 2}
+        {cmd:blist(}{it:matchlist}{cmd:)} to assign specific prefixes to
+        certain rows in the table body. Specify the {it:matchlist} as pairs of
+        regressors and prefixes, that is:
+
+{p 20 20 2}
+            {it:name} {it:prefix} [{it:name} {it:prefix} ...]
+
+{p 16 16 2}
+        A {it:name} is a parameter name (e.g. {cmd:price}), an equation name
+        followed by a colon (e.g. {cmd:mean:}), or a full name
+        (e.g. {cmd:mean:price}) (abbreviation and wildcards
+        not allowed). Note that equation names cannot be used if the
+        {cmd:unstack} option is specified.
+
+{p 12 16 2}
+        {cmd:elist(}{it:matchlist}{cmd:)} to assign specific suffixes to
+        certain rows in the table body (see the analogous {cmd:blist()} option
+        above). This option may, for example, be useful for separating
+        thematic blocks of variables by
+        adding vertical space at the end of each block. A LaTeX example:
+
+{p 20 20 2}
+            {inp:. estout} {it:...}{inp:, varlabels(,elist(price \addlinespace mpg \addlinespace))}
+
+{p 16 16 2}
+        (the  macro {cmd:\addlinespace} is provided by the
+        {cmd:booktabs} package in LaTeX)
+
+{p 12 16 2}
+        {it:{help estout##lsub:label_subopts}}, which are
+        explained in their own section.
+        {p_end}
+{marker labcol2}
+{p 4 8 2}
+    {cmd:labcol2(}{it:strlist}[{cmd:,} {it:suboptions}]{cmd:)} adds a second column
+    containing additional labels for the coefficients and summary statistics. Labels
+    containing spaces should be embraced in double quotes ({bind:{cmd:"}{it:label 1}{cmd:"}}
+    {bind:{cmd:"}{it:label 2}{cmd:"}} etc.). An example would be to add a column
+    indicating the hypothesized directions of effects, e.g.,
+
+        {com}. estout {txt}{it:...}{com}, labcol2(+ - +/- + 0){txt}
+
+{p 8 8 2}
+    The {it:suboptions} are:
+
+{p 12 16 2}
+        {cmd:title(}{it:strlist}{cmd:)} to add text in the table header above
+        the column. Use double quotes to break the title into several
+        rows (given there are multiple header rows), i.e. specify {it:strlist}
+        as {bind:{cmd:"}{it:line 1}{cmd:"}} {bind:{cmd:"}{it:line 2}{cmd:"}} etc.
+
+{p 12 16 2}
+        {cmd:width(}{it:#}{cmd:)} to set the width, in number of characters, of the
+        column. The default is the value of {cmd:modelwidth()}.
+        {p_end}
+{marker refcat}
+{p 4 8 2}
+    {cmd:refcat(}{it:matchlist}[{cmd:,} {it:suboptions}]{cmd:)} may be used to
+    insert a row containing information on the reference category
+    of a categorical variable in the model. {it:matchlist} is
+
+{p 12 12 2}
+        {it:name} {it:refcat} [{it:name} {it:refcat} ...]
+
+{p 8 8 2}
+    A {it:name} is a parameter name (e.g. {cmd:_Irep78_2})
+    (abbreviation and wildcards not allowed). For
+    example, assume that you include the categorical variable {cmd:rep78}
+    ("Repair Record 1978" from the auto dataset) in some of your models
+    using {cmd:xi} (see help {helpb xi}). Since {cmd:rep78} has five
+    levels, 1 through 5, {cmd:xi} will create 4 dummy variables,
+    {cmd:_Irep78_2} through {cmd:_Irep78_5}. You can now type
+
+{p 12 12 2}
+        {inp:. estout} {it:...}{inp:, refcat(_Irep78_2 _Irep78_1)}
+
+{p 8 8 2}
+    to add a table row containing "_Irep78_1" in the left stub and
+    "ref." in each column in which the {cmd:_Irep78_2}
+    dummy appears. The {it:suboptions} are:
+
+{p 12 16 2}
+        {cmd:label(}{it:string}{cmd:)} to specify the label that is printed
+        in the table columns. The default is {cmd:label(ref.)}. Type {cmd:nolabel}
+        to suppress the default label.
+
+{p 12 16 2}
+        {cmd:below} to position the reference category row below the specified
+        coefficient's row. The default is above. For example, if the 5th
+        category of {cmd:rep78} is used as reference category, i.e. if
+        {cmd:_Irep78_1} through {cmd:_Irep78_4} are included in the models,
+        you might want to type {cmd:refcat(_Irep78_4 _Irep78_5, below)}.
+        {p_end}
+{marker mlabels}
+{p 4 8 2}
+    {cmd:mlabels(}{it:strlist}[{cmd:,} {it:suboptions}]{cmd:)} determines the
+    model captions printed in the table heading. The default is to use the names of
+    the stored estimation sets (or their titles, if the {cmd:label} option is
+    specified and titles are available). The {it:suboptions} for use with
+    {cmd:mlabels} are:
+
+{p 12 16 2}
+        {cmd:depvars} to specify that the name (or label) of the (first) dependent
+        variable of the model be used as model label.
+
+{p 12 16 2}
+        {cmd:titles} to specify that, if available, the title of the stored
+        estimation set be used as the model label. Note that the {cmd:label} option
+        implies {cmd:titles} (unless {cmd:notitles} is specified). {cmd:depvars}
+        takes precedence over {cmd:titles}.
+
+{p 12 16 2}
+        {cmd:numbers} to cause the model labels to be numbered consecutively.
+
+{p 12 16 2}
+        {it:{help estout##lsub:label_subopts}}, which are explained in their own section.
+        {p_end}
+{marker collabels}
+{p 4 8 2}
+    {cmd:collabels(}{it:strlist}[{cmd:,} {it:{help estout##lsub:label_subopts}}]{cmd:)}
+    specifies labels for the columns within models or equations. The
+    default is to compose a label from the names or labels of the
+    statistics printed in the cells of that column. The {it:label_subopts}
+    are explained in their own section below.
+    {p_end}
+{marker eqlabels}
+{p 4 8 2}
+    {cmd:eqlabels(}{it:strlist}[{cmd:,} {it:suboptions}]{cmd:)}
+    labels the equations. The default is to use the equation names as
+    stored by the estimation command, or to use the variable labels if the
+    equation names correspond to individual variables and the {cmd:label}
+    option is specified. The {it:suboptions} for use with {cmd:eqlabels}
+    are:
+
+{p 12 16 2}
+        {cmd:merge} to merge equation labels and parameter labels instead of
+        printing equation labels in separate rows. Equation and parameter labels
+        will be separated by ":" unless another delimiter is specified via the
+        {cmd:suffix()} suboption (see {it:{help estout##lsub:label_subopts}}).
+        {cmd:merge} has no effect if {cmd:unstack} is specified.
+
+{p 12 16 2}
+        {it:{help estout##lsub:label_subopts}}, which are explained in their own
+        section. Note  that {bind:{cmd:eqlabels(none)}} causes {cmd:_cons} to be
+        replaced with the equation name or label, if {cmd:_cons} is the only
+        parameter in an equation. This is useful, e.g., for tabulating
+        {cmd:ologit} or {cmd:oprobit} results in Stata 9. Specify
+        {bind:{cmd:eqlabels("", none)}} to not replace {cmd:_cons}.
+        {p_end}
+{marker mgroups}
+{p 4 8 2}
+    {cmd:mgroups(}{it:strlist}[{cmd:,} {it:suboptions}]{cmd:)} may be used to
+    labels groups of (consecutive) models at the top of the table heading. The
+    labels are placed in the first physical column of the output for the group of
+    models to which they apply. The {it:suboptions} for use with {cmd:mgroups}
+    are:
+
+{p 12 16 2}
+        {cmd:pattern(}{it:pattern}{cmd:)} to establish how the models are to be grouped.
+        {it:pattern} should be a list of zeros and ones, with ones indicating the
+        start of a new group of models. For example,
+
+{p 20 20 2}
+            {inp:. estout} {it:...}{inp:, mgroups("Group 1" "Group 2", pattern(1 0 0 1 0))}
+
+{p 16 16 2}
+        would group Models 1, 2, and 3 together and then groups Models 4 and 5
+        together as well. Note that the first group will always start with the first
+        model regardless of whether the first token of {it:pattern} is a one or a
+        zero.
+
+{p 12 16 2}
+        {it:{help estout##lsub:label_subopts}}, which are explained
+        in their own section. In
+        particular, the {cmd:span} suboption might be of interest here.
+        {p_end}
+{marker numbers}
+{p 4 8 2}
+    {cmd:numbers}[{cmd:(}{it:l} {it:r}{cmd:)}] adds a row to the table header
+    displaying consecutive model numbers. The default is to
+    enclose the numbers in parentheses, i.e. {cmd:(1)}, {cmd:(2)}, etc.
+    Alternatively, specify {it:l} and {it:r} to change the tokens on the
+    left and right of each number. For example, {cmd:numbers("" ")")}
+    would result in {cmd:1)}, {cmd:2)}, etc.
+
+{marker out}
+{dlgtab:Output}
+{marker replace}
+{p 4 8 2}
+    {cmd:replace} permits {cmd:estout} to overwrite an existing file.
+    {p_end}
+{marker append}
+{p 4 8 2}
+    {cmd:append} specifies that the output be appended to an existing file. It
+    may be used even if the file does not yet exist.
+    {p_end}
+{marker type}
+{p 4 8 2}
+    {cmd:type} specifies that the assembled estimates table be printed in the
+    results window and the log file. This is the default unless {cmd:using} is
+    specified. Use {cmd:notype} to suppress the display of the table.
+    {p_end}
+{marker showtabs}
+{p 4 8 2}
+    {cmd:showtabs} requests that tabs be displayed as {cmd:<T>}s in both the
+    results window and the log file instead of in expanded form. This option does
+    not affect how tabs are written to the text file specified by {cmd:using}.
+    {p_end}
+{marker topfile}
+{p 4 8 2}
+    {cmd:topfile(}{it:filename}{cmd:)} and
+    {cmd:bottomfile(}{it:filename}{cmd:)} may be used to insert text before
+    and after the table, where the text is imported from a file on disk. Note that
+    {cmd:substitute()} does not apply to text inserted by {cmd:topfile()} or
+    {cmdab:bottomfile()}.
+
+{marker def}
+{dlgtab:Defaults}
+{marker style}
+{p 4 8 2}
+    {cmd:style(}{it:style}{cmd:)} specifies a "style" for the output
+    table. {cmdab:def:aults:(}{it:style}{cmd:)} is a synonym for
+    {cmd:style(}{it:style}{cmd:)}. A "style" is a named combination of options
+    that is saved in an auxiliary file called {cmd:estout_}{it:style}{cmd:.def}.
+    In addition, there are five internal styles called {cmd:smcl}
+    (default for screen display), {cmd:tab} (export default), {cmd:fixed},
+    {cmd:tex}, and {cmd:html}. The {cmd:smcl} style is suitable for displaying
+    the table in Stata's results window and is the default unless
+    {cmd:using} is specified. It includes {help smcl:SMCL} formatting tags and
+    horizontal lines to structure the table. The particulars of the other styles are:
+
+            settings {col 38}styles
+            {col 26}{cmd:tab}{col 34}{cmd:fixed}{col 42}{cmd:tex}{col 50}{cmd:html}
+            {hline 47}
+            {cmd:begin}     {col 50}{cmd:<tr><td>}
+            {cmd:delimiter} {col 26}{cmd:_tab}{col 34}{cmd:" "}{col 42}{cmd:&}{col 50}{cmd:</td><td>}
+            {cmd:end}       {col 42}{cmd:\\}{col 50}{cmd:</td></tr>}
+            {cmd:varwidth}  {col 26}{cmd:0}{col 34}{cmd:12/20}*{col 42}{cmd:12/20}*{col 50}{cmd:12/20}*
+            {cmd:modelwidth}{col 26}{cmd:0}{col 34}{cmd:12}{col 42}{cmd:12}{col 50}{cmd:12}
+            {cmd:abbrev}    {col 26}off{col 34}on{col 42}off{col 50}off
+                                         (* if {cmd:label} is on)
+
+{p 8 8 2}
+    {cmd:tab} is the default export style (i.e. if {cmd:using} is specified).
+
+{p 8 8 2}
+    Note that explicitly specified options take precedence
+    over settings provided by a style. For example, if you type
+
+            {com}. estout, delimiter("") style(tab){txt}
+
+{p 8 8 2}
+    then the column delimiter will be set to empty string since the
+    {cmd:delimiter()} option overwrites the default from the {cmd:tab}
+    style. Similarly, specifying
+    {cmd:noabbrev} will turn abbreviation off if using the {cmd:fixed}
+    style.
+
+{p 8 8 2}
+    See {help estout##defaults:Defaults files} in the
+    {help estout##rem:Remarks} section to make available your own style.
+
+{marker lsub}
+{it:{dlgtab:label_subopts}}
+
+{p 4 4 2}
+The following suboptions may be used within the {cmd:mgroups()},
+{cmd:mlabels()}, {cmd:collabels()}, {cmd:eqlabels()},
+{cmd:varlabels()}, and {cmd:stats(, labels())} options:
+
+{p 4 8 2}
+    {cmd:none} suppresses the printing of the labels or drops the
+    part of the table heading to which it applies. Note that instead of
+    typing {bind:{it:option}{cmd:(, none)}} you may simply specify
+    {it:option}{cmd:(none)}.
+
+{p 4 8 2}
+    {cmd:prefix(}{it:string}{cmd:)} specifies a common prefix to be added to each
+    label.
+
+{p 4 8 2}
+    {cmd:suffix(}{it:string}{cmd:)} specifies a common suffix to be added to each
+    label.
+
+{p 4 8 2}
+    {cmd:begin(}{it:strlist}{cmd:)} specifies a prefix to be printed at the
+    beginning of the part of the table to which it applies. If {cmd:begin} is
+    specified in {cmd:varlabels()} or {cmd:stats(,labels())}, the prefix will
+    be repeated for each regressor or summary statistic.
+
+{p 4 8 2}
+    {cmd:first} specifies that the first occurrence of the {cmd:begin()}-prefix in
+    {cmd:varlabels()} or {cmd:stats(,labels())} be printed. This
+    is the default. Use {cmd:nofirst} to suppress the first occurrence of the
+    prefix. In {cmd:varlabels()}, {cmd:nofirst} applies equation-wise, i.e., the first
+    {cmd:begin()}-prefix in each equation is suppressed (unless {cmd:unstack} is
+    specified).
+
+{p 4 8 2}
+    {cmd:end(}{it:strlist}{cmd:)} specifies a suffix to be printed at the end of the
+    part of the table to which it applies. If {cmd:end} is specified in
+    {cmd:varlabels()} or {cmd:stats(,labels())}, the suffix will be repeated
+    for each regressor or summary statistic.
+
+{p 4 8 2}
+    {cmd:last} specifies that the last occurrence of the {cmd:end()}-suffix in
+    {cmd:varlabels()} or {cmd:stats(,labels())} be printed. This
+    is the default. Use {cmd:nolast} to suppress the last occurrence of the
+    suffix. In {cmd:varlabels()}, {cmd:nolast} applies equation-wise, i.e., the last
+    {cmd:end()}-suffix in each equation is suppressed (unless {cmd:unstack} is
+    specified).
+
+{p 4 8 2}
+    {cmd:replace} causes the label suboption {cmd:begin()}-prefix and {cmd:end()}-suffix
+    to be used instead of the global {cmd:begin()} and {cmd:end()} strings. The default
+    is to print both. {cmd:replace} also applies to {cmd:blist()} and {cmd:elist()}
+    if specified in {cmd:varlabels()}.
+
+{p 4 8 2}
+    {cmd:span} causes labels to span columns, i.e. extends the labels across
+    several columns, if appropriate. This suboption is relevant only for the
+    {cmd:mgroups()}, {cmd:mlabels()}, {cmd:eqlabels()}, and
+    {cmd:collabels()} options. The {cmd:@span} string returns the number of
+    spanned columns if it is included in the label, prefix, or suffix. A LaTeX example:
+
+{p 8 8 2}
+        {inp:. estout} {it:...}{inp:, mlabels(, span prefix(\multicolumn{@span}{c}{) suffix(}))}
+
+{p 4 8 2}
+    {cmd:erepeat(}{it:string}{cmd:)} specifies a string that is repeated for each
+    group of spanned columns at the very end of the row if the {cmd:span}
+    suboption is specified. This suboption is relevant only for the
+    {cmd:mgroups()}, {cmd:mlabels()}, {cmd:eqlabels()}, and
+    {cmd:collabels()} options. If the {cmd:@span} string is included in
+    {it:string} it will be replaced by the range of columns spanned. A LaTeX example:
+
+{p 8 8 2}
+        {inp:. estout} {it:...}{inp:, mlabels(, span erepeat(\cline{@span}))}
+
+{p 4 8 2}
+    {cmd:lhs(}{it:string}{cmd:)} inserts {it:string} into the otherwise empty cell
+    in the left stub of the row of the table heading to which it applies. This
+    suboption is relevant only for the {cmd:mgroups()}, {cmd:mlabels()},
+    {cmd:eqlabels()}, and {cmd:collabels()} options.
+
+{marker msub}
+{it:{dlgtab:matrix_subopts}}
+
+{p 4 4 2}
+The following suboptions may be applied within the {cmd:matrix()},
+{cmd:e()}, or {cmd:r()} argument used to tabulate a matrix:
+    {p_end}
+{marker mfmt}
+{p 4 8 2}
+    {cmd:fmt(}{it:fmtlist}{cmd:)} sets the display formats for the matrix.
+    {it:fmtlist} contains a list of format specifications, one for each
+    column of the matrix. {it:fmtlist} is recycled if it supplies less
+    specifications than there are columns in the matrix. A format
+    specification may be a single {it:{help estout##fmt:fmt}} such as,
+    e.g., {cmd:%9.0g} or {cmd:a3} (see {help estout##fmt:Numerical formats}
+    in the {help estout##rem:Remarks} section for details) to be applied to
+    all cells in the column. Alternatively, a format specification may be
+    a list of {it:{help estout##fmt:fmt}}s, enclosed in double quotes, to be
+    used for the cells in the column one by one. The last format in the
+    list is used for the remaining cells if the number of cells in the
+    column is greater than the number of formats in the list. Also see the
+    {help estout##ex7:examples} below.
+    {p_end}
+{marker mtranspose}
+{p 4 8 2}
+    {cmd:transpose} causes the matrix to be transposed for tabulation.
+
+{marker exa}
+{title:Examples}
+
+    Contents
+        {help estout##intro:Introduction}
+        {help estout##ex1:Publication style table}
+        {help estout##ex2:t-statistics for selected variables only}
+        {help estout##ex3:Summary statistics only}
+        {help estout##ex4:Table of descriptives}
+        {help estout##ex5:Unstack multiple equations}
+        {help estout##ex7:Tabulating a matrix}
+
+{p 4 4 2} Please first read the {help estout##intro:Introduction}. The
+other examples are more advanced and intended for users
+already familiar with the basic features of
+{cmd:estout}. Additional examples can be found in Jann (2005) and at
+{browse "http://repec.sowi.unibe.ch/stata/estout/"}.
+
+{marker intro}
+{dlgtab:Introduction}
+
+{p 4 4 2}
+The full syntax of {cmd:estout} is rather complex and is to be found
+above. However, consider the following basic syntax, which
+includes only the most important options:
+
+{p 8 15 2}
+{cmd:estout} [ {it:namelist} ] [ {cmd:using} {it:filename} ] [ {cmd:,}
+ {cmdab:c:ells:(}{it:array}{cmd:)}
+ {cmdab:s:tats:(}{it:scalarlist}{cmd:)}
+ {cmdab:sty:le:(}{it:style}{cmd:)}
+ {it:more_options}
+ ]
+
+{p 4 4 2}
+where {it:namelist} is a list of the names of stored estimation sets (the name
+list can be entered as {cmd:*} to refer to all stored estimates). The
+{cmd:cells()} and {cmd:stats()} options determine the primary contents of
+the table. The {cmd:style()} option determines the basic formatting of the
+table.
+
+{p 4 4 2}{ul:Basic usage}
+
+{p 4 4 2}
+The general procedure for using {cmd:estout} is to first store several
+models using the {cmd:estimates store} or the {helpb eststo} command and then apply
+{cmd:estout} to display or save a table of the estimates. By default,
+{cmd:estout} displays a plain table of the coefficients of the models and
+uses {help SMCL} tags and horizontal lines to structure the table:
+
+        {com}. sysuse auto
+        {txt}(1978 Automobile Data)
+
+        {com}. replace price = price / 1000
+        {txt}price was {res}int{txt} now {res}float
+        {txt}(74 real changes made)
+
+        {com}. replace weight = weight / 1000
+        {txt}weight was {res}int{txt} now {res}float
+        {txt}(74 real changes made)
+
+        {com}. quietly regress price weight mpg
+        {txt}
+        {com}. estimates store m1, title(Model 1)
+        {txt}
+        {com}. generate forXmpg = foreign * mpg
+        {txt}
+        {com}. quietly regress price weight mpg forXmpg foreign
+        {txt}
+        {com}. estimates store m2, title(Model 2)
+        {txt}
+        {com}. estout m1 m2
+        {res}
+        {txt}{hline 38}
+        {txt}                       m1           m2
+        {txt}                        b            b
+        {txt}{hline 38}
+        {txt}weight      {res}     1.746559     4.613589{txt}
+        {txt}mpg         {res}    -.0495122     .2631875{txt}
+        {txt}forXmpg     {res}                 -.3072165{txt}
+        {txt}foreign     {res}                  11.24033{txt}
+        {txt}_cons       {res}     1.946068    -14.44958{txt}
+        {txt}{hline 38}
+
+{p 4 4 2}Alternatively, if {cmd:using} is specified, {cmd:estout} writes a
+raw tab-delimited table (without SMCL tags and without lines) to the
+indicated file ({cmd:*} is used in the following example to indicate that
+all stored models be tabulated):
+
+        {com}. estout * using example.txt
+        {txt}(output written to {browse  `"example.txt"'})
+
+        {com}. type example.txt
+        {res}        m1      m2
+                b       b
+        weight  1.746559        4.613589
+        mpg     -.0495122       .2631875
+        forXmpg         -.3072165
+        foreign         11.24033
+        _cons   1.946068        -14.44958
+        {txt}
+{p 4 4 2} The table looks messy in the Stata results window or the Stata
+log because the columns are tab-separated (note that tab characters are not
+preserved in the results window or the log). However, the table would look
+tidy if "example.txt" were opened, for example, in a spreadsheet program.
+
+{p 4 4 2}{ul:Choosing a style}
+
+{p 4 4 2}{cmd:estout} has a {cmd:style()} option to set the basic format of
+the table. The default style for screen display is the {cmd:smcl} style.
+The default export style (i.e. if {cmd:using} is specified) is the
+{cmd:tab} style. (See the examples above.) Other predefined styles are
+{cmd:fixed}, {cmd:tex}, and {cmd:html}, but it is also possible to define
+one's own styles (see {help estout##defaults:Defaults files} in the
+{help estout##rem:Remarks} section). The {cmd:tex} style, for example, modifies
+the output table for use with LaTeX's tabular environment:
+
+        {com}. estout *, style(tex) varlabels(_cons \_cons)
+        {res}
+                    &          m1&          m2\\
+                    &           b&           b\\
+        weight      &    1.746559&    4.613589\\
+        mpg         &   -.0495122&    .2631875\\
+        forXmpg     &            &   -.3072165\\
+        foreign     &            &    11.24033\\
+        \_cons      &    1.946068&   -14.44958\\
+        {txt}
+{p 4 4 2}
+Note that {cmd:_cons} has been replaced by its LaTeX equivalent in the example above
+using the {cmd:varlabels()} option (the underscore character produces an
+error in LaTeX unless it is preceded by a backslash). For more
+information on the {cmd:varlabels()} option, see {cmd:estout}'s
+{help estout##lab:Labeling} options.
+
+{p 4 4 2}{ul:The cells option}
+
+{p 4 4 2}
+Use the {cmd:cells()} option to specify the parameter statistics to be
+tabulated and how they are to be arranged. The parameter statistics
+available are {cmd:b} (point estimates; the default), {cmd:se} (standard
+errors), {cmd:t} (t-/z-statistics), {cmd:p} (p-values), {cmd:ci}
+(confidence intervals; to display the lower and upper bounds in separate
+cells use {cmd:ci_l} and {cmd:ci_u}), as well as any additional
+parameter statistics included in the {cmd:e()}-returns for the models
+(see {cmd:estout}'s {help estout##par:Parameter Statistics} options). For
+example, {cmd:cells(b se)} results
+in the reporting of point estimates and standard errors:
+
+        {com}. estout *, cells(b se)
+        {res}
+        {txt}{hline 38}
+        {txt}                       m1           m2
+        {txt}                     b/se         b/se
+        {txt}{hline 38}
+        {txt}weight      {res}     1.746559     4.613589{txt}
+                    {res}     .6413538     .7254961{txt}
+        {txt}mpg         {res}    -.0495122     .2631875{txt}
+                    {res}      .086156     .1107961{txt}
+        {txt}forXmpg     {res}                 -.3072165{txt}
+                    {res}                  .1085307{txt}
+        {txt}foreign     {res}                  11.24033{txt}
+                    {res}                  2.751681{txt}
+        {txt}_cons       {res}     1.946068    -14.44958{txt}
+                    {res}      3.59705      4.42572{txt}
+        {txt}{hline 38}
+
+{p 4 4 2}
+Multiple statistics are placed in separate rows beneath one another by
+default as in the example above. However, elements that are listed in
+quotes or in parentheses are placed beside one another. For
+example, specifying {bind:{cmd:cells("b se t p")}} or, equivalently,
+{bind:{cmd:cells((b se t p))}} produces the following table:
+
+        {com}. estout m2, cells("b se t p")
+        {res}
+        {txt}{hline 64}
+        {txt}                       m2
+        {txt}                        b           se            t            p
+        {txt}{hline 64}
+        {txt}weight      {res}     4.613589     .7254961     6.359219     1.89e-08{txt}
+        {txt}mpg         {res}     .2631875     .1107961     2.375421     .0203122{txt}
+        {txt}forXmpg     {res}    -.3072165     .1085307    -2.830687     .0060799{txt}
+        {txt}foreign     {res}     11.24033     2.751681     4.084896     .0001171{txt}
+        {txt}_cons       {res}    -14.44958      4.42572     -3.26491     .0017061{txt}
+        {txt}{hline 64}
+
+{p 4 4 2}
+The two approaches can be combined. For example, {cmd:cells("b p" se)}
+would produce a table with point estimates and standard errors beneath one
+another in the first column and p-values in the top row of the second
+column for each model.
+
+{p 4 4 2}
+Note that for each statistic named in the {cmd:cells()} option a set of
+suboptions may be specified in parentheses. For example, in social sciences
+it is common to report standard errors or t-statistics in parentheses beneath
+the coefficients and to indicate the significance of individual
+coefficients with stars. Furthermore, the results are rounded. Just such a
+table can be created using the following procedure:
+
+        {com}. estout *, cells(b(star fmt(3)) t(par fmt(2)))
+        {res}
+        {txt}{hline 44}
+        {txt}                       m1              m2
+        {txt}                      b/t             b/t
+        {txt}{hline 44}
+        {txt}weight      {res}        1.747**         4.614***{txt}
+                    {res}       (2.72)          (6.36)   {txt}
+        {txt}mpg         {res}       -0.050           0.263*  {txt}
+                    {res}      (-0.57)          (2.38)   {txt}
+        {txt}forXmpg     {res}                       -0.307** {txt}
+                    {res}                      (-2.83)   {txt}
+        {txt}foreign     {res}                       11.240***{txt}
+                    {res}                       (4.08)   {txt}
+        {txt}_cons       {res}        1.946         -14.450** {txt}
+                    {res}       (0.54)         (-3.26)   {txt}
+        {txt}{hline 44}
+
+{p 4 4 2}
+The {cmd:estout} default is to display {cmd:*} for p<.05,
+{cmd:**} for p<.01, and {cmd:***} for p<.001. However, note that
+the significance thresholds and symbols are fully customizable (see {cmd:estout}'s
+{help estout##sig:Significance stars} options).
+
+{p 4 4 2}{ul:The stats option}
+
+{p 4 4 2}
+Finally, use the {cmd:stats()} option to specify scalar
+statistics to be displayed for each model in the table footer. The
+available scalar statistics are {cmd:aic} (Akaike's information criterion),
+{cmd:bic} (Schwarz's information criterion), {cmd:rank} (the rank of
+{cmd:e(V)}, i.e. the number of free parameters in model), {cmd:p} (the
+p-value of the model), as well as any numeric or string scalars contained in the
+{cmd:e()}-returns for the models (see
+{cmd:estout}'s
+{help estout##sum:Summary statistics} options). For example, specify
+{cmd:stats(r2 bic N)} to add the R-squared, BIC, and the number of cases:
+
+        {com}. estout *, stats(r2 bic N)
+        {res}
+        {txt}{hline 38}
+        {txt}                       m1           m2
+        {txt}                        b            b
+        {txt}{hline 38}
+        {txt}weight      {res}     1.746559     4.613589{txt}
+        {txt}mpg         {res}    -.0495122     .2631875{txt}
+        {txt}forXmpg     {res}                 -.3072165{txt}
+        {txt}foreign     {res}                  11.24033{txt}
+        {txt}_cons       {res}     1.946068    -14.44958{txt}
+        {txt}{hline 38}
+        {txt}r2          {res}     .2933891     .5516277{txt}
+        {txt}bic         {res}     356.2918     331.2406{txt}
+        {txt}N           {res}           74           74{txt}
+        {txt}{hline 38}
+{marker ex1}
+{dlgtab:Publication style table}
+
+        {com}. label variable foreign "Foreign car type"
+        {txt}
+        {com}. label variable forXmpg "Foreign*Mileage"
+        {txt}
+        {com}. estout *, cells(b(star fmt(%9.3f)) se(par))                ///
+        >     stats(r2_a N, fmt(%9.3f %9.0g) labels(R-squared))      ///
+        >     legend label collabels(none) varlabels(_cons Constant)
+        {res}
+        {txt}{hline 52}
+        {txt}                          Model 1         Model 2
+        {txt}{hline 52}
+        {txt}Weight (lbs.)       {res}        1.747**         4.614***{txt}
+                            {res}      (0.641)         (0.725)   {txt}
+        {txt}Mileage (mpg)       {res}       -0.050           0.263*  {txt}
+                            {res}      (0.086)         (0.111)   {txt}
+        {txt}Foreign*Mileage     {res}                       -0.307** {txt}
+                            {res}                      (0.109)   {txt}
+        {txt}Foreign car type    {res}                       11.240***{txt}
+                            {res}                      (2.752)   {txt}
+        {txt}Constant            {res}        1.946         -14.450** {txt}
+                            {res}      (3.597)         (4.426)   {txt}
+        {txt}{hline 52}
+        {txt}R-squared           {res}        0.273           0.526   {txt}
+        {txt}N                   {res}           74              74   {txt}
+        {txt}{hline 52}
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+{marker ex2}
+{dlgtab:t-statistics for selected variables only}
+
+        {com}. estout *, cells(b(star) t(par keep(mpg)))
+        {res}
+        {txt}{hline 44}
+        {txt}                       m1              m2
+        {txt}                      b/t             b/t
+        {txt}{hline 44}
+        {txt}weight      {res}     1.746559**      4.613589***{txt}
+        {txt}mpg         {res}    -.0495122        .2631875*  {txt}
+                    {res}  (-.5746806)      (2.375421)   {txt}
+        {txt}forXmpg     {res}                    -.3072165** {txt}
+        {txt}foreign     {res}                     11.24033***{txt}
+        {txt}_cons       {res}     1.946068       -14.44958** {txt}
+        {txt}{hline 44}
+{marker ex3}
+{dlgtab:Summary statistics only}
+
+        {com}. estout *, cells(none) stats(r2_a bic N, star)
+        {res}
+        {txt}{hline 44}
+        {txt}                       m1              m2
+        {txt}{hline 44}
+        {txt}r2_a        {res}     .2734846***     .5256351***{txt}
+        {txt}bic         {res}     356.2918        331.2406   {txt}
+        {txt}N           {res}           74              74   {txt}
+        {txt}{hline 44}
+{marker ex4}
+{dlgtab:Table of descriptives}
+
+        {com}. quietly generate x = uniform()
+        {txt}
+        {com}. quietly regress x price weight mpg foreign
+        {txt}
+        {com}. estadd mean
+
+        {txt}added matrix:
+                       e(mean) :  {res}1 x 5
+        {txt}
+        {com}. estadd sd, nobinary
+
+        {txt}added matrix:
+                         e(sd) :  {res}1 x 5
+        {txt}
+        {com}. estout, cells("mean sd") stats(N) mlabels(,none) drop(_cons)
+        {res}
+        {txt}{hline 38}
+        {txt}                     mean           sd
+        {txt}{hline 38}
+        {txt}price       {res}     6.165257     2.949496{txt}
+        {txt}weight      {res}     3.019459     .7771936{txt}
+        {txt}mpg         {res}      21.2973     5.785503{txt}
+        {txt}foreign     {res}     .2972973             {txt}
+        {txt}{hline 38}
+        {txt}N           {res}           74             {txt}
+        {txt}{hline 38}
+{marker ex5}
+{dlgtab:Unstack multiple equations}
+
+        {com}. quietly sureg (price foreign weight length) ///
+        >               (mpg displ = foreign weight)
+        {txt}
+        {com}. estout, cells(b t(par)) stats(r2 chi2 p) unstack
+        {res}
+        {txt}{hline 51}
+        {txt}                    price          mpg displacement
+        {txt}                      b/t          b/t          b/t
+        {txt}{hline 51}
+        {txt}foreign     {res}      3.57526    -1.650029     -25.6127{txt}
+                    {res}   (5.749891)  (-1.565555)  (-2.047999){txt}
+        {txt}weight      {res}     5.691462    -6.587886     96.75485{txt}
+                    {res}   (6.182983)  (-10.55641)   (13.06594){txt}
+        {txt}length      {res}    -.0882711                          {txt}
+                    {res}  (-2.809689)                          {txt}
+        {txt}_cons       {res}     4.506212      41.6797    -87.23547{txt}
+                    {res}   (1.255897)   (19.64914)   (-3.46585){txt}
+        {txt}{hline 51}
+        {txt}r2          {res}      .548808     .6627029     .8115213{txt}
+        {txt}chi2        {res}     89.73586     145.3912     318.6174{txt}
+        {txt}p           {res}     2.50e-19     2.68e-32     6.50e-70{txt}
+        {txt}{hline 51}
+{marker ex7}
+{dlgtab:Tabulating a matrix}
+
+{p 4 4 2}
+    Use {cmd:estout matrix(}{it:matname}{cmd:)} to tabulate Stata matrix
+    {it:matname}. Example:
+
+        {com}. set seed 123
+        {txt}
+        {com}. matrix A = matuniform(3,2)
+        {txt}
+        {com}. matrix list A
+
+        {txt}A[3,2]
+                c1         c2
+        r1  {res}.91204397   .0075452
+        {txt}r2  {res}.28085881  .46027868
+        {txt}r3  {res}.56010592  .67319061
+        {txt}
+        {com}. estout matrix(A)
+        {res}
+        {txt}{hline 38}
+        {txt}                        A
+        {txt}                       c1           c2
+        {txt}{hline 38}
+        {txt}r1          {res}      .912044     .0075452{txt}
+        {txt}r2          {res}     .2808588     .4602787{txt}
+        {txt}r3          {res}     .5601059     .6731906{txt}
+        {txt}{hline 38}
+
+{p 4 4 2}
+    Numeric formats for the columns can be set using the {cmd:fmt()}
+    suboption:
+
+        {com}. estout matrix(A, fmt(2 3))
+        {res}
+        {txt}{hline 38}
+        {txt}                        A
+        {txt}                       c1           c2
+        {txt}{hline 38}
+        {txt}r1          {res}         0.91        0.008{txt}
+        {txt}r2          {res}         0.28        0.460{txt}
+        {txt}r3          {res}         0.56        0.673{txt}
+        {txt}{hline 38}
+
+{p 4 4 2}
+    A list of formats can be specified for each column:
+
+        {com}. estout matrix(A, fmt("2 3 4" "4 3 2"))
+        {res}
+        {txt}{hline 38}
+        {txt}                        A
+        {txt}                       c1           c2
+        {txt}{hline 38}
+        {txt}r1          {res}         0.91       0.0075{txt}
+        {txt}r2          {res}        0.281        0.460{txt}
+        {txt}r3          {res}       0.5601         0.67{txt}
+        {txt}{hline 38}
+{marker rem}
+{title:Remarks}
+
+    Contents
+
+        {help estout##fmt:Numerical formats}
+        {help estout##spchar:Special characters}
+        {help estout##atvar:Using @-variables}
+        {help estout##defaults:Defaults files}
+{marker fmt}
+{dlgtab:Numerical formats}
+
+{p 4 4 2}
+Numerical display formats may be specified in {cmd:estout}
+as follows:
+
+{p 5 8 2}
+1. Official Stata's display formats: You may specify formats, such as
+{cmd:%9.0g} or {cmd:%8.2f}. See help {help format} for a list
+of available formats. {cmd:%g} or {cmd:g} may be used as a
+synonym for {cmd:%9.0g}.
+
+{p 5 8 2}
+2. Fixed format: You may specify an integer value such as {cmd:0},
+{cmd:1}, {cmd:2}, etc. to request a display format with a fixed number
+of decimal places. For example, {cmd:cells(t(fmt(3)))} would display
+t-statistics with three decimal places.
+
+{p 5 8 2}
+3. Automatic format: You may specify {cmd:a1}, {cmd:a2}, ..., or
+{cmd:a9} to cause {cmd:esttab} to choose a reasonable display format for
+each number depending on the number's value. {cmd:a} may be used as a
+synonym for {cmd:a3}. The {it:#} in
+{cmd:a}{it:#} determines the minimum precision according to the
+following rules:
+
+{p 10 12 2}
+o Absolute numbers smaller than 1 are displayed with {it:#}
+significant decimal places (i.e. with {it:#} decimal places ignoring
+any leading zeros after the decimal point). For example,
+{cmd:0.00123456} is displayed as {cmd:0.00123} if the format is
+{cmd:a3}.
+
+{p 10 12 2}
+o Absolute numbers greater than 1 are displayed with as many digits
+required to retain at least one decimal place and are displayed with
+a minimum of ({it:#} + 1) digits. For example, if the format is
+{cmd:a3}, {cmd:1.23456} is displayed as {cmd:1.235}, {cmd:12.3456} is
+displayed as {cmd:12.35}, and {cmd:1234.56} is displayed as
+{cmd:1234.6}.
+
+{p 10 12 2}
+o In any case, integers are displayed with zero decimal places, and
+very large or very small absolute numbers are displayed in
+exponential format.
+
+{marker spchar}
+{dlgtab:Special characters}
+
+{p 4 4 2}
+The {cmd:\} and {cmd:$} characters and quotation marks have
+special meanings in Stata. You should therefore consider the following
+instructions if you, for example, intend to specify akward delimiters or
+specify special characters in labels:
+
+{p 6 8 2}- Strings containing unmatched quotes should be enclosed in compound double
+quotes (thus, {cmd:delimiter(`"""')} results in columns
+delimited by {cmd:"}, while {cmd:delimiter(")} produces an error).
+
+{p 6 8 2}- The backslash character is used to delay macro expansion in
+Stata. Specifying {cmd:\\} in Stata 8 just results in the printing of {cmd:\}. To get
+a double backslash in Stata 8 (the {cmd:\newline} command in TeX), type {cmd:\\\}.
+
+{p 6 8 2}- The dollar sign is used for global macro expansion in Stata. Thus,
+{cmd:$x} would result in the display of the contents of global macro
+{cmd:x} (or nothing, if the macro is empty). Therefore, use
+{cmd:\$} to produce {cmd:$} in the output. For math mode in LaTeX I
+recommend using {cmd:\(}...{cmd:\)} instead of {cmd:$}...{cmd:$}.
+
+{p 4 4 2}
+Stata's {cmd:char()} function may also be used to specify odd characters
+(see help {help strfun}). In particular, {cmd:"`=char(9)'"}
+results in a tab character and {cmd:"`=char(13)'"} results
+in a carriage return. For example, {bind:{cmd:delimiter(" `=char(9)' ")}}
+specifies that a tab character with a leading and
+a trailing blank be used as delimiter.
+
+{p 4 4 2} {it:Tip:} It is sometimes very useful to set the format of all cells in a
+spreadsheet to "Text" before pasting the estimates table. This prevents the
+spreadsheet program from trying to interpret the cells and ensures that the contents
+of the table remain unchanged.
+
+{marker atvar}
+{dlgtab:Using @-variables}
+
+{p 4 4 2}
+{cmd:estout} features several variables that can be used within string
+specifications. The following list provides an overview of these variables.
+
+{p 5 8 2}o{space 2}In {cmd:prehead()},  {cmd:posthead()}, {cmd:prefoot()},
+  and {cmd:postfoot()}, in the {cmd:begin()} and {cmd:end()} label
+  suboptions, and in the {cmd:blist()} and {cmd:elist()} suboptions
+  in {cmd:varlabels()}:
+
+{p 12 16 2}{cmd:@span} to return the value of a count variable for the total number of physical
+  columns of the table.
+
+{p 12 16 2}{cmd:@M} to return the number of models in the table.
+
+{p 12 16 2}{cmd:@E} to return the total number columns containing separate equations.
+
+{p 12 16 2}{cmd:@width} to return the total width of the table (number of characters).
+
+{p 12 16 2}{cmd:@hline} to return a horizontal line (series of dashes, by default;
+  see the {cmd:hlinechar()} option).
+
+{p 5 8 2}o{space 2}In {cmd:prehead()},  {cmd:posthead()}, {cmd:prefoot()},
+  and {cmd:postfoot()}:
+
+{p 12 16 2}{cmd:@title} to return the title specified with the {cmd:title()} option.
+
+{p 12 16 2}{cmd:@note} to return the note specified with the {cmd:note()} option.
+
+{p 12 16 2}{cmd:@discrete} to return the explanations provided by the
+  {cmd:discrete()} option (provided that the  {cmd:margin} option is activated).
+
+{p 12 16 2}{cmd:@starlegend} to return a legend explaining the significance symbols.
+
+{p 5 8 2}o{space 2}In the   {cmd:prefix()} and {cmd:suffix()} suboptions of {cmd:mgroups()},
+  {cmd:mlabels()}, {cmd:eqlabels()}, and
+  {cmd:collabels()}, and in the labels specified in these options:
+
+{p 12 16 2}{cmd:@span} to return the number of spanned columns.
+
+{p 5 8 2}o{space 2}In the {cmd:erepeat()} suboption of
+  {cmd:mgroups()}, {cmd:mlabels()}, {cmd:eqlabels()}, and
+  {cmd:collabels()}:
+
+{p 12 16 2}{cmd:@span} to return the range of spanned columns (e.g. {cmd:2-4} if columns 2, 3 and 4
+  are spanned).
+
+{marker defaults}
+{dlgtab:Defaults files}
+
+{p 4 4 2}{ul:Creating new defaults files:}
+
+{p 4 4 2}
+To make available an own set
+of default options, proceed as follows:
+
+{p 8 11 2}
+1. Download "estout_mystyle.def" from the SSC
+Archive (click
+{stata "copy http://fmwww.bc.edu/repec/bocode/e/estout_mystyle.def estout_mystyle.def, text":here}
+to copy the file from SSC and store it in the working directory).
+
+{p 8 11 2}
+2. Open "estout_mystyle.def" in a text editor and make the desired modifications
+(click {stata "doedit estout_mystyle.def":here} to open "estout_mystyle.def" in Stata's Do-File
+Editor).
+
+{p 8 11 2}
+3. Save the file in the current directory or elsewhere
+in the ado-file path as {cmd:estout_}{it:newstyle}{cmd:.def} (see help {help sysdir}).
+
+{p 4 4 2}To use the new options set in {cmd:estout}, then type:
+
+        {inp:. estout} {it:...} {inp:, style(}{it:newstyle}{inp:)}
+
+
+{p 4 4 2}{ul:Defaults files syntax:}
+
+{p 4 4 2}
+{cmd:estout} has two main types of options, which are treated differentially
+in defaults files. On the one hand, there are simple on/off options without
+arguments, like {cmd:legend} or {cmd:showtabs}. To turn such an option on,
+enter the option followed by the options name as an argument, i.e. add the line
+
+        {it:option} {it:option}
+
+{p 4 4 2}
+to the defaults file. For example,
+
+        {inp:legend legend}
+
+{p 4 4 2}
+specifies that a legend be printed in the table footer. Otherwise, if you want
+to turn the option of, just delete or comment out the line that contains it (or
+specify {it:option} without an argument).
+
+{p 4 4 2}
+To temporarily turn off an option that has been activated in a defaults file,
+specify {cmd:no}{it:option} in the command line (do not, however, use
+{cmd:no}{it:option} in defaults files). For example, if the legend has been
+turned on in the defaults file, but you want to suppress it in a specific call of
+{cmd:estout}, type
+
+        {inp:. estout} {it:...}{inp:, nolegend}
+
+{p 4 4 2}
+On the other hand, there are options that take arguments, such as
+{cmd:prehead(}{it:args}{cmd:)}, {cmd:delimiter(}{it:args}{cmd:)}, or
+{cmd:stats(}{it:args}{cmd:,} {it:...}{cmd:)}. Such options are specified as
+
+        {it:option} {it:args}
+
+{p 4 4 2}
+in the defaults file (where {it:args} must not include suboptions; see
+below). Specifying an option in the command line overwrites the settings from
+the defaults file. However, note that a {cmd:no} form, which exists for the
+first options type, is not available here.
+
+{p 4 4 2}
+Last but not least, there are two options that reflect a combination of the first
+and second types: {cmd:eform}[{cmd:(}{it:args}{cmd:)}] and
+{cmd:margin}[{cmd:(}{it:args}{cmd:)}]. These options can be specified
+as either
+
+        {it:option} {it:option}
+
+{p 4 4 2}
+or
+
+        {it:option} {it:args}
+
+{p 4 4 2}
+in the defaults file; the {cmd:no} form is allowed.
+
+{p 4 4 2}
+Many {cmd:estout} options have suboptions, i.e., an option might take the
+form {it:option}{cmd:(}{it:...}{cmd:,} {it:suboption}{cmd:)} or
+{it:option}{cmd:(}{it:...}{cmd:,} {it:suboption}{cmd:(}{it:args}{cmd:))}. In
+the defaults file, the suboptions cannot be included in the
+definition of a higher-level option. Instead, they must be
+specified in their own lines, as either
+
+        {it:optionsuboption} {it:suboption}
+
+{p 4 4 2}
+or
+
+        {it:optionsuboption} {it:args}
+
+{p 4 4 2}
+In the case of a two-level nesting of options, the name
+used to refer to the suboption is a concatenation of the option's name and the
+suboption's name,
+i.e. {cmd:"}{it:optionsuboption}{cmd:"="}{it:option}{cmd:"+"}{it:suboption}{cmd:"}. For
+example, the {cmd:labels()} suboption of the {cmd:stats()} option would be
+set by the term {cmd:statslabels}. Analogously, the three level nesting in
+the {cmd:stats()} option yields suboption names composed of three names. For
+instance, the suboption called by the command
+
+        {inp:. estout} {it:...}{inp:, stats(}{it:...}{inp:, labels(}{it:...}{inp:, prefix(}{it:args}{inp:)))}
+
+{p 4 4 2}
+would be referred to as
+
+        {inp:statslabelsprefix} {it:args}
+
+{p 4 4 2}
+in the defaults file. The {cmd:cells()} option represents an exception to
+this rule. It may be defined in the defaults file using
+only a plain array of cells elements without suboptions, e.g.
+
+        {inp:cells "b se" p}
+
+{p 4 4 2}
+However, the suboptions of the cells elements may be referred to as
+{it:el_suboption}, for example
+
+        {inp:b_star star}
+
+{p 4 4 2}
+or
+
+        {inp:se_par [ ]}
+
+
+{p 4 4 2}{ul:Comments in defaults files:}
+
+{p 4 4 2}
+Be aware that the support for comments in defaults files is limited. In
+particular, the {cmd:/*} and {cmd:*/} comment indicators cannot be used.
+The other comment indicators work (more or less) as usual, that is:
+
+{p 5 8 2}
+ o{space 2}Empty lines and lines beginning with {cmd:*} (with or without preceding
+blanks) will be ignored.
+
+{p 5 8 2}
+ o{space 2}{cmd://} preceded by one or more blanks indicates that the rest of the
+line should be ignored. Lines beginning with {cmd://} (with or without preceding
+blanks) will be ignored.
+
+{p 5 8 2}
+ o{space 2}{cmd:///} preceded by one or more blanks indicates that the rest of the
+line should be ignored and the part of the line preceding it should be added to
+the next line. In other words, {cmd:///} can be used to split commands into
+two or more lines of code.
+
+{marker ret}
+{title:Saved results}
+
+{p 4 4 2}
+{cmd:estout} saves the following in {cmd:r()}:
+
+{p 4 4 2}Scalars
+    {p_end}
+{p 6 20 2}{cmd:r(nmodels)}{space 4}number of models
+    {p_end}
+{p 6 20 2}{cmd:r(ccols)}{space 6}number of columns per model in {cmd:r(coefs)}
+    {p_end}
+
+{p 4 4 2}Macros
+    {p_end}
+{p 6 20 2}{cmd:r(cmdline)}{space 4}command as typed
+    {p_end}
+{p 6 20 2}{cmd:r(names)}{space 6}names of models
+    {p_end}
+{p 6 20 2}{cmd:r(m}{it:#}{cmd:_}{it:name}{cmd:)}{space 4}model-specific
+macros where {it:#} is the model number and {it:name} is macro name
+    {p_end}
+
+{p 4 4 2}Matrices
+    {p_end}
+{p 6 20 2}{cmd:r(coefs)}{space 6}coefficients
+    {p_end}
+{p 6 20 2}{cmd:r(stats)}{space 6}summary statistics
+    {p_end}
+
+{marker ref}
+{title:References}
+
+{p 4 8 2}Cong, R. (2000). sg144: Marginal effects of the tobit model.
+{it:Stata Technical Bulletin} 56: 27-34.
+
+{p 4 8 2}Jann, B. (2005). Making regression tables from stored estimates.
+{it:The Stata Journal} 5(3): 288-308.
+
+{p 4 8 2}Jann, B. (2007). Making regression tables simplified.
+{it:The Stata Journal} 7(2): 227-244.
+
+{p 4 8 2}Newson, R. (2003). Confidence intervals and p-values for delivery to the end
+user. {it:The Stata Journal} 3(3): 245-269.
+
+{marker ack}
+{title:Acknowledgements}
+
+{p 4 4 2}I would like to thank numerous people
+for their comments and suggestions. Among them
+are
+Joao Pedro Azevedo,
+Kit Baum,
+Elisabeth Coutts,
+Henriette Engelhardt,
+Jonathan Gardnerand,
+Simone Hirschvogl,
+Daniel Hoechle,
+Friedrich Huebler,
+Maren Kandulla,
+J. Scott Long,
+David Newhouse,
+Clive Nicholas,
+Fredrik Wallenberg,
+Ian Watson, and
+Vince Wiggins.
+
+{marker aut}
+{title:Author}
+
+    Ben Jann, Institute of Sociology, University of Bern, jann@soz.unibe.ch
+
+{marker als}
+{title:Also see}
+
+    Manual:  {hi:[R] estimates}
+
+    SJ:      SJ5-3 st0085 (Jann 2005)
+             SJ7-2 st0085_1 (Jann 2007)
+
+{p 4 13 2}Online:  help for
+ {helpb estimates},
+ {help estcom},
+ {helpb est_table:estimates table},
+ {helpb ereturn},
+ {help format},
+ {helpb file},
+ {helpb mfx},
+ {helpb eststo},
+ {helpb esttab},
+ {helpb estadd},
+ {helpb estpost}
+{p_end}

--- a/analysis/extra_ados/estpost.ado
+++ b/analysis/extra_ados/estpost.ado
@@ -1,0 +1,2124 @@
+*! version 1.2.2  10feb2023  Ben Jann
+* 1. estpost
+* 2. estpost_summarize
+* 3. estpost_tabulate
+* 4. estpost_tabstat
+* 5. estpost_ttest
+* 6. estpost_correlate
+* 7. estpost_stci (Stata 9 required)
+* 8. estpost_ci
+* 9. estpost_prtest
+* 10. estpost__svy_tabulate
+* 12. estpost_gtabstat
+* 99. _erepost
+
+* 1. estpost
+program estpost, rclass // rclass => remove r()'s left behind by subcommand
+    version 8.2
+    local caller : di _caller()
+    capt syntax [, * ]
+    if _rc==0 { // => for bootstrap
+        _coef_table_header
+        ereturn display, `options'
+        exit
+    }
+    gettoken subcommand rest : 0, parse(" ,:")
+    capt confirm name `subcommand'
+    if _rc {
+        di as err "invalid subcommand"
+        exit 198
+    }
+
+    local l = length(`"`subcommand'"')
+         if `"`subcommand'"'==substr("summarize",1,max(2,`l')) local subcommand "summarize"
+    else if `"`subcommand'"'==substr("tabulate",1,max(2,`l'))  local subcommand "tabulate"
+    else if `"`subcommand'"'==substr("correlate",1,max(3,`l')) local subcommand "correlate"
+    else if `"`subcommand'"'=="svy" {
+        _estpost_parse_svy `macval(rest)'
+    }
+    else if substr(`"`subcommand'"',1,5)=="_svy_" {
+        di as err "invalid subcommand"
+        exit 198
+    }
+
+    capt local junk: properties estpost_`subcommand' // does not work in Stata 8
+    if _rc==199 {
+        di as err "invalid subcommand"
+        exit 198
+    }
+
+    version `caller': estpost_`subcommand' `macval(rest)'
+    //eret list
+end
+program _estpost_markout2 // marks out obs that are missing on *all* variables
+    gettoken touse varlist: 0
+    if `:list sizeof varlist'>0 {
+        tempname touse2
+        gen byte `touse2' = 0
+        foreach var of local varlist {
+            qui replace `touse2' = 1 if !missing(`var')
+        }
+        qui replace `touse' = 0 if `touse2'==0
+    }
+end
+program _estpost_parse_svy
+    version 9.2
+    _on_colon_parse `0'
+    local 0 `"`s(after)'"'
+    gettoken subcommand rest : 0, parse(" ,")
+    local l = length(`"`subcommand'"')
+    if `"`subcommand'"'==substr("tabulate",1,max(2,`l'))  local subcommand "tabulate"
+    c_local subcommand `"_svy_`subcommand'"'
+    c_local rest `"`s(before)' : `rest'"'
+end
+program _estpost_namesandlabels // used by some routines such as estpost_tabulate
+    version 8.2                 // returns locals names, savenames, and labels
+    args varname values0 labels0 elabel
+    if `"`values0'"'=="" { // generate values: 1 2 3 ...
+        local i 0
+        foreach label of local labels0 {
+            local values0 `values0' `++i'
+        }
+    }
+    local haslabels = "`elabel'"!=""
+    if `"`labels0'"'=="" & "`varname'"!="" {
+        local vallab: value label `varname'
+    }
+    while (1) {
+        gettoken value values0 : values0
+        if "`value'"=="" continue, break  //=> exit loop
+        if `"`vallab'"'!="" {
+            local lbl: label `vallab' `value', strict
+        }
+        else {
+            gettoken lbl labels0 : labels0
+        }
+        if index("`value'",".") {
+            local haslabels 1
+            if `"`macval(lbl)'"'=="" {
+                local lbl "`value'"
+            }
+            local value: subinstr local value "." "_missing_"
+        }
+        local names0 `names0' `value'
+        if `"`macval(lbl)'"'!="" {
+            local labels `"`macval(labels)'`lblspace'`value' `"`macval(lbl)'"'"'
+            local lblspace " "
+        }
+        if `haslabels' continue
+        if `"`macval(lbl)'"'=="" {
+            local names `"`names'`space'`value'"'
+            local savenames `"`savenames'`space'`value'"'
+        }
+        else {
+            if regexm(`"`macval(lbl)'"', `"[:."]"') local haslabels 1
+            else if length(`"`macval(lbl)'"')>30    local haslabels 1
+            else {
+                local names `"`names'`space'`"`lbl'"'"'
+                local lbl: subinstr local lbl " " "_", all
+                local savenames `"`savenames'`space'`lbl'"'
+            }
+        }
+        local space " "
+    }
+    if `haslabels' {
+        local names `names0'
+        local savenames `names0'
+    }
+    c_local names       `"`names'"'         // to be used as matrix row- or colnames
+    c_local savenames   `"`savenames'"'     // names without spaces (for matlist)
+    if `haslabels' {
+        c_local labels      `"`macval(labels)'"'    // label dictionary
+    }
+    else c_local labels ""
+end
+program _estpost_eqnamesandlabels // used by some routines such as estpost_tabulate
+    version 8.2                   // returns locals eqnames and eqlabels
+    args varname values0 labels0 elabel
+    if `"`values0'"'=="" { // generate values: 1 2 3 ...
+        local i 0
+        foreach label of local labels0 {
+            local values0 `values0' `++i'
+        }
+    }
+    local haslabels = "`elabel'"!=""
+    if `"`labels0'"'=="" & "`varname'"!="" {
+        local vallab: value label `varname'
+    }
+    while (1) {
+        gettoken value values0 : values0
+        if "`value'"=="" continue, break  //=> exit loop
+        if `"`vallab'"'!="" {
+            local lbl: label `vallab' `value', strict
+        }
+        else {
+            gettoken lbl labels0 : labels0
+        }
+        if index("`value'",".") {
+            local haslabels 1
+            if `"`macval(lbl)'"'=="" {
+                local lbl "`value'"
+            }
+            local value: subinstr local value "." "_missing_"
+        }
+        local names0 `names0' `value'
+        if `"`macval(lbl)'"'=="" local lbl "`value'"
+        local labels `"`macval(labels)'`lblspace'`"`macval(lbl)'"'"'
+        local lblspace " "
+        if `haslabels' continue
+        if `"`macval(lbl)'"'=="" {
+            local names `"`names'`space'`value'"'
+        }
+        else {
+            if regexm(`"`macval(lbl)'"', `"[:."]"') local haslabels 1
+            else if length(`"`macval(lbl)'"')>30    local haslabels 1
+            else {
+                local names `"`names'`space'`"`lbl'"'"'
+            }
+        }
+        local space " "
+    }
+    if `haslabels' {
+        local names `names0'
+    }
+    c_local eqnames       `"`names'"'         // to be used as matrix roweqs or coleqs
+    if `haslabels' {
+        c_local eqlabels  `"`macval(labels)'"'        // list of labels
+    }
+    else c_local eqlabels ""
+end
+
+* 2. estpost_summarize: wrapper for -summarize-
+prog estpost_summarize, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax [varlist] [if] [in] [aw fw iw] [, ESample Quietly ///
+        LISTwise CASEwise Detail MEANonly ]
+    if "`casewise'"!="" local listwise listwise
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    local nvars: list sizeof varlist
+    tempname emptymat
+    mat `emptymat' = J(1, `nvars', .)
+    mat coln `emptymat' = `varlist'
+    local i 0
+    local rnames ""
+    foreach v of local varlist {
+        local ++i
+        qui summarize `v' if `touse' [`weight'`exp'], `detail' `meanonly'
+        local rnamesi: r(scalars)
+        local rnamesi: list rnamesi - rnames
+        if `"`rnamesi'"'!="" {
+            foreach name of local rnamesi {
+                tempname _`name'
+                mat `_`name'' = `emptymat'
+            }
+            local rnames: list rnames | rnamesi
+        }
+        foreach rname of local rnames {
+            mat `_`rname''[1,`i'] = r(`rname')
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        local rescoln
+        foreach rname of local rnames {
+            mat `res' = nullmat(`res'), `_`rname'''
+            if "`rname'"=="N" {
+                local rescoln `rescoln' e(count)
+            }
+            else {
+                local rescoln `rescoln' e(`rname')
+            }
+        }
+        mat coln `res' = `rescoln'
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            matlist `res', nohalf lines(oneline)
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local b
+    local V
+    if c(stata_version)<9 { // b and V required in Stata 8
+        tempname b V
+        mat `b' = J(1, `nvars', 0)
+        mat coln `b' = `varlist'
+        mat `V' = `b'' * `b'
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `b' `V', obs(`N') `esample'
+
+    eret scalar k = `nvars'
+
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local subcmd "summarize"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof rnames
+    forv i=`nmat'(-1)1 {
+        local rname: word `i' of `rnames'
+        if "`rname'"=="N" {
+            eret matrix count = `_N'
+            continue
+        }
+        eret matrix `rname' = `_`rname''
+    }
+end
+
+
+* 2. estpost_tabulate: wrapper for -tabulate-
+prog estpost_tabulate, eclass
+    version 8.2
+    local caller : di _caller() // not used
+    syntax varlist(min=1 max=2) [if] [in] [fw aw iw pw] [, * ]
+    if `:list sizeof varlist'==1 {
+        version `caller': estpost_tabulate_oneway `0'
+    }
+    else {
+        version `caller': estpost_tabulate_twoway `0'
+    }
+end
+prog estpost_tabulate_oneway, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varname [if] [in] [fw aw iw] [, ESample Quietly ///
+        noTOTal subpop(passthru) Missing sort noLabel ELabels ]
+
+    // sample
+    if "`missing'"!="" marksample touse, nov strok
+    else               marksample touse, strok
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // handle string variables
+    capt confirm numeric variable `varlist'
+    if _rc {
+        tempname varname
+        qui encode `varlist' if `touse', generate(`varname')
+    }
+    else local varname `varlist'
+
+    // gather results
+    tempname count vals
+    tab `varname' if `touse' [`weight'`exp'], nofreq ///
+        matcell(`count') matrow(`vals') `subpop' `missing' `sort'
+    local N = r(N)
+    mat `count' = `count''
+    local R = r(r)
+    forv r = 1/`R' {
+        local value: di `vals'[`r',1]
+        local values `values' `value'
+    }
+    if "`label'"=="" {
+        _estpost_namesandlabels `varname' "`values'" "" "`elabels'" // sets names, savenames, labels
+    }
+    else {
+        _estpost_namesandlabels "" "`values'" "" "`elabels'"
+    }
+    if "`total'"=="" {
+        mat `count' = `count', `N'
+        local names `"`names' Total"'
+        local savenames `"`savenames' Total"'
+        local linesopt "lines(rowtotal)"
+    }
+    mat colname `count' = `names'
+    tempname percent cum
+    mat `percent' = `count'/`N'*100
+    mat `cum' = J(1, colsof(`count'), .z)
+    mat colname `cum' = `names'
+    mat `cum'[1,1] = `count'[1,1]
+    forv r = 2/`R' {
+        mat `cum'[1,`r'] = `cum'[1,`r'-1] + `count'[1,`r']
+    }
+    mat `cum' = `cum'/`N'*100
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `count'', `percent'', `cum''
+        mat coln `res' = e(b) e(pct) e(cumpct)
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g) nodotz
+        }
+        else {
+            mat rown `res' = `savenames'
+            matlist `res', nohalf `linesopt' rowtitle(`varlist') nodotz
+        }
+        mat drop `res'
+        if `"`macval(labels)'"'!="" {
+            di _n as txt "row labels saved in macro e(labels)"
+        }
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = `count'' * `count' * 0
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `count' `V', depname(`varlist') obs(`N') `esample'
+    eret scalar r = r(r)
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local labels `"`macval(labels)'"'
+    eret local depvar "`varlist'"
+    eret local subcmd "tabulate"
+    eret local cmd "estpost"
+    eret mat cumpct = `cum'
+    eret mat pct   = `percent'
+end
+prog estpost_tabulate_twoway, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist(min=2 max=2) [if] [in] [fw aw iw] [, ESample Quietly ///
+        noTOTal Missing noLabel ELabels ///
+        CHi2 Exact Exact2(passthru) Gamma LRchi2 Taub v All noLOg ]
+    local v = upper("`v'")
+    local qui2 "`quietly'"
+    local hastests = `"`chi2'`exact'`exact2'`gamma'`lrchi2'`taub'`v'`all'"'!=""
+    if `hastests' local nofreq nofreq
+    else local qui2 "quietly"
+
+    // sample
+    if "`missing'"!="" marksample touse, nov strok
+    else               marksample touse, strok
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // handle string variables
+    gettoken rvar cvar : varlist
+    gettoken cvar : cvar
+    foreach d in r c {
+        capt confirm numeric variable ``d'var'
+        if _rc {
+            tempname `d'varname
+            qui encode ``d'var' if `touse', generate(``d'varname')
+        }
+        else local `d'varname ``d'var'
+    }
+
+    // gather results
+    tempname cell rvals cvals
+    if `hastests' {
+        `quietly' di ""
+    }
+    `qui2' tab `rvarname' `cvarname' if `touse' [`weight'`exp'], `nofreq' ///
+        matcell(`cell') matrow(`rvals') matcol(`cvals') `missing' ///
+        `chi2' `exact' `exact2' `gamma' `lrchi2' `taub' `v' `all' `log'
+    mat `cvals' = `cvals''
+    local N = r(N)
+    tempname rtot ctot
+    mat `ctot' = J(1,rowsof(`cell'),1) * `cell'
+    mat `rtot' =  `cell' * J(colsof(`cell'),1,1)
+    foreach d in r c {
+        local I = r(`d')
+        forv i = 1/`I' {
+            local value: di ``d'vals'[`i',1]
+            local `d'values ``d'values' `value'
+        }
+    }
+    if "`label'"=="" {
+        _estpost_namesandlabels `rvarname' "`rvalues'" "" "`elabels'" // sets names, savenames, labels
+        _estpost_eqnamesandlabels `cvarname' "`cvalues'" "" "`elabels'" // sets eqnames, eqlabels
+    }
+    else {
+        _estpost_namesandlabels "" "`rvalues'" "" "`elabels'" // sets names, savenames, labels
+        _estpost_eqnamesandlabels "" "`cvalues'" "" "`elabels'" // sets eqnames, eqlabels
+    }
+    local savenames0 `"`savenames'"'
+    local savenames
+    if "`total'"=="" {
+        mat `ctot' = `ctot', `N'
+        mat `cell' = (`cell', `rtot') \ `ctot'
+        mat `rtot' = `rtot' \ `N'
+        local names      `"`names' Total"'
+        local savenames0 `"`savenames0' Total"'
+        local eqnames    `"`eqnames' Total"'
+    }
+    mat rowname `cell' = `names'
+    tempname count col row tot tmp
+    forv i = 1/`=colsof(`cell')' {
+        gettoken eq eqnames : eqnames
+        mat `tmp' = `cell'[1...,`i']
+        mat roweq `tmp' = `"`eq'"'
+        mat `tmp' = `tmp''
+        mat `count' = nullmat(`count'), `tmp'
+        mat `col' = nullmat(`col'), `tmp' / `ctot'[1,`i']*100
+        forv j = 1/`=colsof(`tmp')' {
+            mat `tmp'[1,`j'] = `tmp'[1,`j'] / `rtot'[`j',1]*100
+        }
+        mat `row' = nullmat(`row'), `tmp'
+        local savenames `"`savenames' `savenames0'"'
+    }
+    mat `tot' = `count' / `N'*100
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `count'', `tot'', `col'', `row''
+        mat coln `res' = e(b) e(pct) e(colpct) e(rowpct)
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            mat rown `res' = `savenames'
+            di _n as res %-12s abbrev("`cvar'",12) as txt " {c |}{space 44}"
+            matlist `res', twidth(12) format(%9.0g) noblank nohalf rowtitle(`rvar')
+        }
+        mat drop `res'
+        if `"`macval(labels)'`macval(eqlabels)'"'!="" {
+            di ""
+            if `"`macval(labels)'"'!="" {
+                di as txt "row labels saved in macro e(labels)"
+            }
+            if `"`macval(eqlabels)'"'!="" {
+                di as txt "column labels saved in macro e(eqlabels)"
+            }
+        }
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = `count'' * `count' * 0
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `count' `V', obs(`N') `esample'
+    local rscalars: r(scalars)
+    local rscalars: subinstr local rscalars "N" "", word
+    foreach rsc of local rscalars {
+        eret scalar `rsc' = r(`rsc')
+    }
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local labels `"`macval(labels)'"'
+    eret local eqlabels `"`macval(eqlabels)16jun2015'"'
+    eret local colvar "`cvar'"
+    eret local rowvar "`rvar'"
+    eret local subcmd "tabulate"
+    eret local cmd "estpost"
+    eret mat rowpct = `row'
+    eret mat colpct = `col'
+    eret mat pct = `tot'
+end
+
+
+* 4. estpost_tabstat: wrapper for -tabstat-
+prog estpost_tabstat, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist [if] [in] [aw fw] [, ESample Quietly ///
+          Statistics(passthru) stats(passthru) LISTwise CASEwise ///
+          by(varname) noTotal Missing Columns(str) ELabels ]
+    if "`casewise'"!="" local listwise listwise
+    local l = length(`"`columns'"')
+    if `"`columns'"'==substr("variables",1,max(1,`l')) local columns "variables"
+    else if `"`columns'"'==substr("statistics",1,max(1,`l')) local columns "statistics"
+    else if `"`columns'"'=="stats" local columns "statistics"
+    else if `"`columns'"'=="" {
+        if `:list sizeof varlist'>1 local columns "variables"
+        else local columns "statistics"
+    }
+    else {
+        di as err `"columns(`columns') invalid"'
+        exit 198
+    }
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    if "`by'"!="" {
+        capt confirm string variable `by'
+        local numby = (_rc!=0)
+        if `numby' {
+            tempname tmpby
+            qui gen `:type `by'' `tmpby' = `by'
+        }
+        else local tmpby `by'
+        if "`missing'"=="" markout `touse' `by', strok
+        local byopt "by(`tmpby')"
+    }
+    else local numby 0
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    if "`total'"!="" & "`by'"=="" {
+        di as txt "nothing to post"
+        eret clear
+        exit
+    }
+    qui tabstat `varlist' if `touse' [`weight'`exp'], save ///
+        `statistics' `stats' `byopt' `total' `missing' columns(`columns')
+    tempname tmp
+    capt confirm matrix r(StatTot)
+    if _rc {
+        mat `tmp' = r(Stat1)
+    }
+    else {
+        mat `tmp' = r(StatTot)
+    }
+    if `"`columns'"'=="statistics" {
+        local cnames: rownames `tmp'
+        local cnames: subinstr local cnames "N" "count", word all
+        local cnames: subinstr local cnames "se(mean)" "semean", word all
+        local R = colsof(`tmp')
+        local stats "`cnames'"
+        local vars: colnames `tmp'
+    }
+    else {
+        local cnames: colnames `tmp'
+        local R = rowsof(`tmp')
+        local stats: rownames `tmp'
+        local stats: subinstr local stats "N" "count", word all
+        local stats: subinstr local stats "se(mean)" "semean", word all
+        local vars "`cnames'"
+        local cnames: subinstr local cnames "b" "_b", word all
+        local cnames: subinstr local cnames "V" "_V", word all
+    }
+    local j 0
+    foreach cname of local cnames {
+        tempname _`++j'
+    }
+    local groups: r(macros)
+    local g: list sizeof groups
+    local space
+    local labels
+    forv i = 1/`g' {
+        local labels `"`labels'`space'`"`r(name`i')'"'"'
+    }
+    if `R'==1 {
+        if `numby' {
+            _estpost_namesandlabels "`by'" `"`labels'"' "" "`elabels'" // sets names, savenames, labels
+        }
+        else {
+            _estpost_namesandlabels "" "" `"`labels'"' "`elabels'" // sets names, savenames, labels
+        }
+    }
+    else {
+        if `numby' {
+            _estpost_eqnamesandlabels "`by'" `"`labels'"' "" "`elabels'" // sets eqnames, eqlabels
+        }
+        else {
+            _estpost_eqnamesandlabels "" "" `"`labels'"' "`elabels'" // sets eqnames, eqlabels
+        }
+        local names `"`eqnames'"'
+        local labels `"`macval(eqlabels)'"'
+    }
+    forv i = 1/`g' {
+        gettoken name names : names
+        mat `tmp' = r(Stat`i')
+        mat rown `tmp' = `stats'
+        if `"`columns'"'=="statistics" {
+            mat `tmp' = `tmp''
+        }
+        if `R'==1 {
+            mat rown `tmp' = `"`name'"'
+        }
+        else {
+            mat roweq `tmp' = `"`name'"'
+        }
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `_`j'' = nullmat(`_`j''), `tmp'[1..., `j']'
+        }
+    }
+    if "`total'"=="" {
+        mat `tmp' = r(StatTot)
+        mat rown `tmp' = `stats'
+        if `"`columns'"'=="statistics" {
+            mat `tmp' = `tmp''
+        }
+        if `g'>0 {
+            if `R'==1 {
+                mat rown  `tmp' = "Total"
+                local savenames `"`savenames' Total"'
+                local rowtotal "lines(rowtotal)"
+            }
+            else {
+                mat roweq `tmp' = "Total"
+                if `"`labels'"'!="" {
+                    local labels `"`macval(labels)' Total"'
+                }
+            }
+        }
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `_`j'' = nullmat(`_`j''), `tmp'[1..., `j']'
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        local rescoln
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `res' = nullmat(`res'), `_`j'''
+            local rescoln `rescoln' e(`cname')
+        }
+        mat coln `res' = `rescoln'
+        di _n as txt "Summary statistics: `stats'"
+        di    as txt "     for variables: `vars'"
+        if "`by'"!="" {
+            di as txt "  by categories of: `by'"
+        }
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            if `R'==1 & `g'>0 {
+                mat rown `res' = `savenames'
+            }
+            matlist `res', nohalf `rowtotal' rowtitle(`by')
+        }
+        if `"`macval(labels)'"'!="" {
+            di _n as txt "category labels saved in macro e(labels)"
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local b
+    local V
+    if c(stata_version)<9 { // b and V required in Stata 8
+        tempname b V
+        mat `b' = `_1' \ J(1, colsof(`_1'), 0)
+        mat `b' = `b'[2,1...]
+        mat `V' = `b'' * `b'
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `b' `V', obs(`N') `esample'
+
+    eret local labels `"`macval(labels)'"'
+    eret local byvar "`by'"
+    eret local vars "`vars'"
+    eret local stats "`stats'"
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local subcmd "tabstat"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof cnames
+    forv j=`nmat'(-1)1 {
+        local cname: word `j' of `cnames'
+        eret matrix `cname' = `_`j''
+    }
+end
+
+
+* 5. estpost_ttest: wrapper for -ttest- (two-sample)
+prog estpost_ttest, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist(numeric) [if] [in] , by(varname) [ ESample Quietly ///
+         LISTwise CASEwise UNEqual Welch ]
+    if "`casewise'"!="" local listwise listwise
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    markout `touse' `by', strok
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    local nvars: list sizeof varlist
+    tempname diff count
+    mat `diff' = J(1, `nvars', .)
+    mat coln `diff' = `varlist'
+    mat `count' = `diff'
+    local mnames se /*sd*/ t df_t p_l p p_u N_1 mu_1 /*sd_1*/ N_2 mu_2 /*sd_2*/
+    foreach m of local mnames {
+        tempname `m'
+        mat ``m'' = `diff'
+    }
+    local i 0
+    foreach v of local varlist {
+        local ++i
+        qui ttest `v' if `touse', by(`by') `unequal' `welch'
+        mat `diff'[1,`i'] = r(mu_1) - r(mu_2)
+        mat `count'[1,`i'] = r(N_1) + r(N_2)
+        foreach m of local mnames {
+            mat ``m''[1,`i'] = r(`m')
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `diff'', `count''
+        local rescoln "e(b) e(count)"
+        foreach m of local mnames {
+            mat `res' = `res', ``m'''
+            local rescoln `rescoln' e(`m')
+        }
+        mat coln `res' = `rescoln'
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            matlist `res', nohalf lines(oneline)
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = diag(vecdiag(`se'' * `se'))
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `diff' `V', obs(`N') `esample'
+
+    eret scalar k = `nvars'
+
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local welch "`welch'"
+    eret local unequal "`unequal'"
+    eret local byvar "`by'"
+    eret local subcmd "ttest"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof mnames
+    forv i=`nmat'(-1)1 {
+        local m: word `i' of `mnames'
+        eret matrix `m' = ``m''
+    }
+    eret matrix count = `count'
+end
+
+
+* 6. estpost_correlate: wrapper for -correlate-
+prog estpost_correlate, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist [if] [in] [aw fw iw pw] [, ESample Quietly ///
+        LISTwise CASEwise Matrix noHalf noLabel ELabels ELabels2(str asis) ///
+        Print(real 1) /*Covariance*/ Bonferroni SIDak ]
+    if "`casewise'"!="" local listwise listwise
+    if "`bonferroni'"!="" & "`sidak'"!="" {
+        di as err "only one of bonferroni and sidak allowed"
+        exit 198
+    }
+    local pw = ("`weight'"=="pweight")
+    if `:list sizeof varlist'<=1 & `"`matrix'"'=="" {
+        di as err "too few variables specified"
+        exit 102
+    }
+    if `"`matrix'"'!="" & `"`half'"'!="" local fullmatrix fullmatrix
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    tempname b rho pval count
+    if "`bonferroni'`sidak'"!="" {
+        local nvars : list sizeof varlist
+        local k = `nvars' * (`nvars'-1) / 2
+    }
+    foreach depvar of local varlist {
+        if `"`fullmatrix'"'!="" {
+            local indepvars `varlist'
+        }
+        else if `"`matrix'"'!="" {
+            local indepvars `depvar' `ferest()'
+        }
+        else {
+            local indepvars `ferest()'
+        }
+        foreach v of local indepvars {
+            qui reg `depvar' `v' [`weight'`exp'] if `touse'
+            local r = sqrt(e(r2)) * (-1)^(_b[`v']<0)
+            local n = e(N)
+            mat `b' = nullmat(`b'), `r'
+            if "`depvar'"=="`v'" {
+                mat `rho'  = nullmat(`rho'), `r'
+                mat `count' = nullmat(`count'), `n'
+                mat `pval' = nullmat(`pval'), .z
+                continue
+            }
+            local p = Ftail(e(df_m), e(df_r), e(F))
+            if `pw' {
+                qui reg `v' `depvar' [`weight'`exp'] if `touse'
+                local p = max(`p', Ftail(e(df_m), e(df_r), e(F)))
+            }
+            if "`bonferroni'"!="" {
+                local p = min(1, `k'*`p')
+            }
+            else if "`sidak'"!="" {
+                local p = min(1, 1 - (1-`p')^`k')
+            }
+            if `p'>`print' {
+                local r .z
+                local n .z
+                local p .z
+            }
+            mat `rho'  = nullmat(`rho'), `r'
+            mat `count' = nullmat(`count'), `n'
+            mat `pval' = nullmat(`pval'), `p'
+        }
+        if `"`matrix'`fullmatrix'"'=="" {
+            local colnames `indepvars'
+            local depname `depvar'
+            continue, break
+        }
+        foreach v of local indepvars {
+            local colnames `"`colnames'`depvar':`v' "'
+        }
+    }
+    mat coln `b' = `colnames'
+    mat coln `rho' = `colnames'
+    mat coln `count' = `colnames'
+    mat coln `pval' = `colnames'
+    local vce `"`e(vce)'"'          // from last -regress- call
+    local vcetype `"`e(vcetype)'"'
+    
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `b'', `rho'', `pval'', `count''
+        mat coln `res' = e(b) e(rho) e(p) e(count)
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g) nodotz
+        }
+        else {
+            matlist `res', nohalf lines(oneline) rowtitle(`depname') nodotz
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = `b'' * `b' * 0
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `b' `V', depname(`depname') obs(`N') `esample'
+    eret local vcetype `"`vcetype'"'
+    eret local vce `"`vce'"'
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local depvar `depname'
+    eret local subcmd "correlate"
+    eret local cmd "estpost"
+    eret matrix count = `count'
+    eret matrix p = `pval'
+    eret matrix rho = `rho'
+    // additional labels in case of matrix
+    if `"`matrix'"'=="" exit
+    if `"`elabels'`elabels2'"'=="" exit
+    gettoken lhs rhs : elabels2
+    gettoken rhs     : rhs
+    local space
+    local vlbls
+    local eqlbls
+    local i 0
+    foreach v of local varlist {
+        local ++i
+        local num `"`lhs'`i'`rhs'"'
+        local eqlbls `"`eqlbls'`space'`"`num'"'"'
+        local space " "
+        local lbl
+        if "`label'"=="" {
+            local lbl: var lab `v'
+        }
+        if `"`lbl'"'=="" local lbl "`v'"
+        local vlbls `vlbls' `v' `"`num' `lbl'"'
+    }
+    eret local labels `"`vlbls'"'
+    eret local eqlabels `"`eqlbls'"'
+end
+
+
+* 7. estpost_stci: wrapper for -stci-
+prog estpost_stci, eclass
+    version 9.2                 // Stata 8 not supported because levelsof is used
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax [if] [in] [ , ESample Quietly by(varname) ///
+        Median Rmean Emean p(numlist >0 <100 integer max=1) ///
+        CCorr Level(real `c(level)') ELabels ]
+    local stat "p50"
+    if `"`p'"'!="" {
+        local stat `"p`p'"'
+        local p `"p(`p')"'
+    }
+    else if "`rmean'"!=""   local stat "rmean"
+    else if "`emean'"!=""   local stat "emean"
+
+    // sample
+    marksample touse
+    if `"`by'"'!="" {
+        markout `touse' `by', strok
+    }
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // get results
+    tempname _`stat' se N_sub lb ub
+    if "`by'"!="" {
+        qui levelsof `by' if `touse', local(levels)
+        capt confirm string variable `by'
+        if _rc {
+            local vallab: value label `by'
+            if `"`vallab'"'!="" {
+                _estpost_namesandlabels `by' `"`levels'"' "" "`elabels'" // sets names, savenames, labels
+            }
+            else {
+                local names `"`levels'"'
+                local savenames `"`levels'"'
+            }
+        }
+        else {
+            _estpost_namesandlabels `by' "" `"`levels'"' "`elabels'" // sets names, savenames, labels
+        }
+    }
+    local levels `"`levels' "total""'
+    local names `"`names' "total""'
+    local savenames `"`savenames' "total""'
+    gettoken l rest : levels, quotes
+    while (`"`l'"'!="") {
+        if `"`rest'"'=="" local lcond
+        else              local lcond `" & `by'==`l'"'
+        qui stci if `touse'`lcond', `median' `rmean' `emean' `p' `ccorr' level(`level')
+        mat `_`stat'' = nullmat(`_`stat''), r(`stat')
+        mat `se' = nullmat(`se'), r(se)
+        mat `N_sub' = nullmat(`N_sub'), r(N_sub)
+        mat `lb' = nullmat(`lb'), r(lb)
+        mat `ub' = nullmat(`ub'), r(ub)
+        gettoken l rest : rest, quotes
+    }
+    foreach m in _`stat' se N_sub lb ub {
+        mat coln ``m'' = `names'
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `N_sub'', `_`stat''', `se'', `lb'', `ub''
+        mat coln `res' = e(count) e(`stat') e(se) e(lb) e(ub)
+        di as txt "(confidence level is " `level' "%)"
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g) nodotz
+        }
+        else {
+            mat rown `res' = `savenames'
+            matlist `res', nohalf lines(rowtotal) nodotz
+        }
+        mat drop `res'
+        if `"`labels'"'!="" {
+            di _n as txt "labels saved in macro e(labels)"
+        }
+    }
+
+    // post results
+    local b
+    local V
+    if c(stata_version)<9 { // b and V required in Stata 8
+        tempname b V
+        mat `b' = `_`stat'' \ J(1, colsof(`_`stat''), 0)
+        mat `b' = `b'[2,1...]
+        mat `V' = `b'' * `b'
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `b' `V', obs(`N') `esample'
+    eret scalar level = `level'
+
+    eret local ccorr `ccorr'
+    eret local labels `"`labels'"'
+    eret local subcmd "stci"
+    eret local cmd "estpost"
+
+    eret matrix ub = `ub'
+    eret matrix lb = `lb'
+    eret matrix se = `se'
+    eret matrix `stat' = `_`stat''
+    eret matrix count = `N_sub'
+end
+
+
+* 8. estpost_ci: wrapper for -ci-
+prog estpost_ci, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax [varlist] [if] [in] [aw fw], [ ESample Quietly ///
+         LISTwise CASEwise Level(real `c(level)') ///
+         Binomial EXAct WAld Wilson Agresti Jeffreys ///
+         Poisson Exposure(varname) ///
+         ]
+    if "`casewise'"!="" local listwise listwise
+    if "`exposure'"!="" local exposureopt "exposure(`exposure')"
+    if "`binomial'"!="" & "`exact'`wald'`wilson'`agresti'`jeffreys'"=="" local exact exact
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    local mnames se lb ub
+    tempname mean count `mnames'
+    local i 0
+    foreach v of local varlist {
+        local ++i
+        qui ci `v' if `touse' [`weight'`exp'], level(`level') ///
+            `binomial' `exact' `wald' `wilson' `agresti' `jeffreys' ///
+            `poisson' `exposureopt'
+        if r(N)>=. continue
+        mat `mean' = nullmat(`mean'), r(mean)
+        mat `count' = nullmat(`count'), r(N)
+        foreach m of local mnames {
+            mat ``m'' = nullmat(``m''), r(`m')
+        }
+        local rnames "`rnames' `v'"
+    }
+    capt confirm matrix `count'
+    if _rc {
+        di as txt "nothing to post"
+        eret clear
+        exit
+    }
+    foreach m in mean count `mnames' {
+        mat coln ``m'' = `rnames'
+    }
+    if "`listwise'"=="" { // update sample
+        if colsof(`count') < `: list sizeof varlist' {
+            _estpost_markout2 `touse' `rnames'
+            qui count if `touse'
+            local N = r(N)
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `mean'', `count''
+        local rescoln "e(b) e(count)"
+        foreach m of local mnames {
+            mat `res' = `res', ``m'''
+            local rescoln `rescoln' e(`m')
+        }
+        mat coln `res' = `rescoln'
+        di as txt "(confidence level is " `level' "%)"
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            matlist `res', nohalf lines(oneline)
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = diag(vecdiag(`se'' * `se'))
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `mean' `V', obs(`N') `esample'
+
+    eret scalar k = colsof(`count')
+    eret scalar level = `level'
+
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local exposure "`exposure'"
+    eret local poisson "`poisson'"
+    eret local binomial "`exact'`wald'`wilson'`agresti'`jeffreys'"
+    eret local subcmd "ci"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof mnames
+    forv i=`nmat'(-1)1 {
+        local m: word `i' of `mnames'
+        eret matrix `m' = ``m''
+    }
+    eret matrix count = `count'
+end
+
+
+* 9. estpost_prtest: wrapper for -prtest- (two-sample)
+prog estpost_prtest, eclass
+    version 8.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist(numeric) [if] [in] , by(varname) [ ESample Quietly ///
+         LISTwise CASEwise  ]
+    if "`casewise'"!="" local listwise listwise
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    markout `touse' `by', strok
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    // gather results
+    local nvars: list sizeof varlist
+    tempname diff count
+    mat `count' = J(1, `nvars', .)
+    mat coln `count' = `varlist'
+    mat `diff' = `count'
+    local mnames se se0 z p_l p p_u N_1 P_1 N_2 P_2
+    foreach m of local mnames {
+        tempname `m'
+        mat ``m'' = `count'
+    }
+    local i 0
+    foreach v of local varlist {
+        local ++i
+        qui prtest `v' if `touse', by(`by')
+        mat `count'[1,`i'] = r(N_1) + r(N_2)
+        mat `diff'[1,`i'] = r(P_1) - r(P_2)
+        mat `se'[1,`i'] = sqrt(r(P_1)*(1-r(P_1))/r(N_1) + r(P_2)*(1-r(P_2))/r(N_2))
+        mat `se0'[1,`i'] = `diff'[1,`i'] / r(z)
+        mat `p_l'[1,`i'] = normal(r(z))
+        mat `p'[1,`i'] = (1-normal(abs(r(z))))*2
+        mat `p_u'[1,`i'] = 1-normal(r(z))
+        foreach m in z N_1 P_1 N_2 P_2 {
+            mat ``m''[1,`i'] = r(`m')
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        mat `res' = `diff'', `count''
+        local rescoln "e(b) e(count)"
+        foreach m of local mnames {
+            mat `res' = `res', ``m'''
+            local rescoln `rescoln' e(`m')
+        }
+        mat coln `res' = `rescoln'
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            matlist `res', nohalf lines(oneline)
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local V
+    if c(stata_version)<9 { // V required in Stata 8
+        tempname V
+        mat `V' = diag(vecdiag(`se'' * `se'))
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `diff' `V', obs(`N') `esample'
+
+    eret scalar k = `nvars'
+
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local byvar "`by'"
+    eret local subcmd "prtest"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof mnames
+    forv i=`nmat'(-1)1 {
+        local m: word `i' of `mnames'
+        eret matrix `m' = ``m''
+    }
+    eret matrix count = `count'
+end
+
+
+* 10. estpost__svy_tabulate: wrapper for -svy:tabulate-
+prog estpost__svy_tabulate
+    version 9.2
+    local caller : di _caller()
+    _on_colon_parse `0'
+    local svyopts `"svyopts(`s(before)')"'
+    local 0       `"`s(after)'"'
+    syntax varlist(min=1 max=2) [if] [in] [ , * ]
+    if `:list sizeof varlist'==1 {
+        version `caller': _svy_tabulate_oneway `varlist' `if' `in', ///
+            `svyopts' `options'
+    }
+    else {
+         version `caller': _svy_tabulate_twoway `varlist' `if' `in', ///
+            `svyopts' `options'
+    }
+end
+prog _svy_tabulate_oneway
+    version 9.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varname [if] [in] [, ESample Quietly ///
+        svyopts(str asis) MISSing Level(cilevel) ///
+        noTOTal noMARGinals noLabel ELabels PROPortion PERcent ///
+        CELl COUnt se ci deff deft * ]
+    if "`marginals'"!=""   local total "nototal"
+    else if "`total'"!=""  local marginals "nomarginals"
+
+    // run svy:tabulate
+    `quietly' svy `svyopts' : tabulate `varlist' `if' `in', ///
+        level(`level') `cell' `count' `se' `ci' `deff' `deft' ///
+        `missing' `marginals' `label' `proportion' `percent' `options'
+    if "`count'"!="" & "`cell'`se'`ci'`deff'`deft'"=="" { // => return count in e(b)
+        quietly svy `svyopts' : tabulate `varlist' `if' `in', count se ///
+            level(`level') `missing' `marginals' `label' `proportion' `percent' `options'
+    }
+
+    // get labels
+    qui levelsof `varlist' if e(sample), `missing' local(levels)
+    local R : list sizeof levels
+    if e(r)!=`R' {
+        di as err "unexpected error; number of rows unequal number of levels"
+        exit 499
+    }
+    capt confirm string variable `varlist'
+    if _rc {
+        if "`label'"=="" {
+            _estpost_namesandlabels `varlist' "`levels'" "" "`elabels'" // sets names, savenames, labels
+        }
+        else {
+            _estpost_namesandlabels "" "`levels'" "" "`elabels'" // sets names, savenames, labels
+        }
+    }
+    else {
+        _estpost_namesandlabels "" "" `"`levels'"' "`elabels'" // sets names, savenames, labels
+    }
+
+    // collect results
+    tempname cell count obs b se lb ub deff deft
+    local N_pop = cond(e(N_subpop)<., e(N_subpop), e(N_pop))
+    local N_obs = cond(e(N_sub)<., e(N_sub), e(N))
+    local tval = invttail(e(df_r), (100-`level')/200)
+    if `tval'>=. local tval = invnormal(1 - (100-`level')/200)
+    mat `cell'  = e(Prop)'
+    mat `count' = `cell' * `N_pop'
+    capture confirm matrix e(ObsSub)
+    if _rc {
+        mat `obs'   = e(Obs)'
+    }
+    else {
+        mat `obs'   = e(ObsSub)'
+    }
+    capture confirm matrix e(Deff)
+    if _rc local DEFF  ""
+    else   {
+        local DEFF deff
+        mat `deff'  = e(Deff)
+    }
+    capture confirm matrix e(Deft)
+    if _rc local DEFT  ""
+    else   {
+        local DEFT deft
+        mat `deft'  = e(Deft)
+    }
+    mat `b' = e(b)
+    mata: st_matrix(st_local("se"), sqrt(diagonal(st_matrix("e(V)")))')
+    if "`total'"=="" {
+        mat `cell'  = `cell', 1
+        mat `count' = `count', `N_pop'
+        mat `obs'   = `obs', `N_obs'
+        if "`DEFF'"!="" mat `deff'  = `deff', .z
+        if "`DEFT'"!="" mat `deft'  = `deft', .z
+        if e(setype)=="count" {
+            mat `b' = `b', `N_pop'
+            mat `se' = `se', sqrt(el(e(V_col),1,1))
+        }
+        else { // e(setype)=="cell"
+            mat `b' = `b', 1
+            mat `se' = `se', 0
+        }
+        local names `"`names' "Total""'
+        local savenames `"`savenames' "Total""'
+        local linesopt "lines(rowtotal)"
+
+    }
+    if e(setype)!="count" {
+        mata: st_matrix( st_local("lb"), invlogit( ///
+            logit(st_matrix(st_local("b"))) - strtoreal(st_local("tval")) * ///
+                st_matrix(st_local("se")) :/ ///
+                (st_matrix(st_local("b")) :* (1 :- st_matrix(st_local("b"))))))
+        mata: st_matrix( st_local("ub"), invlogit( ///
+            logit(st_matrix(st_local("b"))) + strtoreal(st_local("tval")) * ///
+                st_matrix(st_local("se")) :/ ///
+                (st_matrix(st_local("b")) :* (1 :- st_matrix(st_local("b"))))))
+        if "`total'"=="" {
+            mat `lb'[1, colsof(`lb')] = .z
+            mat `ub'[1, colsof(`ub')] = .z
+        }
+    }
+    else {
+        mata: st_matrix( st_local("lb"), st_matrix(st_local("b")) - ///
+            strtoreal(st_local("tval")) * st_matrix(st_local("se")) )
+        mata: st_matrix( st_local("ub"), st_matrix(st_local("b")) + ///
+            strtoreal(st_local("tval")) * st_matrix(st_local("se")) )
+    }
+    foreach m in cell count obs b se lb ub `DEFF' `DEFT' {
+        capt mat coln ``m'' = `names'
+    }
+    if "`percent'"!="" {
+        mat `cell' = `cell' * 100
+        if e(setype)!="count" {
+            mat `b' = `b' * 100
+            mat `se' = `se' * 100
+            mat `lb' = `lb' * 100
+            mat `ub' = `ub' * 100
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        /*
+        tempname res
+        mat `res' = `b'', `se'', `lb'', `ub'', `deff'', `deft'' ///, `cell'', `count'', `obs''
+        mat coln `res' = e(b) e(se) e(lb) e(ub) e(deff) e(deft) /// e(cell) e(count) e(obs)
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g) nodotz
+        }
+        else {
+            mat rown `res' = `savenames'
+            matlist `res', nohalf `linesopt' rowtitle(`varlist') nodotz
+        }
+        mat drop `res'
+        */
+        local plabel = cond("`percent'"!="","percentages","proportions")
+        local blabel = cond("`e(setype)'"=="count", "weighted counts", "`e(setype)' `plabel'")
+        di _n as txt "saved vectors:"
+        di as txt %20s "e(b) = "     " " as res "`blabel'"
+        di as txt %20s "e(se) = "    " " as res "standard errors of `blabel'"
+        di as txt %20s "e(lb) = "    " " as res "lower `level'% confidence bounds for `blabel'"
+        di as txt %20s "e(ub) = "    " " as res "upper `level'% confidence bounds for `blabel'"
+        if "`DEFF'"!="" ///
+            di as txt %20s "e(deff) = "  " " as res "deff for variances of `blabel'"
+        if "`DEFT'"!="" ///
+            di as txt %20s "e(deft) = "  " " as res "deft for variances of `blabel'"
+        di as txt %20s "e(cell) = "  " " as res "cell `plabel'"
+        di as txt %20s "e(count) = " " " as res "weighted counts"
+        di as txt %20s "e(obs) = "   " " as res "number of observations"
+        if `"`labels'"'!="" {
+            di _n as txt "row labels saved in macro e(labels)"
+        }
+    }
+
+    // post results
+    erepost b=`b', cmd(estpost) nov `esample'
+    qui estadd local labels `"`labels'"'
+    qui estadd local subcmd "tabulate"
+    qui estadd scalar level = `level'
+    foreach m in obs count cell `DEFT' `DEFF' ub lb se {
+        qui estadd matrix `m' = ``m'', replace
+    }
+end
+prog _svy_tabulate_twoway
+    version 9.2
+    local caller : di _caller() // not used
+
+    // syntax
+    syntax varlist(min=1 max=2) [if] [in] [, ESample Quietly ///
+        svyopts(str asis) MISSing Level(cilevel) ///
+        noTOTal noMARGinals noLabel ELabels PROPortion PERcent ///
+        CELl COUnt COLumn row se ci deff deft * ]
+    if "`marginals'"!=""   local total "nototal"
+    else if "`total'"!=""  local marginals "nomarginals"
+
+    // run svy:tabulate
+    `quietly' svy `svyopts' : tabulate `varlist' `if' `in', ///
+        level(`level') `cell' `count' `column' `row' `se' `ci' `deff' `deft' ///
+        `missing' `marginals' `label' `proportion' `percent' `options'
+    if `: word count `count' `column' `row''==1 & "`cell'`se'`ci'`deff'`deft'"=="" {
+        quietly svy `svyopts' : tabulate `varlist' `if' `in', `count' `column' `row' se ///
+            level(`level') `missing' `marginals' `label' `proportion' `percent' `options'
+    }
+
+    // get labels
+    local rvar `"`e(rowvar)'"'
+    qui levelsof `rvar' if e(sample), `missing' local(levels)
+    local R : list sizeof levels
+    if e(r)!=`R' {
+        di as err "unexpected error; number of rows unequal number of rowvar levels"
+        exit 499
+    }
+    capt confirm string variable `rvar'
+    if _rc {
+        if "`label'"=="" {
+            _estpost_namesandlabels `rvar' "`levels'" "" "`elabels'" // sets names, savenames, labels
+        }
+        else {
+            _estpost_namesandlabels "" "`levels'" "" "`elabels'" // sets names, savenames, labels
+        }
+    }
+    else {
+        _estpost_namesandlabels "" "" `"`levels'"' "`elabels'" // sets names, savenames, labels
+    }
+    local cvar `"`e(colvar)'"'
+    qui levelsof `cvar' if e(sample), `missing' local(levels)
+    local C : list sizeof levels
+    if e(c)!=`C' {
+        di as err "unexpected error; number of column unequal number of colvar levels"
+        exit 499
+    }
+    local savenames0 `"`savenames'"'
+    local savenames
+    capt confirm string variable `cvar'
+    if _rc {
+        if "`label'"=="" {
+            _estpost_eqnamesandlabels `cvar' "`levels'" "" "`elabels'" // sets eqnames, eqlabels
+        }
+        else {
+            _estpost_eqnamesandlabels "" "`levels'" "" "`elabels'" // sets eqnames, eqlabels
+        }
+    }
+    else {
+        _estpost_eqnamesandlabels "" "" `"`levels'"' "`elabels'" // sets eqnames, eqlabels
+    }
+
+    // collect results
+    tempname tmp cell row col count obs b se lb ub deff deft
+    local N_pop = cond(e(N_subpop)<., e(N_subpop), e(N_pop))
+    local N_obs = cond(e(N_sub)<., e(N_sub), e(N))
+    local tval = invttail(e(df_r), (100-`level')/200)
+    if `tval'>=. local tval = invnormal(1 - (100-`level')/200)
+    mat `cell' = e(Prop)    // r x c matrix
+    mat `cell' = (`cell', `cell' * J(`C',1,1)) \ (J(1,`R',1) * `cell', 1)
+    mat `count' = `cell' * `N_pop'
+    mat `tmp' = `cell'[1..., `C'+1]
+    mata: st_matrix(st_local("row"), st_matrix(st_local("cell")) :/ ///
+        st_matrix(st_local("tmp")))
+    mat `tmp' = `cell'[`R'+1, 1...]
+    mata: st_matrix(st_local("col"), st_matrix(st_local("cell")) :/ ///
+        st_matrix(st_local("tmp")))
+    mat drop `tmp'
+    capture confirm matrix e(ObsSub)
+    if _rc {
+        mat `obs' = e(Obs)    // r x c matrix
+    }
+    else {
+        mat `obs' = e(ObsSub) // r x c matrix
+    }
+    capt confirm matrix e(Deff)
+    if _rc local DEFF ""
+    else {
+        local DEFF deff
+        mat `deff'  = e(Deff)   // vector
+    }
+    capt confirm matrix e(Deft)
+    if _rc local DEFT ""
+    else {
+        local DEFT deft
+        mat `deft'  = e(Deft)   // vector
+    }
+    mat `b' = e(b)          // vector
+    mata: st_matrix(st_local("se"), sqrt(diagonal(st_matrix("e(V)")))') // vector
+    if e(setype)=="count"       local btype count
+    else if e(setype)=="row"    local btype row
+    else if e(setype)=="column" local btype col
+    else                        local btype cell
+    foreach m in `DEFF' `DEFT' b se { // vector -> r x c matrix
+        forv r = 1/`R' {
+            local from = (`r'-1)*`C' + 1
+            local to = `r'*`C'
+            mat `tmp' = nullmat(`tmp') \ ``m''[1, `from'..`to']
+        }
+        mat drop ``m''
+        mat rename `tmp' ``m''
+    }
+    if "`total'"=="" {
+        mat `obs' = (`obs', `obs' * J(`C',1,1)) \ (J(1,`R',1) * `obs', `N_obs')
+        if "`DEFF'"!="" mat `deff'  = (`deff', e(Deff_row)') \ (e(Deff_col), .z)
+        if "`DEFT'"!="" mat `deft'  = (`deft', e(Deft_row)') \ (e(Deft_col), .z)
+        mat `b' = (`b', ``btype''[1..`R',`C'+1]) \ ``btype''[`R'+1,1...]
+        mata: st_matrix(st_local("se"), ///
+            ((st_matrix(st_local("se")), sqrt(diagonal(st_matrix("e(V_row)")))) ///
+            \ (sqrt(diagonal(st_matrix("e(V_col)")))', .z)))
+        if "`btype'"=="row" {
+            mat `se' = `se'[1..., 1..`C'], J(`R'+1, 1, .z)
+        }
+        else if "`btype'"=="col" {
+            mat `se' = `se'[1..`R', 1...] \ J(1, `C'+1, .z)
+        }
+        local names `"`names' "Total""'
+        local savenames0 `"`savenames0' "Total""'
+        local eqnames `"`eqnames' "Total""'
+    }
+    else {
+        mat `cell' = `cell'[1..`R', 1..`C']
+        mat `count' = `count'[1..`R', 1..`C']
+        mat `row' = `row'[1..`R', 1..`C']
+        mat `col' = `col'[1..`R', 1..`C']
+    }
+    if "`btype'"!="count" {
+        mata: st_matrix( st_local("lb"), invlogit( ///
+            logit(st_matrix(st_local("b"))) - strtoreal(st_local("tval")) * ///
+                st_matrix(st_local("se")) :/ ///
+                (st_matrix(st_local("b")) :* (1 :- st_matrix(st_local("b"))))))
+        mata: st_matrix( st_local("ub"), invlogit( ///
+            logit(st_matrix(st_local("b"))) + strtoreal(st_local("tval")) * ///
+                st_matrix(st_local("se")) :/ ///
+                (st_matrix(st_local("b")) :* (1 :- st_matrix(st_local("b"))))))
+    }
+    else {
+        mata: st_matrix( st_local("lb"), st_matrix(st_local("b")) - ///
+            strtoreal(st_local("tval")) * st_matrix(st_local("se")) )
+        mata: st_matrix( st_local("ub"), st_matrix(st_local("b")) + ///
+            strtoreal(st_local("tval")) * st_matrix(st_local("se")) )
+    }
+    if "`total'"=="" {
+        if "`btype'"=="row" {
+            mat `lb' = `lb'[1..., 1..`C'] , J(`R'+1, 1, .z)
+            mat `ub' = `ub'[1..., 1..`C'] , J(`R'+1, 1, .z)
+        }
+        else if  "`btype'"=="col" {
+            mat `lb' = `lb'[1..`R', 1...] \ J(1, `C'+1, .z)
+            mat `ub' = `ub'[1..`R', 1...] \ J(1, `C'+1, .z)
+        }
+        else {
+            mat `lb'[`R'+1, `C'+1] = .z
+            mat `ub'[`R'+1, `C'+1] = .z
+        }
+    }
+    foreach m in cell count obs row col `DEFF' `DEFT' b se lb ub { // r x c matrix -> vector
+        mat rown ``m'' = `names'
+        gettoken eq rest : eqnames
+        forv c = 1/`=colsof(``m'')' {
+            mat roweq ``m'' = `"`eq'"'
+            mat `tmp' = nullmat(`tmp'), ``m''[1...,`c']'
+            gettoken eq rest : rest
+        }
+        mat drop ``m''
+        mat rename `tmp' ``m''
+    }
+    if "`percent'"!="" {
+        mat `cell' = `cell' * 100
+        mat `col' = `col' * 100
+        mat `row' = `row' * 100
+        if e(setype)!="count" {
+            mat `b' = `b' * 100
+            mat `se' = `se' * 100
+            mat `lb' = `lb' * 100
+            mat `ub' = `ub' * 100
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        /*
+        forv c = 1/`=colsof(`cell')' {
+            local savenames `"`savenames' `savenames0'"'
+        }
+        tempname res
+        mat `res' = `b'', `se'', `lb'', `ub'', `deff'', `deft'', `cell'', `row'', `col'', `count'', `obs''
+        mat coln `res' = e(b) e(se) e(lb) e(ub) e(deff) e(deft) e(cell) e(row) e(col) e(count) e(obs)
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g) nodotz
+        }
+        else {
+            mat rown `res' = `savenames'
+            di _n as res %-12s abbrev("`cvar'",12) as txt " {c |}{space 44}"
+            matlist `res', twidth(12) format(%9.0g) noblank nohalf ///
+                rowtitle(`rvar') nodotz
+        }
+        mat drop `res'
+        */
+        local plabel = cond("`percent'"!="","percentages","proportions")
+        local blabel = cond("`e(setype)'"=="count", "weighted counts", "`e(setype)' `plabel'")
+        di _n as txt "saved vectors:"
+        di as txt %20s "e(b) = "     " " as res "`blabel'"
+        di as txt %20s "e(se) = "    " " as res "standard errors of `blabel'"
+        di as txt %20s "e(lb) = "    " " as res "lower `level'% confidence bounds for `blabel'"
+        di as txt %20s "e(ub) = "    " " as res "upper `level'% confidence bounds for `blabel'"
+        if "`DEFF'"!="" ///
+            di as txt %20s "e(deff) = "  " " as res "deff for variances of `blabel'"
+        if "`DEFT'"!="" ///
+            di as txt %20s "e(deft) = "  " " as res "deft for variances of `blabel'"
+        di as txt %20s "e(cell) = "  " " as res "cell `plabel'"
+        di as txt %20s "e(row) = "   " " as res "row `plabel'"
+        di as txt %20s "e(col) = "   " " as res "column `plabel'"
+        di as txt %20s "e(count) = " " " as res "weighted counts"
+        di as txt %20s "e(obs) = "   " " as res "number of observations"
+        if `"`labels'`eqlabels'"'!="" {
+            di ""
+            if `"`labels'"'!="" {
+                di as txt "row labels saved in macro e(labels)"
+            }
+            if `"`eqlabels'"'!="" {
+                di as txt "column labels saved in macro e(eqlabels)"
+            }
+        }
+    }
+
+    // post results
+    erepost b=`b', cmd(estpost) nov `esample'
+    qui estadd local eqlabels `"`eqlabels'"'
+    qui estadd local labels `"`labels'"'
+    qui estadd local subcmd "tabulate"
+    qui estadd scalar level = `level'
+    foreach m in obs count row col cell `DEFT' `DEFF' ub lb se {
+        qui estadd matrix `m' = ``m'', replace
+    }
+end
+
+* 11. estpost_margins: wrapper for -margins- (Stata 11)
+prog estpost_margins, eclass
+    version 11
+    local caller : di _caller()
+
+    // syntax
+    _parse comma anything 0 : 0
+    syntax [ , /*ESample*/ Quietly ///
+        post * ]
+    if "`post'"!="" {
+        di as err "post not allowed"
+        exit 198
+    }
+
+    // run margins
+    `quietly' version `caller': margins `anything', `options'
+
+    // post results
+    capt postrtoe, noclear resize
+    if _rc<=1 {     // -postrtoe- does not work, e.g., with -regress-
+        error _rc   // _rc=1 (break)
+        exit
+    }
+    tempname b V
+    mat `b' = r(b)
+    mat `V' = r(V)
+    erepost b = `b' V = `V' /*, `esample'*/
+    foreach r in `:r(scalars)' {
+        eret scalar `r' = r(`r')
+    }
+    foreach r in `:r(macros)' {
+        eret local `r' `"`r(`r')'"'
+    }
+    tempname tmp
+    foreach r in `:r(matrices)' {
+        if inlist("`r'", "b", "V") continue
+        mat `tmp' = r(`r')
+        eret matrix `r' = `tmp'
+    }
+end
+
+* 12. estpost_gtabstat: wrapper for -gstats tabstat- (gtools required)
+prog estpost_gtabstat, eclass
+    version 13.1
+    local caller : di _caller() // not used
+
+    cap gtools
+    if ( _rc ) {
+        disp as err "gtools required for estpost gtabstat"
+        exit 111
+    }
+
+    // syntax
+    syntax varlist [if] [in] [aw fw iw pw] [, ESample Quietly ///
+          Statistics(passthru) stats(passthru) ///
+          by(varname) Missing Columns(str) ELabels ]
+    local l = length(`"`columns'"')
+    if `"`columns'"'==substr("variables",1,max(1,`l')) local columns "variables"
+    else if `"`columns'"'==substr("statistics",1,max(1,`l')) local columns "statistics"
+    else if `"`columns'"'=="stats" local columns "statistics"
+    else if `"`columns'"'=="" {
+        if `:list sizeof varlist'>1 local columns "variables"
+        else local columns "statistics"
+    }
+    else {
+        di as err `"columns(`columns') invalid"'
+        exit 198
+    }
+
+    // sample
+    if "`listwise'"!="" marksample touse
+    else {
+        marksample touse, nov
+        _estpost_markout2 `touse' `varlist'
+    }
+    if "`by'"!="" {
+        capt confirm string variable `by'
+        local numby = (_rc!=0)
+
+        // NOTE(mauricio): Not sure what this does. I think it's just
+        // a copy of the by variable so that _estpost_eqnamesandlabels
+        // parses the numeric input back into value labels?
+        //
+        // if `numby' {
+        //     tempname tmpby
+        //     qui gen `:type `by'' `tmpby' = `by'
+        // }
+        // else local tmpby `by'
+        // local byopt "by(`tmpby')"
+
+        if "`missing'"=="" markout `touse' `by', strok
+        local byopt by(`by')
+    }
+    else local numby 0
+    qui count if `touse'
+    local N = r(N)
+    if `N'==0 error 2000
+
+    if ( `"`missing'"' == "" ) local missing nomissing
+
+    // gather results
+    tempname tmp
+    tempname gtabstat
+    qui gstats tabstat `varlist' if `touse' [`weight'`exp'], mata(`gtabstat') ///
+        `statistics' `stats' `byopt' `missing' columns(`columns')
+
+    mata st_local("stats",  invtokens(`gtabstat'.statnames))
+    mata st_local("vars",   invtokens(`gtabstat'.statvars))
+    mata st_local("R",      strofreal(`gtabstat'.ksources))
+    mata st_local("g",      strofreal(`gtabstat'.kby? `gtabstat'.J: 0))
+
+    local stats: subinstr local stats "N" "count", word all
+    local stats: subinstr local stats "se(mean)" "semean", word all
+
+    if `"`columns'"'=="statistics" {
+        local cnames: copy local stats
+    }
+    else {
+        local cnames: copy local vars
+    }
+    local cnames: subinstr local cnames "b" "_b", word all
+    local cnames: subinstr local cnames "V" "_V", word all
+
+    local j 0
+    foreach cname of local cnames {
+        tempname _`++j'
+    }
+
+    local space
+    local labels
+    forv i = 1/`g' {
+        if `numby' {
+            mata st_local("name", sprintf(st_varformat(`gtabstat'.byvars[1]), `gtabstat'.getnum(`i', 1)))
+        }
+        else {
+            mata st_local("name", `gtabstat'.getchar(`i', 1, 0))
+        }
+        local labels `"`labels'`space'`"`name'"'"'
+    }
+
+    if `R'==1 {
+        if `numby' {
+            _estpost_namesandlabels "`by'" `"`labels'"' "" "`elabels'"   // sets names, savenames, labels
+        }
+        else {
+            _estpost_namesandlabels "" "" `"`labels'"' "`elabels'"       // sets names, savenames, labels
+        }
+    }
+    else {
+        if `numby' {
+            _estpost_eqnamesandlabels "`by'" `"`labels'"' "" "`elabels'" // sets eqnames, eqlabels
+        }
+        else {
+            _estpost_eqnamesandlabels "" "" `"`labels'"' "`elabels'"     // sets eqnames, eqlabels
+        }
+        local names `"`eqnames'"'
+        local labels `"`macval(eqlabels)'"'
+    }
+
+    tempname glabname
+    tempname glabstat
+    tempname glabvar
+    tempname glabmat
+
+    forv i = 1/`g' {
+        mata `glabname' = `gtabstat'.getf(`i', 1, .)
+        mata `glabmat'  = `gtabstat'.colvar? `gtabstat'.getOutputGroup(`i'): `gtabstat'.getOutputGroup(`i')'
+
+        if `"`columns'"'=="statistics"  {
+            mata `glabstat' = (J(`gtabstat'.kstats,   1, ""),         `gtabstat'.statnames')
+            mata `glabvar'  = (J(`gtabstat'.ksources, 1, `glabname'), `gtabstat'.statvars')
+        }
+        else {
+            mata `glabstat' = (J(`gtabstat'.kstats,   1, `glabname'), `gtabstat'.statnames')
+            mata `glabvar'  = (J(`gtabstat'.ksources, 1, ""),         `gtabstat'.statvars')
+        }
+
+        mata st_matrix("`tmp'", `glabmat')
+        mata st_matrixrowstripe("`tmp'", `glabstat')
+        mata st_matrixcolstripe("`tmp'", `glabvar')
+
+        if `"`columns'"'=="statistics"  {
+            mat `tmp' = `tmp''
+            if ( `R'==1 ) {
+                mata `glabstat' = ("", `glabname')
+                mata `glabvar'  = (J(`gtabstat'.kstats, 1, ""), `gtabstat'.statnames')
+                mata st_matrixrowstripe("`tmp'", `glabstat')
+                mata st_matrixcolstripe("`tmp'", `glabvar')
+            }
+        }
+
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `_`j'' = nullmat(`_`j''), `tmp'[1..., `j']'
+        }
+    }
+
+    if ( `g' == 0 ) {
+        mata `glabmat'  = `gtabstat'.colvar? `gtabstat'.output: `gtabstat'.output'
+        mata `glabstat' = (J(`gtabstat'.kstats,   1, ""), `gtabstat'.statnames')
+        mata `glabvar'  = (J(`gtabstat'.ksources, 1, ""), `gtabstat'.statvars')
+
+        mata st_matrix("`tmp'", `glabmat')
+        mata st_matrixrowstripe("`tmp'", `glabstat')
+        mata st_matrixcolstripe("`tmp'", `glabvar')
+        if `"`columns'"'=="statistics" {
+            mat `tmp' = `tmp''
+        }
+
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `_`j'' = nullmat(`_`j''), `tmp'[1..., `j']'
+        }
+    }
+
+    // display
+    if "`quietly'"=="" {
+        tempname res
+        local rescoln
+        local j 0
+        foreach cname of local cnames {
+            local ++j
+            mat `res' = nullmat(`res'), `_`j'''
+            local rescoln `rescoln' e(`cname')
+        }
+        mat coln `res' = `rescoln'
+        di _n as txt "Summary statistics: `stats'"
+        di    as txt "     for variables: `vars'"
+        if "`by'"!="" {
+            di as txt "  by categories of: `by'"
+        }
+        if c(stata_version)<9 {
+            mat list `res', noheader nohalf format(%9.0g)
+        }
+        else {
+            if `R'==1 & `g'>0 {
+                mat rown `res' = `savenames'
+            }
+            matlist `res', nohalf `rowtotal' rowtitle(`by')
+        }
+        if `"`macval(labels)'"'!="" {
+            di _n as txt "category labels saved in macro e(labels)"
+        }
+        mat drop `res'
+    }
+
+    // post results
+    local b
+    local V
+    if c(stata_version)<9 { // b and V required in Stata 8
+        tempname b V
+        mat `b' = `_1' \ J(1, colsof(`_1'), 0)
+        mat `b' = `b'[2,1...]
+        mat `V' = `b'' * `b'
+    }
+    if "`esample'"!="" local esample esample(`touse')
+    eret post `b' `V', obs(`N') `esample'
+
+    eret local labels `"`macval(labels)'"'
+    eret local byvar "`by'"
+    eret local vars "`vars'"
+    eret local stats "`stats'"
+    eret local wexp `"`exp'"'
+    eret local wtype `"`weight'"'
+    eret local subcmd "tabstat"
+    eret local cmd "estpost"
+
+    local nmat: list sizeof cnames
+    forv j=`nmat'(-1)1 {
+        local cname: word `j' of `cnames'
+        eret matrix `cname' = `_`j''
+    }
+
+    cap mata mata drop `gtabstat'
+    cap mata mata drop `glabname'
+    cap mata mata drop `glabstat'
+    cap mata mata drop `glabvar'
+    cap mata mata drop `glabmat'
+end
+
+* 99.
+* copy of erepost.ado, version 1.0.1, Ben Jann, 30jul2007
+* 14jan2009: noV option added => repost e(b) and remove e(V) if not specified
+prog erepost, eclass
+    version 8.2
+    syntax [anything(equalok)] [, NOV cmd(str) noEsample Esample2(varname) REName ///
+        Obs(passthru) Dof(passthru) PROPerties(passthru) * ]
+    if "`esample'"!="" & "`esample2'"!="" {
+        di as err "only one allowed of noesample and esample()"
+        exit 198
+    }
+// parse [b = b] [V = V]
+    if `"`anything'"'!="" {
+        tokenize `"`anything'"', parse(" =")
+        if `"`7'"'!="" error 198
+        if `"`1'"'=="b" {
+            if `"`2'"'=="=" & `"`3'"'!="" {
+                local b `"`3'"'
+                confirm matrix `b'
+            }
+            else error 198
+            if `"`4'"'=="V" {
+                if `"`5'"'=="=" & `"`6'"'!="" {
+                    local v `"`6'"'
+                    confirm matrix `b'
+                }
+                else error 198
+            }
+            else if `"`4'"'!="" error 198
+        }
+        else if `"`1'"'=="V" {
+            if `"`4'"'!="" error 198
+            if `"`2'"'=="=" & `"`3'"'!="" {
+                local v `"`3'"'
+                confirm matrix `v'
+            }
+            else error 198
+        }
+        else error 198
+    }
+//backup existing e()'s
+    if "`esample2'"!="" {
+        local sample "`esample2'"
+    }
+    else if "`esample'"=="" {
+        tempvar sample
+        gen byte `sample' = e(sample)
+    }
+    local emacros: e(macros)
+    if `"`properties'"'!="" {
+        local emacros: subinstr local emacros "properties" "", word
+    }
+    foreach emacro of local emacros {
+        local e_`emacro' `"`e(`emacro')'"'
+    }
+    local escalars: e(scalars)
+    if `"`obs'"'!="" {
+        local escalars: subinstr local escalars "N" "", word
+    }
+    if `"`dof'"'!="" {
+        local escalars: subinstr local escalars "df_r" "", word
+    }
+    foreach escalar of local escalars {
+        tempname e_`escalar'
+        scalar `e_`escalar'' = e(`escalar')
+    }
+    local ematrices: e(matrices)
+    if "`v'"=="" & "`nov'"!="" {   // added 14jan2009
+        local nov V
+        local ematrices : list ematrices - nov
+    }
+    if "`b'"=="" & `:list posof "b" in ematrices' {
+        tempname b
+        mat `b' = e(b)
+    }
+    if "`v'"=="" & `:list posof "V" in ematrices' {
+        tempname v
+        mat `v' = e(V)
+    }
+    local bV "b V"
+    local ematrices: list ematrices - bV
+    foreach ematrix of local ematrices {
+        tempname e_`ematrix'
+        matrix `e_`ematrix'' = e(`ematrix')
+    }
+// rename
+    if "`b'"!="" & "`v'"!="" & "`rename'"!="" {
+        local eqnames: coleq `b', q
+        local vnames: colnames `b'
+        mat coleq `v' = `eqnames'
+        mat coln `v' = `vnames'
+        mat roweq `v' = `eqnames'
+        mat rown `v' = `vnames'
+    }
+// post results
+    if "`esample'"=="" {
+        eret post `b' `v', esample(`sample') `obs' `dof' `properties' `options'
+    }
+    else {
+        eret post `b' `v', `obs' `dof' `properties' `options'
+    }
+    foreach emacro of local emacros {
+        eret local `emacro' `"`e_`emacro''"'
+    }
+    if `"`cmd'"'!="" {
+        eret local cmd `"`cmd'"'
+    }
+    foreach escalar of local escalars {
+        eret scalar `escalar' = scalar(`e_`escalar'')
+    }
+    foreach ematrix of local ematrices {
+        eret matrix `ematrix' = `e_`ematrix''
+    }
+end

--- a/analysis/extra_ados/estpost.hlp
+++ b/analysis/extra_ados/estpost.hlp
@@ -1,0 +1,1524 @@
+{smcl}
+{* 19may2021}{...}
+{hi:help estpost}{right:also see: {helpb esttab}, {helpb estout}, {helpb eststo}, {helpb estadd}}
+{right: {browse "http://repec.sowi.unibe.ch/stata/estout/"}}
+{hline}
+
+{title:Title}
+
+{p 4 4 2}{hi:estpost} {hline 2} Post results from various commands in {cmd:e()}
+
+
+{title:Syntax}
+
+{p 8 15 2}
+{cmd:estpost} {it:{help estpost##commands:command}} [...]
+
+{marker commands}
+    {it:command}{col 26}description
+    {hline 79}
+    {helpb estpost##summarize:{ul:su}mmarize}{col 26}{...}
+post summary statistics
+    {helpb estpost##tabstat:tabstat}{col 26}{...}
+post summary statistics
+    {helpb estpost##gtabstat:gtabstat}{col 26}{...}
+post summary statistics (using {helpb gstats tab} from {helpb gtools})
+    {helpb estpost##ttest:ttest}{col 26}{...}
+post two-group mean-comparison tests
+    {helpb estpost##prtest:prtest}{col 26}{...}
+post two-group tests of proportions
+    {helpb estpost##tabulate:{ul:ta}bulate}{col 26}{...}
+post one-way or two-way frequency table
+    {helpb estpost##svy_tabulate:svy: {ul:ta}bulate}{col 26}{...}
+post frequency table for survey data
+    {helpb estpost##correlate:{ul:cor}relate}{col 26}{...}
+post correlations
+    {helpb estpost##ci:ci}{col 26}{...}
+post confidence intervals for means,
+    {col 26}{...}
+    proportions, or counts
+    {helpb estpost##stci:stci}{col 26}{...}
+post confidence intervals for means
+    {col 26}{...}
+    and percentiles of survival time
+    {helpb estpost##margins:margins}{col 26}{...}
+post results from {cmd:margins} (Stata 11 or newer)
+    {hline 79}
+
+
+{title:Description}
+
+{p 4 4 2}
+{cmd:estpost} posts results from various Stata commands in {cmd:e()}
+so that they can be tabulated using {helpb esttab} or {helpb estout}. Type
+{helpb ereturn:ereturn list} after {cmd:estpost} to list the elements saved
+in {cmd:e()}.
+
+
+{title:Commands}
+{marker summarize}
+{dlgtab:summarize}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:su:mmarize}
+    [{it:{help varlist}}] [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:d:etail}
+        {cmdab:mean:only}
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+    ]
+
+{p 4 4 2}
+    posts summary statistics computed by {helpb summarize}. If no
+    {it:varlist} is specified, summary statistics are calculated for all
+    variables in the dataset.
+
+{p 4 4 2}
+    {cmd:aweight}s, {cmd:fweight}s, and {cmd:iweight}s are allowed
+    (however, {cmd:iweight}s may not be used with the {cmd:detail} option);
+    see {help weight}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:detail} and {cmd:meanonly} as described in help {helpb summarize}.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation
+        sample if any of the variables in {it:varlist} is missing for that
+        observation. The default is to determine the used observations for
+        each variable separately without regard to whether other variables
+        are missing. {cmd:casewise} is a synonym for {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 4 4 2}The following results vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(count)}}number of observations
+        {lalign 13:{cmd:e(mean)}}mean
+        {lalign 13:{cmd:e(min)}}minimum
+        {lalign 13:{cmd:e(max)}}maximum
+        {lalign 13:{cmd:e(sum)}}sum of variable
+        {lalign 13:{cmd:e(sum_w)}}sum of the weights
+        {lalign 13:{cmd:e(Var)}}variance (unless {cmd:meanonly})
+        {lalign 13:{cmd:e(sd)}}standard deviation (unless {cmd:meanonly})
+        {lalign 13:{cmd:e(p1)}}1st percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p5)}}5th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p10)}}10th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p25)}}25th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p50)}}50th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p75)}}75th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p90)}}90th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p95)}}95th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(p99)}}99th percentile ({cmd:detail} only)
+        {lalign 13:{cmd:e(skewness)}}skewness ({cmd:detail} only)
+        {lalign 13:{cmd:e(kurtosis)}}kurtosis ({cmd:detail} only)
+
+{p 4 4 2}
+    Example:
+
+{* begin example summarize }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost summarize price mpg rep78 foreign
+
+        {txt}{ralign 12:} {c |} {ralign 9:e(count)}  {ralign 9:e(sum_w)}  {ralign 9:e(mean)}  {ralign 9:e(Var)}  {ralign 9:e(sd)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: 6165.257}}}  {ralign 9:{res:{sf:  8699526}}}  {ralign 9:{res:{sf: 2949.496}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf:  21.2973}}}  {ralign 9:{res:{sf: 33.47205}}}  {ralign 9:{res:{sf: 5.785503}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf: .9799659}}}  {ralign 9:{res:{sf: .9899323}}}
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: .2972973}}}  {ralign 9:{res:{sf: .2117734}}}  {ralign 9:{res:{sf: .4601885}}}
+
+        {ralign 12:} {c |} {ralign 9:e(min)}  {ralign 9:e(max)}  {ralign 9:e(sum)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:     3291}}}  {ralign 9:{res:{sf:    15906}}}  {ralign 9:{res:{sf:   456229}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:       12}}}  {ralign 9:{res:{sf:       41}}}  {ralign 9:{res:{sf:     1576}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:        5}}}  {ralign 9:{res:{sf:      235}}}
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:       22}}}
+
+        {com}. esttab ., cells("mean sd count") noobs
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}
+        {txt}                     mean           sd        count
+        {txt}{hline 51}
+        {txt}price       {res}     6165.257     2949.496           74{txt}
+        {txt}mpg         {res}      21.2973     5.785503           74{txt}
+        {txt}rep78       {res}     3.405797     .9899323           69{txt}
+        {txt}foreign     {res}     .2972973     .4601885           74{txt}
+        {txt}{hline 51}
+{* end example }{txt}{...}
+
+{marker tabstat}
+{dlgtab:tabstat}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:tabstat}
+    {it:{help varlist}} [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:s:tatistics:(}{it:{help tabstat##statname:statname}} [{it:...}]{cmd:)}
+        {cmdab:c:olumns:(}{cmdab:v:ariables}|{cmdab:s:tatistics:)}
+        {cmd:by(}{it:varname}{cmd:)}
+        {cmdab:not:otal}
+        {cmdab:m:issing}
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+    ]
+
+{p 4 4 2}
+    posts summary statistics computed by {helpb tabstat}. {cmd:aweight}s and
+    {cmd:fweight}s are allowed; see {help weight}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:statistics()}, {cmd:columns()}, {cmd:by()}, {cmd:nototal},
+        and {cmd:missing} as described in help {helpb tabstat}.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation
+        sample if any of the variables in {it:varlist} is missing for that
+        observation. The default is to determine the used observations for
+        each variable separately without regard to whether other variables
+        are missing. {cmd:casewise} is a synonym for {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels} to enforce saving the {cmd:by()} values/labels in macro
+        {cmd:e(labels)}.
+
+{p 4 4 2}A vector of results is saved in {cmd:e()} for each specified
+variable or statistic, depending on {cmd:columns()}.
+
+{p 4 4 2}
+    Examples:
+
+{* begin example tabstat }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost tabstat price mpg rep78, listwise ///
+        >     statistics(mean sd)
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+
+        {ralign 12:} {c |} {ralign 9:e(price)}  {ralign 9:e(mpg)}  {ralign 9:e(rep78)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}
+        {ralign 12:mean} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 3.405797}}}
+        {ralign 12:sd} {c |} {ralign 9:{res:{sf:  2912.44}}}  {ralign 9:{res:{sf: 5.866408}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., cells("price mpg rep78")
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}
+        {txt}                    price          mpg        rep78
+        {txt}{hline 51}
+        {txt}mean        {res}     6146.043     21.28986     3.405797{txt}
+        {txt}sd          {res}      2912.44     5.866408     .9899323{txt}
+        {txt}{hline 51}
+        {txt}N           {res}           69                          {txt}
+        {txt}{hline 51}
+
+        {com}. estpost tabstat price mpg rep78, listwise ///
+        >     statistics(mean sd) columns(statistics)
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+
+        {ralign 12:} {c |} {ralign 9:e(mean)}  {ralign 9:e(sd)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf:  2912.44}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 5.866408}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., cells("mean(fmt(a3)) sd")
+        {res}
+        {txt}{hline 38}
+        {txt}                      (1)
+        {txt}
+        {txt}                     mean           sd
+        {txt}{hline 38}
+        {txt}price       {res}       6146.0       2912.4{txt}
+        {txt}mpg         {res}        21.29        5.866{txt}
+        {txt}rep78       {res}        3.406        0.990{txt}
+        {txt}{hline 38}
+        {txt}N           {res}           69             {txt}
+        {txt}{hline 38}
+
+        {com}. estpost tabstat price mpg rep78, by(foreign) ///
+        >     statistics(mean sd) columns(statistics) listwise
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+          by categories of: foreign
+
+        {ralign 12:foreign} {c |} {ralign 9:e(mean)}  {ralign 9:e(sd)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Domestic}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:  6179.25}}}  {ralign 9:{res:{sf: 3188.969}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 19.54167}}}  {ralign 9:{res:{sf: 4.753312}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.020833}}}  {ralign 9:{res:{sf:  .837666}}}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Foreign}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6070.143}}}  {ralign 9:{res:{sf: 2220.984}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 25.28571}}}  {ralign 9:{res:{sf: 6.309856}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 4.285714}}}  {ralign 9:{res:{sf: .7171372}}}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Total}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf:  2912.44}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 5.866408}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., main(mean) aux(sd) nostar unstack ///
+        >     noobs nonote label
+        {res}
+        {txt}{hline 59}
+        {txt}                              (1)
+        {txt}
+        {txt}                         Domestic      Foreign        Total
+        {txt}{hline 59}
+        {txt}Price               {res}       6179.3       6070.1       6146.0{txt}
+                            {res} {ralign 12:{txt:(}3189.0{txt:)}} {ralign 12:{txt:(}2221.0{txt:)}} {ralign 12:{txt:(}2912.4{txt:)}}{txt}
+
+        {txt}Mileage (mpg)       {res}        19.54        25.29        21.29{txt}
+                            {res} {ralign 12:{txt:(}4.753{txt:)}} {ralign 12:{txt:(}6.310{txt:)}} {ralign 12:{txt:(}5.866{txt:)}}{txt}
+
+        {txt}Repair Record 1978  {res}        3.021        4.286        3.406{txt}
+                            {res} {ralign 12:{txt:(}0.838{txt:)}} {ralign 12:{txt:(}0.717{txt:)}} {ralign 12:{txt:(}0.990{txt:)}}{txt}
+        {txt}{hline 59}
+{* end example }{txt}{...}
+
+{marker gtabstat}
+{dlgtab:gtabstat}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:gtabstat}
+    {it:{help varlist}} [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:s:tatistics:(}{it:{help gstats tab##statname:statname}} [{it:...}]{cmd:)}
+        {cmdab:c:olumns:(}{cmdab:v:ariables}|{cmdab:s:tatistics:)}
+        {cmd:by(}{it:varname}{cmd:)}
+        {cmdab:m:issing}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+    ]
+
+{p 4 4 2}
+    posts summary statistics computed by {helpb gstats tab} from
+    the {helpb gtools} package. {cmd:gstats tab} is a fast, by-able
+    alternative to {cmd:tabstat}. {cmd:aweight}s, {cmd:fweight}s, {cmd:pweight}s
+    and {cmd:pweight}s are allowed; see {help weight}. However, {cmd:total}, {cmd:casewise},
+    and {cmd:listwise} are not allowed.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:statistics()}, {cmd:columns()}, and {cmd:by()} as described
+        in help {helpb gstats tab}. By default {cmd:nomissing} is passed;
+        use {cmd:missing} to include missing-value groups.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels} to enforce saving the {cmd:by()} values/labels in macro
+        {cmd:e(labels)}.
+
+{p 4 4 2}A vector of results is saved in {cmd:e()} for each specified
+variable or statistic, depending on {cmd:columns()}.
+
+{p 4 4 2}
+    Examples:
+
+{* begin example gtabstat }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost gtabstat price mpg rep78, ///
+        >     statistics(mean sd)
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+
+        {ralign 12:} {c |} {ralign 9:e(price)}  {ralign 9:e(mpg)}  {ralign 9:e(rep78)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}
+        {ralign 12:mean} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 3.405797}}}
+        {ralign 12:sd} {c |} {ralign 9:{res:{sf:  2912.44}}}  {ralign 9:{res:{sf: 5.866408}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., cells("price mpg rep78")
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}
+        {txt}                    price          mpg        rep78
+        {txt}{hline 51}
+        {txt}mean        {res}     6146.043     21.28986     3.405797{txt}
+        {txt}sd          {res}      2912.44     5.866408     .9899323{txt}
+        {txt}{hline 51}
+        {txt}N           {res}           69                          {txt}
+        {txt}{hline 51}
+
+        {com}. estpost gtabstat price mpg rep78, ///
+        >     statistics(mean sd) columns(statistics)
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+
+        {ralign 12:} {c |} {ralign 9:e(mean)}  {ralign 9:e(sd)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf:  2912.44}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 5.866408}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., cells("mean(fmt(a3)) sd")
+        {res}
+        {txt}{hline 38}
+        {txt}                      (1)
+        {txt}
+        {txt}                     mean           sd
+        {txt}{hline 38}
+        {txt}price       {res}       6146.0       2912.4{txt}
+        {txt}mpg         {res}        21.29        5.866{txt}
+        {txt}rep78       {res}        3.406        0.990{txt}
+        {txt}{hline 38}
+        {txt}N           {res}           69             {txt}
+        {txt}{hline 38}
+
+        {com}. estpost gtabstat price mpg rep78, by(foreign) ///
+        >     statistics(mean sd) columns(statistics)
+
+        {txt}Summary statistics: mean sd
+             for variables: price mpg rep78
+          by categories of: foreign
+
+        {ralign 12:foreign} {c |} {ralign 9:e(mean)}  {ralign 9:e(sd)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Domestic}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:  6179.25}}}  {ralign 9:{res:{sf: 3188.969}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 19.54167}}}  {ralign 9:{res:{sf: 4.753312}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.020833}}}  {ralign 9:{res:{sf:  .837666}}}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Foreign}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6070.143}}}  {ralign 9:{res:{sf: 2220.984}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 25.28571}}}  {ralign 9:{res:{sf: 6.309856}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 4.285714}}}  {ralign 9:{res:{sf: .7171372}}}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {res:{lalign 13:Total}}{c |}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf:  2912.44}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf: 5.866408}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf: .9899323}}}
+
+        {com}. esttab ., main(mean) aux(sd) nostar unstack ///
+        >     noobs nonote label
+        {res}
+        {txt}{hline 59}
+        {txt}                              (1)
+        {txt}
+        {txt}                         Domestic      Foreign        Total
+        {txt}{hline 59}
+        {txt}Price               {res}       6179.3       6070.1       6146.0{txt}
+                            {res} {ralign 12:{txt:(}3189.0{txt:)}} {ralign 12:{txt:(}2221.0{txt:)}} {ralign 12:{txt:(}2912.4{txt:)}}{txt}
+
+        {txt}Mileage (mpg)       {res}        19.54        25.29        21.29{txt}
+                            {res} {ralign 12:{txt:(}4.753{txt:)}} {ralign 12:{txt:(}6.310{txt:)}} {ralign 12:{txt:(}5.866{txt:)}}{txt}
+
+        {txt}Repair Record 1978  {res}        3.021        4.286        3.406{txt}
+                            {res} {ralign 12:{txt:(}0.838{txt:)}} {ralign 12:{txt:(}0.717{txt:)}} {ralign 12:{txt:(}0.990{txt:)}}{txt}
+        {txt}{hline 59}
+{* end example }{txt}{...}
+
+{marker ttest}
+{dlgtab:ttest}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:ttest}
+    {it:{help varlist}} [{it:{help if}}] [{it:{help in}}]{cmd:,}
+    {cmd:by(}{it:groupvar}{cmd:)}
+    [
+        {cmdab:une:qual} {cmdab:w:elch}
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+    ]
+
+{p 4 4 2}
+    posts two-group mean-comparison tests computed by {helpb ttest}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:by()}, {cmd:unequal}, and {cmd:welch} as described in
+        help {helpb ttest}.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation
+        sample if any of the variables in {it:varlist} is missing for that
+        observation. The default is to determine the used observations for
+        each variable separately without regard to whether other variables
+        are missing. {cmd:casewise} is a synonym for {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 4 4 2}The following results vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(b)}}mean difference
+        {lalign 13:{cmd:e(count)}}number of observations
+        {lalign 13:{cmd:e(se)}}standard error of difference
+        {lalign 13:{cmd:e(t)}}t statistic
+        {lalign 13:{cmd:e(df_t)}}degrees of freedom
+        {lalign 13:{cmd:e(p_l)}}lower one-sided p-value
+        {lalign 13:{cmd:e(p)}}two-sided p-value
+        {lalign 13:{cmd:e(p_u)}}upper one-sided p-value
+        {lalign 13:{cmd:e(N_1)}}number of observations in group 1
+        {lalign 13:{cmd:e(mu_1)}}mean in group 1
+        {lalign 13:{cmd:e(N_2)}}number of observations in group 2
+        {lalign 13:{cmd:e(mu_2)}}mean in group 2
+
+{p 4 4 2}
+    Example:
+
+{* begin example ttest }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost ttest price mpg headroom trunk, by(foreign)
+
+        {txt}{ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(count)}  {ralign 9:e(se)}  {ralign 9:e(t)}  {ralign 9:e(df_t)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:-312.2587}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: 754.4488}}}  {ralign 9:{res:{sf:-.4138899}}}  {ralign 9:{res:{sf:       72}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:-4.945804}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: 1.362162}}}  {ralign 9:{res:{sf:-3.630848}}}  {ralign 9:{res:{sf:       72}}}
+        {ralign 12:headroom} {c |} {ralign 9:{res:{sf: .5402098}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: .2070884}}}  {ralign 9:{res:{sf: 2.608596}}}  {ralign 9:{res:{sf:       72}}}
+        {ralign 12:trunk} {c |} {ralign 9:{res:{sf: 3.340909}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: 1.022208}}}  {ralign 9:{res:{sf: 3.268327}}}  {ralign 9:{res:{sf:       72}}}
+
+        {ralign 12:} {c |} {ralign 9:e(p_l)}  {ralign 9:e(p)}  {ralign 9:e(p_u)}  {ralign 9:e(N_1)}  {ralign 9:e(mu_1)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: .3400925}}}  {ralign 9:{res:{sf: .6801851}}}  {ralign 9:{res:{sf: .6599075}}}  {ralign 9:{res:{sf:       52}}}  {ralign 9:{res:{sf: 6072.423}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: .0002627}}}  {ralign 9:{res:{sf: .0005254}}}  {ralign 9:{res:{sf: .9997373}}}  {ralign 9:{res:{sf:       52}}}  {ralign 9:{res:{sf: 19.82692}}}
+        {ralign 12:headroom} {c |} {ralign 9:{res:{sf: .9944757}}}  {ralign 9:{res:{sf: .0110486}}}  {ralign 9:{res:{sf: .0055243}}}  {ralign 9:{res:{sf:       52}}}  {ralign 9:{res:{sf: 3.153846}}}
+        {ralign 12:trunk} {c |} {ralign 9:{res:{sf:   .99917}}}  {ralign 9:{res:{sf:   .00166}}}  {ralign 9:{res:{sf:   .00083}}}  {ralign 9:{res:{sf:       52}}}  {ralign 9:{res:{sf:    14.75}}}
+
+        {ralign 12:} {c |} {ralign 9:e(N_2)}  {ralign 9:e(mu_2)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:       22}}}  {ralign 9:{res:{sf: 6384.682}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:       22}}}  {ralign 9:{res:{sf: 24.77273}}}
+        {ralign 12:headroom} {c |} {ralign 9:{res:{sf:       22}}}  {ralign 9:{res:{sf: 2.613636}}}
+        {ralign 12:trunk} {c |} {ralign 9:{res:{sf:       22}}}  {ralign 9:{res:{sf: 11.40909}}}
+
+        {com}. esttab ., wide
+        {res}
+        {txt}{hline 41}
+        {txt}                      (1)
+        {txt}
+        {txt}{hline 41}
+        {txt}price       {res}       -312.3    {ralign 12:{txt:(}-0.41{txt:)}}{txt}
+        {txt}mpg         {res}       -4.946*** {ralign 12:{txt:(}-3.63{txt:)}}{txt}
+        {txt}headroom    {res}        0.540*   {ralign 12:{txt:(}2.61{txt:)}}{txt}
+        {txt}trunk       {res}        3.341**  {ralign 12:{txt:(}3.27{txt:)}}{txt}
+        {txt}{hline 41}
+        {txt}N           {res}           74                {txt}
+        {txt}{hline 41}
+        {txt}t statistics in parentheses
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+{* end example }{txt}{...}
+
+{marker prtest}
+{dlgtab:prtest}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:prtest}
+    {it:{help varlist}} [{it:{help if}}] [{it:{help in}}]{cmd:,}
+    {cmd:by(}{it:groupvar}{cmd:)}
+    [
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+    ]
+
+{p 4 4 2}
+    posts two-group tests of proportions computed by {helpb prtest}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:by()} as described in
+        help {helpb prtest}.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation
+        sample if any of the variables in {it:varlist} is missing for that
+        observation. The default is to determine the used observations for
+        each variable separately without regard to whether other variables
+        are missing. {cmd:casewise} is a synonym for {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 4 4 2}The following results vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(b)}}difference in proportions
+        {lalign 13:{cmd:e(count)}}number of observations
+        {lalign 13:{cmd:e(se)}}standard error of difference
+        {lalign 13:{cmd:e(se0)}}standard error under Ho
+        {lalign 13:{cmd:e(z)}}z statistic
+        {lalign 13:{cmd:e(p_l)}}lower one-sided p-value
+        {lalign 13:{cmd:e(p)}}two-sided p-value
+        {lalign 13:{cmd:e(p_u)}}upper one-sided p-value
+        {lalign 13:{cmd:e(N_1)}}number of observations in group 1
+        {lalign 13:{cmd:e(P_1)}}proportion in group 1
+        {lalign 13:{cmd:e(N_2)}}number of observations in group 2
+        {lalign 13:{cmd:e(P_2)}}proportion in group 2
+
+{p 4 4 2}
+    Example:
+
+{* begin example prtest }{...}
+        {com}. webuse cure2, clear
+        {txt}
+        {com}. estpost prtest cure, by(sex)
+
+        {txt}{ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(count)}  {ralign 9:e(se)}  {ralign 9:e(se0)}  {ralign 9:e(z)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:cure} {c |} {ralign 9:{res:{sf:-.0729167}}}  {ralign 9:{res:{sf:      109}}}  {ralign 9:{res:{sf: .0933123}}}  {ralign 9:{res:{sf: .0942404}}}  {ralign 9:{res:{sf:-.7737309}}}
+
+        {ralign 12:} {c |} {ralign 9:e(p_l)}  {ralign 9:e(p)}  {ralign 9:e(p_u)}  {ralign 9:e(N_1)}  {ralign 9:e(P_1)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:cure} {c |} {ralign 9:{res:{sf:  .219545}}}  {ralign 9:{res:{sf:   .43909}}}  {ralign 9:{res:{sf:  .780455}}}  {ralign 9:{res:{sf:       64}}}  {ralign 9:{res:{sf:   .59375}}}
+
+        {ralign 12:} {c |} {ralign 9:e(N_2)}  {ralign 9:e(P_2)}
+        {hline 13}{c   +}{hline 11}{hline 11}
+        {ralign 12:cure} {c |} {ralign 9:{res:{sf:       45}}}  {ralign 9:{res:{sf: .6666667}}}
+
+        {com}. esttab ., cell("b se0 z p")
+        {res}
+        {txt}{hline 64}
+        {txt}                      (1)
+        {txt}
+        {txt}                        b          se0            z            p
+        {txt}{hline 64}
+        {txt}cure        {res}    -.0729167     .0942404    -.7737309       .43909{txt}
+        {txt}{hline 64}
+        {txt}N           {res}          109                                       {txt}
+        {txt}{hline 64}
+{* end example }{txt}{...}
+
+{marker tabulate}
+{dlgtab:tabulate}
+
+{p 4 4 2}One-way table:
+
+{p 8 15 2}
+{cmd:estpost} {cmdab:ta:bulate}
+    {it:varname} [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:m:issing}
+        {cmdab:nol:abel}
+        {cmd:sort}
+        {cmd:subpop(}{it:varname}{cmd:)}
+        {cmdab:notot:al}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+    ]
+
+{p 4 4 2}Two-way table:
+
+{p 8 15 2}
+{cmd:estpost} {cmdab:ta:bulate}
+    {it:varname1} {it:varname2} [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:m:issing}
+        {cmdab:nol:abel}
+        {cmdab:ch:i2}
+        {cmdab:e:xact}[{cmd:(}{it:#}{cmd:)}]
+        {cmdab:g:amma}
+        {cmdab:lr:chi2}
+        {cmdab:t:aub}
+        {cmdab:v}
+        {cmdab:notot:al}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+    ]
+
+{p 4 4 2}
+    {cmd:estpost tabulate} posts a one-way or two-way table
+    computed by {helpb tabulate}. {cmd:aweight}s, {cmd:fweight}s,
+    and {cmd:iweight}s are allowed;  see {help weight}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:missing},
+        {cmd:nolabel},
+        {cmd:sort},
+        {cmd:subpop()},
+        {cmd:chi2},
+        {cmd:exact},
+        {cmd:gamma},
+        {cmd:lrchi2},
+        {cmd:taub}, and
+        {cmd:v}
+        as described in help {helpb tabulate}.
+
+{p 8 12 2}
+        {cmdab:nototal} to omit row and column totals.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels} to enforce saving labels in {cmd:e(labels)} and
+        {cmd:e(eqlabels)}.
+
+{p 4 4 2}The following vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(b)}}frequency counts
+        {lalign 13:{cmd:e(pct)}}percent
+        {lalign 13:{cmd:e(cumpct)}}cumulative percent (one-way only)
+        {lalign 13:{cmd:e(colpct)}}column percent (two-way only)
+        {lalign 13:{cmd:e(rowpct)}}row percent (two-way only)
+
+{p 4 4 2}If two-way options such as, e.g., {cmd:chi2} or {cmd:exact} are
+specified, the results of the tests added as scalars in {cmd:e()} using the
+names documented in {helpb tabulate:{bind:[R] tabulate}}.
+
+{p 4 4 2}The value labels of the row variable are stored as names in the
+saved vectors, unless
+no label exceeds 30 characters or contains unsuitable characters in which case
+the labels are stored in macro {cmd:e(labels)}. Type
+{cmd:varlabels(`e(labels)')} in {helpb esttab} or {helpb estout} to
+use the labels stored {cmd:e(labels)}. The value labels of the column variable
+are stored as equation names or, alternatively,
+in macro {cmd:e(eqlabels)}. Type {cmd:eqlabels(`e(eqlabels)')} in
+{helpb esttab} or {helpb estout} to use the labels stored in
+{cmd:e(eqlabels)}. Specify the {cmd:elabels} option to enforce saving labels
+in {cmd:e(labels)} and {cmd:e(eqlabels)}.
+
+{p 4 4 2}Examples:
+
+{* begin example tabulate }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost tabulate foreign
+
+        {txt}{ralign 12:foreign} {c |} {ralign 9:e(b)}  {ralign 9:e(pct)}  {ralign 9:e(cumpct)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}
+        {ralign 12:Domestic} {c |} {ralign 9:{res:{sf:       52}}}  {ralign 9:{res:{sf: 70.27027}}}  {ralign 9:{res:{sf: 70.27027}}}
+        {ralign 12:Foreign} {c |} {ralign 9:{res:{sf:       22}}}  {ralign 9:{res:{sf: 29.72973}}}  {ralign 9:{res:{sf:      100}}}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}
+        {ralign 12:Total} {c |} {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf:      100}}}  {ralign 9:{res:{sf:{space 9}}}}
+
+        {com}. esttab ., cells("b pct(fmt(2)) cumpct(fmt(2))") noobs
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}                  foreign
+        {txt}                        b          pct       cumpct
+        {txt}{hline 51}
+        {txt}Domestic    {res}           52        70.27        70.27{txt}
+        {txt}Foreign     {res}           22        29.73       100.00{txt}
+        {txt}Total       {res}           74       100.00             {txt}
+        {txt}{hline 51}
+
+        {com}. estpost tabulate rep78 foreign
+
+        {res}foreign     {txt} {c |}{space 44}
+        {ralign 12:rep78} {c |} {ralign 9:e(b)}  {ralign 9:e(pct)}  {ralign 9:e(colpct)}  {ralign 9:e(rowpct)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {res:{lalign 13:Domestic}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:1} {c |} {ralign 9:{res:{sf:        2}}}  {ralign 9:{res:{sf: 2.898551}}}  {ralign 9:{res:{sf: 4.166667}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:2} {c |} {ralign 9:{res:{sf:        8}}}  {ralign 9:{res:{sf:  11.5942}}}  {ralign 9:{res:{sf: 16.66667}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:3} {c |} {ralign 9:{res:{sf:       27}}}  {ralign 9:{res:{sf: 39.13043}}}  {ralign 9:{res:{sf:    56.25}}}  {ralign 9:{res:{sf:       90}}}
+        {ralign 12:4} {c |} {ralign 9:{res:{sf:        9}}}  {ralign 9:{res:{sf: 13.04348}}}  {ralign 9:{res:{sf:    18.75}}}  {ralign 9:{res:{sf:       50}}}
+        {ralign 12:5} {c |} {ralign 9:{res:{sf:        2}}}  {ralign 9:{res:{sf: 2.898551}}}  {ralign 9:{res:{sf: 4.166667}}}  {ralign 9:{res:{sf: 18.18182}}}
+        {ralign 12:Total} {c |} {ralign 9:{res:{sf:       48}}}  {ralign 9:{res:{sf: 69.56522}}}  {ralign 9:{res:{sf:      100}}}  {ralign 9:{res:{sf: 69.56522}}}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {res:{lalign 13:Foreign}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:1} {c |} {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}
+        {ralign 12:2} {c |} {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}  {ralign 9:{res:{sf:        0}}}
+        {ralign 12:3} {c |} {ralign 9:{res:{sf:        3}}}  {ralign 9:{res:{sf: 4.347826}}}  {ralign 9:{res:{sf: 14.28571}}}  {ralign 9:{res:{sf:       10}}}
+        {ralign 12:4} {c |} {ralign 9:{res:{sf:        9}}}  {ralign 9:{res:{sf: 13.04348}}}  {ralign 9:{res:{sf: 42.85714}}}  {ralign 9:{res:{sf:       50}}}
+        {ralign 12:5} {c |} {ralign 9:{res:{sf:        9}}}  {ralign 9:{res:{sf: 13.04348}}}  {ralign 9:{res:{sf: 42.85714}}}  {ralign 9:{res:{sf: 81.81818}}}
+        {ralign 12:Total} {c |} {ralign 9:{res:{sf:       21}}}  {ralign 9:{res:{sf: 30.43478}}}  {ralign 9:{res:{sf:      100}}}  {ralign 9:{res:{sf: 30.43478}}}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {res:{lalign 13:Total}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:1} {c |} {ralign 9:{res:{sf:        2}}}  {ralign 9:{res:{sf: 2.898551}}}  {ralign 9:{res:{sf: 2.898551}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:2} {c |} {ralign 9:{res:{sf:        8}}}  {ralign 9:{res:{sf:  11.5942}}}  {ralign 9:{res:{sf:  11.5942}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:3} {c |} {ralign 9:{res:{sf:       30}}}  {ralign 9:{res:{sf: 43.47826}}}  {ralign 9:{res:{sf: 43.47826}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:4} {c |} {ralign 9:{res:{sf:       18}}}  {ralign 9:{res:{sf: 26.08696}}}  {ralign 9:{res:{sf: 26.08696}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:5} {c |} {ralign 9:{res:{sf:       11}}}  {ralign 9:{res:{sf: 15.94203}}}  {ralign 9:{res:{sf: 15.94203}}}  {ralign 9:{res:{sf:      100}}}
+        {ralign 12:Total} {c |} {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf:      100}}}  {ralign 9:{res:{sf:      100}}}  {ralign 9:{res:{sf:      100}}}
+
+        {com}. esttab ., cell(colpct(fmt(2))) unstack noobs
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}
+        {txt}                 Domestic      Foreign        Total
+        {txt}                   colpct       colpct       colpct
+        {txt}{hline 51}
+        {txt}1           {res}         4.17         0.00         2.90{txt}
+        {txt}2           {res}        16.67         0.00        11.59{txt}
+        {txt}3           {res}        56.25        14.29        43.48{txt}
+        {txt}4           {res}        18.75        42.86        26.09{txt}
+        {txt}5           {res}         4.17        42.86        15.94{txt}
+        {txt}Total       {res}       100.00       100.00       100.00{txt}
+        {txt}{hline 51}
+
+        {com}. esttab ., cell(colpct(fmt(2)) count(fmt(g) par keep(Total))) ///
+        >     collabels(none) unstack noobs nonumber nomtitle          ///
+        >     eqlabels(, lhs("Repair Rec."))                           ///
+        >     varlabels(, blist(Total "{c -(}hline @width{c )-}{c -(}break{c )-}"))
+        {res}
+        {txt}{hline 51}
+        {txt}Repair Rec.      Domestic      Foreign        Total
+        {txt}{hline 51}
+        {txt}1           {res}         4.17         0.00         2.90{txt}
+        {txt}2           {res}        16.67         0.00        11.59{txt}
+        {txt}3           {res}        56.25        14.29        43.48{txt}
+        {txt}4           {res}        18.75        42.86        26.09{txt}
+        {txt}5           {res}         4.17        42.86        15.94{txt}
+        {txt}{hline 51}{break}        Total       {res}       100.00       100.00       100.00{txt}
+                    {res}                                       {txt}
+        {txt}{hline 51}
+{* end example }{txt}{...}
+
+{marker svy_tabulate}
+{dlgtab:svy: tabulate}
+
+{p 4 4 2}One-way table:
+
+{p 8 15 2}
+{cmd:estpost} {cmd:svy} [{it:vcetype}] [, {it:svy_options}] {cmd::} {cmdab:ta:bulate}
+    {it:varname} [{it:{help if}}] [{it:{help in}}]
+    [{cmd:,}
+        {cmdab:notot:al}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+        {help svy_tabulate_oneway:{it:svy_tabulate_opts}}
+    ]
+
+{p 4 4 2}Two-way table:
+
+{p 8 15 2}
+{cmd:estpost} {cmd:svy} [{it:vcetype}] [, {it:svy_options}] {cmd::} {cmdab:ta:bulate}
+    {it:varname1} {it:varname2} [{it:{help if}}] [{it:{help in}}]
+    [{cmd:,}
+        {cmdab:notot:al}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+        {help svy_tabulate_oneway:{it:svy_tabulate_opts}}
+    ]
+
+{p 4 4 2}
+    {cmd:estpost svy: tabulate} posts a one-way or two-way table
+    for complex survey data computed by {helpb svy_tabulate:svy: tabulate}. Stata 9 or newer
+    is required.
+
+{p 4 4 2}
+    Options are as described in {helpb svy_tabulate_oneway:[SVY] svy: tabulate oneway} or
+        {helpb svy_tabulate_twoway:[SVY] svy: tabulate twoway}, respectively, and:
+
+{p 8 12 2}
+        {cmdab:nototal} to omit row and column totals (synonym for {cmd:nomarginals}).
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels} to enforce saving labels in {cmd:e(labels)} and
+        {cmd:e(eqlabels)}.
+
+{p 4 4 2}{cmd:estpost svy: tabulate} posts results in {cmd:e()} (except {cmd:e(V)})
+as documented in {helpb svy_tabulate_oneway:[SVY] svy: tabulate oneway} and
+{helpb svy_tabulate_twoway:[SVY] svy: tabulate twoway}, respectively,
+and adds or replaces the following matrices:
+
+        {lalign 10:{cmd:e(b)}}cell, column, or row proportions or percentages,
+                    or weighted counts, depending on options
+        {lalign 10:{cmd:e(se)}}standard errors of {cmd:e(b)}
+        {lalign 10:{cmd:e(lb)}}lower confidence bounds for {cmd:e(b)}
+        {lalign 10:{cmd:e(ub)}}upper confidence bounds for {cmd:e(b)}
+        {lalign 10:{cmd:e(deff)}}deff for variances of {cmd:e(b)}
+        {lalign 10:{cmd:e(deft)}}deft for variances of {cmd:e(b)}
+        {lalign 10:{cmd:e(cell)}}cell proportion or percentages
+        {lalign 10:{cmd:e(row)}}row proportion or percentages (two-way only)
+        {lalign 10:{cmd:e(col)}}column proportion or percentages (two-way only)
+        {lalign 10:{cmd:e(count)}}weighted counts
+        {lalign 10:{cmd:e(obs)}}number of observations
+
+{p 4 4 2}The value labels of the row variable are stored as names in the
+saved vectors, unless
+no label exceeds 30 characters or contains unsuitable characters in which case
+the labels are stored in macro {cmd:e(labels)}. Type
+{cmd:varlabels(`e(labels)')} in {helpb esttab} or {helpb estout} to
+use the labels stored {cmd:e(labels)}. The value labels of the column variable
+are stored as equation names or, alternatively,
+in macro {cmd:e(eqlabels)}. Type {cmd:eqlabels(`e(eqlabels)')} in
+{helpb esttab} or {helpb estout} to use the labels stored in
+{cmd:e(eqlabels)}. Specify the {cmd:elabels} option to enforce saving labels
+in {cmd:e(labels)} and {cmd:e(eqlabels)}.
+
+{p 4 4 2}Examples:
+
+{* begin example svy_tabulate }{...}
+        {com}. webuse nhanes2b, clear
+        {txt}
+        {com}. svyset psuid [pweight=finalwgt], strata(stratid)
+
+              {txt}pweight:{col 16}{res}finalwgt
+                  {txt}VCE:{col 16}{res}linearized
+          {txt}Single unit:{col 16}{res}missing
+             {txt}Strata 1:{col 16}{res}stratid
+                 {txt}SU 1:{col 16}{res}psuid
+                {txt}FPC 1:{col 16}<zero>
+        {p2colreset}{...}
+
+        {com}. estpost svy: tabulate race
+        {txt}(running tabulate on estimation sample)
+
+        {col 1}Number of strata{col 20}= {res}       31{txt}{col 48}Number of obs{col 67}= {res}     10351
+        {txt}{col 1}Number of PSUs{col 20}= {res}       62{txt}{col 48}Population size{col 67}={res}  117157513
+        {txt}{col 48}Design df{col 67}= {res}        31
+
+        {txt}{hline 10}{c TT}{hline 12}
+        1=white,  {c |}
+        2=black,  {c |}
+        3=other   {c |} proportions
+        {hline 10}{c +}{hline 12}
+            White {c |}       {res}.8792
+            {txt}Black {c |}       {res}.0955
+            {txt}Other {c |}       {res}.0253
+                  {txt}{c |}
+            Total {c |}           {res}1
+        {txt}{hline 10}{c BT}{hline 12}
+          Key:  {col 1}proportions  =  {res}cell proportions
+
+        {txt}saved vectors:
+                     e(b) =  {res}cell proportions
+                    {txt}e(se) =  {res}standard errors of cell proportions
+                    {txt}e(lb) =  {res}lower 95% confidence bounds for cell proportions
+                    {txt}e(ub) =  {res}upper 95% confidence bounds for cell proportions
+                  {txt}e(deff) =  {res}deff for variances of cell proportions
+                  {txt}e(deft) =  {res}deft for variances of cell proportions
+                  {txt}e(cell) =  {res}cell proportions
+                 {txt}e(count) =  {res}weighted counts
+                   {txt}e(obs) =  {res}number of observations
+        {txt}
+        {com}. esttab ., cell("b(f(4)) se deft")
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}
+        {txt}                        b           se         deft
+        {txt}{hline 51}
+        {txt}White       {res}       0.8792       0.0167       5.2090{txt}
+        {txt}Black       {res}       0.0955       0.0127       4.4130{txt}
+        {txt}Other       {res}       0.0253       0.0105       6.8246{txt}
+        {txt}Total       {res}       1.0000       0.0000             {txt}
+        {txt}{hline 51}
+        {txt}N           {res}        10351                          {txt}
+        {txt}{hline 51}
+
+        {com}. estpost svy: tabulate race diabetes, row percent
+        {txt}(running tabulate on estimation sample)
+
+        {col 1}Number of strata{col 20}= {res}       31{txt}{col 48}Number of obs{col 67}= {res}     10349
+        {txt}{col 1}Number of PSUs{col 20}= {res}       62{txt}{col 48}Population size{col 67}={res}  117131111
+        {txt}{col 48}Design df{col 67}= {res}        31
+
+        {txt}{hline 10}{c TT}{hline 20}
+        1=white,  {c |}  diabetes, 1=yes,
+        2=black,  {c |}        0=no
+        3=other   {c |}     0      1  Total
+        {hline 10}{c +}{hline 20}
+            White {c |}  {res}96.8  3.195    100
+            {txt}Black {c |}  {res}94.1  5.903    100
+            {txt}Other {c |} {res}97.97  2.034    100
+                  {txt}{c |}
+            Total {c |} {res}96.58  3.425    100
+        {txt}{hline 10}{c BT}{hline 20}
+          Key:  {col 1}{res}row percentages
+
+        {txt}  Pearson:
+        {col 5}Uncorrected{col 19}chi2({res}2{txt}){col 35}= {res}  21.3483
+        {txt}{col 5}Design-based{col 19}F({res}1.52{txt}, {res}47.26{txt}){col 35}= {res}  15.0056{col 51}{txt}P = {res}0.0000
+
+        {txt}saved vectors:
+                     e(b) =  {res}row percentages
+                    {txt}e(se) =  {res}standard errors of row percentages
+                    {txt}e(lb) =  {res}lower 95% confidence bounds for row percentages
+                    {txt}e(ub) =  {res}upper 95% confidence bounds for row percentages
+                  {txt}e(deff) =  {res}deff for variances of row percentages
+                  {txt}e(deft) =  {res}deft for variances of row percentages
+                  {txt}e(cell) =  {res}cell percentages
+                   {txt}e(row) =  {res}row percentages
+                   {txt}e(col) =  {res}column percentages
+                 {txt}e(count) =  {res}weighted counts
+                   {txt}e(obs) =  {res}number of observations
+        {txt}
+        {com}. esttab ., b(2) se(2) scalars(F_Pear) nostar unstack ///
+        >     mtitle(`e(colvar)')
+        {res}
+        {txt}{hline 51}
+        {txt}                      (1)
+        {txt}                 diabetes
+        {txt}                        0            1        Total
+        {txt}{hline 51}
+        {txt}White       {res}        96.80         3.20       100.00{txt}
+                    {res} {ralign 12:{txt:(}0.20{txt:)}} {ralign 12:{txt:(}0.20{txt:)}}             {txt}
+
+        {txt}Black       {res}        94.10         5.90       100.00{txt}
+                    {res} {ralign 12:{txt:(}0.61{txt:)}} {ralign 12:{txt:(}0.61{txt:)}}             {txt}
+
+        {txt}Other       {res}        97.97         2.03       100.00{txt}
+                    {res} {ralign 12:{txt:(}0.76{txt:)}} {ralign 12:{txt:(}0.76{txt:)}}             {txt}
+
+        {txt}Total       {res}        96.58         3.42       100.00{txt}
+                    {res} {ralign 12:{txt:(}0.18{txt:)}} {ralign 12:{txt:(}0.18{txt:)}}             {txt}
+        {txt}{hline 51}
+        {txt}N           {res}        10349                          {txt}
+        {txt}F_Pear      {res}        15.01                          {txt}
+        {txt}{hline 51}
+        {txt}Standard errors in parentheses
+{* end example }{txt}{...}
+
+{marker correlate}
+{dlgtab:correlate}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:cor:relate}
+    {it:{help varlist}} [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:m:atrix}
+        {cmdab:noh:alf}
+        {cmdab:print:(}{it:#}{cmd:)}
+        {cmdab:b:onferroni}
+        {cmdab:sid:ak}
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}[{cmd:(}{it:pfx} {it:sfx}{cmd:)}]
+        {cmdab:nol:abel}
+    ]
+
+{p 4 4 2}
+    posts the pairwise correlations between the first variable in
+    {it:varlist} and the remaining variables. Alternatively, if the
+    {cmd:matrix} option is specified, all pairwise correlations among the
+    variable in {it:varlist} are posted.
+
+{p 4 4 2}
+    {cmd:aweight}s, {cmd:fweight}s,
+    {cmd:iweight}s and {cmd:pweight}s are  allowed; see {help weight}.
+
+{p 4 4 2}
+    Methods and formulas are as described in
+    {helpb correlate:{bind:[R] correlate}}. However, if {cmd:pweight}s
+    are specified, the p-values of the correlations are computed
+    as suggested in the Stata FAQ on
+    {browse "http://www.stata.com/support/faqs/stat/survey.html":"Estimating correlations with survey data"}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:matrix} to return the (lower triangle) of the correlation
+        matrix of the variables in {it:varlist}. The default is to return
+        the pairwise correlations between the first variable in
+        {it:varlist} and the remaining variables.
+
+{p 8 12 2}
+        {cmd:nohalf} to return the full correlation matrix rather than just
+        the lower triangle. {cmd:nohalf} has no effect unless {cmd:matrix}
+        is specified.
+
+{p 8 12 2}
+        {cmd:print(}{it:#}{cmd:)} to suppress (leave blank)
+        correlation coefficients with a p-value larger than
+        {it:#}. {cmd:print()} only affects what is saved in
+        {cmd:e(rho)}, {cmd:e(p)}, and {cmd:e(count)}, but
+        not what is saved in {cmd:e(b)}.
+
+{p 8 12 2}
+        {cmd:bonferroni} to apply the Bonferroni adjustment to the
+        p-values.
+
+{p 8 12 2}
+        {cmd:sidak} to apply the Sidak adjustment to the
+        p-values.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation sample
+        if any of the variables in {it:varlist} is missing for that
+        observation. The default is to handle missing values by pairwise
+        deletion, i.e. all available observations are used to calculate a
+        pairwise correlation without regard to whether variables outside
+        that pair are missing. {cmd:casewise} is a synonym for
+        {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels}[{cmd:(}{it:pfx} {it:sfx}{cmd:)}] stores numbered labels in
+        {cmd:e(labels)} and {cmd:e(eqlabels)} if option {cmd:matrix} has been
+        specified. This is useful if you want to tabulate a correlation
+        matrix. See below for an example. Specify {it:pfx} and 
+        {it:sfx} to provide a prefix and suffix for the numbers; for 
+        example,  {cmd:eqlabels([ ])} will format the numbers as 
+        {cmd:[1]}, {cmd:[2]}, etc.; {cmd:eqlabels("" .)} will format the numbers as 
+        {cmd:1.}, {cmd:2.}, etc.
+
+{p 8 12 2}
+        {cmd:nolabel} causes option {cmd:elabels()} to use variable names rather
+        than variable labels.
+
+{p 4 4 2}The following vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(b)}}correlation coefficients
+        {lalign 13:{cmd:e(rho)}}correlation coefficients
+        {lalign 13:{cmd:e(p)}}p-values
+        {lalign 13:{cmd:e(count)}}number of observations
+
+{p 4 4 2}Examples:
+
+{* begin example correlate }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 automobile data)
+        
+        {com}. estpost correlate price mpg turn foreign, matrix elabels(( ))
+        
+        {txt}{ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(rho)}  {ralign 9:e(p)}  {ralign 9:e(count)} 
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {res:{lalign 13:price}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:{space 9}}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:-.4685967}}}  {ralign 9:{res:{sf:-.4685967}}}  {ralign 9:{res:{sf: .0000255}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:turn} {c |} {ralign 9:{res:{sf: .3096174}}}  {ralign 9:{res:{sf: .3096174}}}  {ralign 9:{res:{sf: .0072662}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf: .0487195}}}  {ralign 9:{res:{sf: .0487195}}}  {ralign 9:{res:{sf: .6801851}}}  {ralign 9:{res:{sf:       74}}} 
+        {res:{lalign 13:mpg}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:{space 9}}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:turn} {c |} {ralign 9:{res:{sf:-.7191863}}}  {ralign 9:{res:{sf:-.7191863}}}  {ralign 9:{res:{sf: 5.30e-13}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf: .3933974}}}  {ralign 9:{res:{sf: .3933974}}}  {ralign 9:{res:{sf: .0005254}}}  {ralign 9:{res:{sf:       74}}} 
+        {res:{lalign 13:turn}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:turn} {c |} {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:{space 9}}}}  {ralign 9:{res:{sf:       74}}} 
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf:-.6310965}}}  {ralign 9:{res:{sf:-.6310965}}}  {ralign 9:{res:{sf: 1.66e-09}}}  {ralign 9:{res:{sf:       74}}} 
+        {res:{lalign 13:foreign}}{c |}{space 11}{space 11}{space 11}{space 11}
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:        1}}}  {ralign 9:{res:{sf:{space 9}}}}  {ralign 9:{res:{sf:       74}}} 
+        
+        {com}. esttab ., not unstack compress noobs
+        {res}
+        {txt}{hline 62}
+        {txt}                 (1)                                          
+        {txt}                                                              
+        {txt}               price          mpg         turn      foreign   
+        {txt}{hline 62}
+        {txt}price     {res}         1                                          {txt}
+        {txt}mpg       {res}    -0.469***         1                             {txt}
+        {txt}turn      {res}     0.310**     -0.719***         1                {txt}
+        {txt}foreign   {res}    0.0487        0.393***    -0.631***         1   {txt}
+        {txt}{hline 62}
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+        
+        {com}. esttab ., not unstack compress noobs nonum nomtitle ///
+        >     varwidth(21) varlabels(`e(labels)') eqlabels(`e(eqlabels)')
+        {res}
+        {txt}{hline 73}
+        {txt}                            (1)          (2)          (3)          (4)   
+        {txt}{hline 73}
+        {txt}(1) Price            {res}         1                                          {txt}
+        {txt}(2) Mileage (mpg)    {res}    -0.469***         1                             {txt}
+        {txt}(3) Turn circle (ft.){res}     0.310**     -0.719***         1                {txt}
+        {txt}(4) Car origin       {res}    0.0487        0.393***    -0.631***         1   {txt}
+        {txt}{hline 73}
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+        
+        {com}. bysort foreign: eststo: ///
+        >     estpost correlate price turn weight rep78, listwise
+        
+        {txt}{hline 60}
+        -> Domestic
+        
+        {ralign 12:price} {c |} {ralign 9:e(b)}  {ralign 9:e(rho)}  {ralign 9:e(p)}  {ralign 9:e(count)} 
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:turn} {c |} {ralign 9:{res:{sf: .4328091}}}  {ralign 9:{res:{sf: .4328091}}}  {ralign 9:{res:{sf: .0021229}}}  {ralign 9:{res:{sf:       48}}} 
+        {ralign 12:weight} {c |} {ralign 9:{res:{sf: .6864719}}}  {ralign 9:{res:{sf: .6864719}}}  {ralign 9:{res:{sf: 7.19e-08}}}  {ralign 9:{res:{sf:       48}}} 
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf:-.0193249}}}  {ralign 9:{res:{sf:-.0193249}}}  {ralign 9:{res:{sf: .8962741}}}  {ralign 9:{res:{sf:       48}}} 
+        ({res}est1{txt} stored)
+        
+        {hline 60}
+        -> Foreign
+        
+        {ralign 12:price} {c |} {ralign 9:e(b)}  {ralign 9:e(rho)}  {ralign 9:e(p)}  {ralign 9:e(count)} 
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:turn} {c |} {ralign 9:{res:{sf: .5102425}}}  {ralign 9:{res:{sf: .5102425}}}  {ralign 9:{res:{sf: .0181155}}}  {ralign 9:{res:{sf:       21}}} 
+        {ralign 12:weight} {c |} {ralign 9:{res:{sf: .8315886}}}  {ralign 9:{res:{sf: .8315886}}}  {ralign 9:{res:{sf: 2.99e-06}}}  {ralign 9:{res:{sf:       21}}} 
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: .1797879}}}  {ralign 9:{res:{sf: .1797879}}}  {ralign 9:{res:{sf: .4354917}}}  {ralign 9:{res:{sf:       21}}} 
+        ({res}est2{txt} stored)
+        
+        {com}. esttab est1 est2, not mtitles
+        {res}
+        {txt}{hline 44}
+        {txt}                      (1)             (2)   
+        {txt}                 Domestic         Foreign   
+        {txt}{hline 44}
+        {txt}turn        {res}        0.433**         0.510*  {txt}
+        {txt}weight      {res}        0.686***        0.832***{txt}
+        {txt}rep78       {res}      -0.0193           0.180   {txt}
+        {txt}{hline 44}
+        {txt}N           {res}           48              21   {txt}
+        {txt}{hline 44}
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+{* end example }{txt}{...}
+
+{marker ci}
+{dlgtab:ci}
+
+{p 4 15 2}
+{cmd:estpost} {cmdab:ci}
+    [{it:{help varlist}}] [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:b:inomial}
+        {cmdab:p:oisson} {cmdab:e:xposure:(}{it:varname}{cmd:)}
+        {cmdab:ex:act} {cmdab:wa:ld} {cmdab:w:ilson} {cmdab:a:gresti} {cmdab:j:effreys}
+        {cmdab:l:evel:(}{it:#}{cmd:)}
+        {cmdab:list:wise}
+        {cmdab:case:wise}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+    ]
+
+{p 4 4 2}
+    posts standard errors and confidence intervals computed by
+    {helpb ci}. {cmd:aweight}s and {cmd:fweight}s are allowed,
+    but {cmd:aweight}s may not be specified with options
+    {cmd:binomial} or {cmd:poisson};
+    see {help weight}.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:binomial}, {cmd:poisson}, {cmd:exposure()},
+        {cmd:exact}, {cmd:wald}, {cmd:wilson}, {cmd:agresti},
+        {cmd:jeffreys}, and {cmd:level()}
+        as described in help {helpb ci}.
+
+{p 8 12 2}
+        {cmd:listwise} to handle missing values through listwise deletion,
+        meaning that an observation is omitted from the estimation
+        sample if any of the variables in {it:varlist} is missing for that
+        observation. The default is to determine the used observations for
+        each variable separately without regard to whether other variables
+        are missing. {cmd:casewise} is a synonym for {cmd:listwise}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 4 4 2}The following results vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(b)}}mean
+        {lalign 13:{cmd:e(count)}}number of observations
+        {lalign 13:{cmd:e(se)}}estimate of standard error
+        {lalign 13:{cmd:e(lb)}}lower bound of confidence interval
+        {lalign 13:{cmd:e(ub)}}upper bound of confidence interval
+
+{p 4 4 2}
+    Examples:
+
+{* begin example ci }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. estpost ci price mpg rep78, listwise
+        {txt}(confidence level is 95%)
+
+        {ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(count)}  {ralign 9:e(se)}  {ralign 9:e(lb)}  {ralign 9:e(ub)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:price} {c |} {ralign 9:{res:{sf: 6146.043}}}  {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf: 350.6166}}}  {ralign 9:{res:{sf: 5446.399}}}  {ralign 9:{res:{sf: 6845.688}}}
+        {ralign 12:mpg} {c |} {ralign 9:{res:{sf: 21.28986}}}  {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf: .7062326}}}  {ralign 9:{res:{sf: 19.88059}}}  {ralign 9:{res:{sf: 22.69912}}}
+        {ralign 12:rep78} {c |} {ralign 9:{res:{sf: 3.405797}}}  {ralign 9:{res:{sf:       69}}}  {ralign 9:{res:{sf: .1191738}}}  {ralign 9:{res:{sf: 3.167989}}}  {ralign 9:{res:{sf: 3.643605}}}
+
+        {com}. esttab ., cells("b lb ub") label
+        {res}
+        {txt}{hline 59}
+        {txt}                              (1)
+        {txt}
+        {txt}                                b           lb           ub
+        {txt}{hline 59}
+        {txt}Price               {res}     6146.043     5446.399     6845.688{txt}
+        {txt}Mileage (mpg)       {res}     21.28986     19.88059     22.69912{txt}
+        {txt}Repair Record 1978  {res}     3.405797     3.167989     3.643605{txt}
+        {txt}{hline 59}
+        {txt}Observations        {res}           69                          {txt}
+        {txt}{hline 59}
+
+        {com}. eststo exact: estpost ci foreign, binomial exact
+        {txt}(confidence level is 95%)
+
+        {ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(count)}  {ralign 9:e(se)}  {ralign 9:e(lb)}  {ralign 9:e(ub)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf: .2972973}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: .0531331}}}  {ralign 9:{res:{sf:  .196584}}}  {ralign 9:{res:{sf: .4148353}}}
+
+        {com}. eststo agresti: estpost ci foreign, binomial agresti
+        {txt}(confidence level is 95%)
+
+        {ralign 12:} {c |} {ralign 9:e(b)}  {ralign 9:e(count)}  {ralign 9:e(se)}  {ralign 9:e(lb)}  {ralign 9:e(ub)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:foreign} {c |} {ralign 9:{res:{sf: .2972973}}}  {ralign 9:{res:{sf:       74}}}  {ralign 9:{res:{sf: .0531331}}}  {ralign 9:{res:{sf:  .204807}}}  {ralign 9:{res:{sf: .4097942}}}
+
+        {com}. esttab exact agresti, cells(lb ub) mtitles
+        {res}
+        {txt}{hline 38}
+        {txt}                      (1)          (2)
+        {txt}                    exact      agresti
+        {txt}                    lb/ub        lb/ub
+        {txt}{hline 38}
+        {txt}foreign     {res}      .196584      .204807{txt}
+                    {res}     .4148353     .4097942{txt}
+        {txt}{hline 38}
+        {txt}N           {res}           74           74{txt}
+        {txt}{hline 38}
+{* end example }{txt}{...}
+
+{marker stci}
+{dlgtab:stci}
+
+{p 4 15 2}
+{cmd:estpost} {cmd:stci}
+    [{it:{help if}}] [{it:{help in}}]
+    [{cmd:,}
+        {cmd:by(}{it:groupvar}{cmd:)}
+        {cmdab:m:edian}
+        {cmdab:r:mean}
+        {cmdab:e:mean}
+        {cmd:p(}{it:#}{cmd:)}
+        {cmdab:cc:orr}
+        {cmdab:l:evel:(}{it:#}{cmd:)}
+        {cmdab:q:uietly}
+        {cmdab:es:ample}
+        {cmdab:el:abels}
+    ]
+
+{p 4 4 2}
+    posts confidence intervals for means
+    and percentiles of survival time computed by {helpb stci}. Stata 9 or
+    newer is required.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:by(}{it:groupvar}{cmd:)}
+        to report separate summaries for each group defined by
+        {it:groupvar}, along with an overall total.
+
+{p 8 12 2}
+        {cmd:median},
+        {cmd:rmean},
+        {cmd:emean},
+        {cmd:p()},
+        {cmd:ccorr}, and
+        {cmd:level()}
+        as described in help {helpb stci}.
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {cmd:esample} to mark the estimation sample in {cmd:e(sample)}.
+
+{p 8 12 2}
+        {cmd:elabels} to enforce saving {cmd:by()} labels in {cmd:e(labels)}.
+
+{p 4 4 2}The following vectors are saved in {cmd:e()}:
+
+        {lalign 13:{cmd:e(count)}}number of subjects
+        {lalign 13:{cmd:e(p50)}}median (if {cmd:median} specified; the default)
+        {lalign 13:{cmd:e(p}{it:#}{cmd:)}}#th percentile (if {cmd:p(}{it:#}{cmd:)} specified)
+        {lalign 13:{cmd:e(rmean)}}restricted mean (if {cmd:rmean} specified)
+        {lalign 13:{cmd:e(emean)}}extended mean (if {cmd:emean} specified)
+        {lalign 13:{cmd:e(se)}}standard error
+        {lalign 13:{cmd:e(lb)}}lower bound of CI
+        {lalign 13:{cmd:e(ub)}}upper bound of CI
+
+{p 4 4 2}
+    Examples:
+
+{* begin example stci }{...}
+        {com}. webuse page2, clear
+        {txt}
+        {com}. estpost stci
+        {txt}(confidence level is 95%)
+
+        {ralign 12:} {c |} {ralign 9:e(count)}  {ralign 9:e(p50)}  {ralign 9:e(se)}  {ralign 9:e(lb)}  {ralign 9:e(ub)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:total} {c |} {ralign 9:{res:{sf:       40}}}  {ralign 9:{res:{sf:      232}}}  {ralign 9:{res:{sf: 2.562933}}}  {ralign 9:{res:{sf:      213}}}  {ralign 9:{res:{sf:      239}}}
+
+        {com}. esttab ., cell("count p50 se lb ub") noobs compress
+        {res}
+        {txt}{hline 60}
+        {txt}                 (1)
+        {txt}
+        {txt}               count       p50        se        lb        ub
+        {txt}{hline 60}
+        {txt}total     {res}        40       232  2.562933       213       239{txt}
+        {txt}{hline 60}
+
+        {com}. estpost stci, by(group)
+        {txt}(confidence level is 95%)
+
+        {ralign 12:} {c |} {ralign 9:e(count)}  {ralign 9:e(p50)}  {ralign 9:e(se)}  {ralign 9:e(lb)}  {ralign 9:e(ub)}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:1} {c |} {ralign 9:{res:{sf:       19}}}  {ralign 9:{res:{sf:      216}}}  {ralign 9:{res:{sf: 5.171042}}}  {ralign 9:{res:{sf:      190}}}  {ralign 9:{res:{sf:      234}}}
+        {ralign 12:2} {c |} {ralign 9:{res:{sf:       21}}}  {ralign 9:{res:{sf:      233}}}  {ralign 9:{res:{sf: 2.179595}}}  {ralign 9:{res:{sf:      232}}}  {ralign 9:{res:{sf:      280}}}
+        {hline 13}{c   +}{hline 11}{hline 11}{hline 11}{hline 11}{hline 11}
+        {ralign 12:total} {c |} {ralign 9:{res:{sf:       40}}}  {ralign 9:{res:{sf:      232}}}  {ralign 9:{res:{sf: 2.562933}}}  {ralign 9:{res:{sf:      213}}}  {ralign 9:{res:{sf:      239}}}
+
+        {com}. esttab ., cell("count p50 se lb ub") noobs compress
+        {res}
+        {txt}{hline 60}
+        {txt}                 (1)
+        {txt}
+        {txt}               count       p50        se        lb        ub
+        {txt}{hline 60}
+        {txt}1         {res}        19       216  5.171042       190       234{txt}
+        {txt}2         {res}        21       233  2.179595       232       280{txt}
+        {txt}total     {res}        40       232  2.562933       213       239{txt}
+        {txt}{hline 60}
+{* end example }{txt}{...}
+
+{marker margins}
+{dlgtab:margins}
+
+{p 4 15 2}
+{cmd:estpost} {cmd:margins}
+    [{it:{help fvvarlist:marginlist}}] [{it:{help if}}] [{it:{help in}}] [{it:{help weight}}]
+    [{cmd:,}
+        {cmdab:q:uietly}
+        {it:{help margins:margins_opions}}
+    ]
+
+{p 4 4 2}
+    posts results from the {helpb margins} command, that was introduced in
+    Stata 11.
+
+{p 4 4 2}
+    Options are:
+
+{p 8 12 2}
+        {cmd:quietly} to suppress the output.
+
+{p 8 12 2}
+        {it:margins_opions} as described in help {helpb margins} (except {cmd:post}).
+
+{p 4 4 2}{cmd:estpost margins} replaces the current {cmd:e(b)} and
+{cmd:e(V)} with {cmd:r(b)} and {cmd:r(V)} from {helpb margins} and
+also copies all other matrixes, scalars, and macros from {helpb margins} into
+{cmd:e()} (possibly replacing identically named existing entries).
+
+{p 4 4 2}
+    Examples:
+
+{* begin example margins }{...}
+        {com}. sysuse auto, clear
+        {txt}(1978 Automobile Data)
+
+        {com}. quietly logit foreign price mpg weight
+        {txt}
+        {com}. estpost margins, dydx(*) quietly
+        {txt}
+        {com}. esttab ., cell("b se") pr2
+        {res}
+        {txt}{hline 38}
+        {txt}                      (1)
+        {txt}                  foreign
+        {txt}                        b           se
+        {txt}{hline 38}
+        {txt}price       {res}     .0000686     .0000136{txt}
+        {txt}mpg         {res}    -.0089607      .006596{txt}
+        {txt}weight      {res}    -.0005069      .000055{txt}
+        {txt}{hline 38}
+        {txt}N           {res}           74             {txt}
+        {txt}pseudo R-sq {res}        0.619             {txt}
+        {txt}{hline 38}
+{* end example }{txt}{...}
+
+
+{title:Author}
+
+{p 4 4 2} Ben Jann, Institute of Sociology, University of Bern, jann@soz.unibe.ch
+
+{p 4 4 2} {cmd:estpost gtabstat} has been contributed by Mauricio Caceres Bravo.
+
+
+{title:Also see}
+
+    Manual:  {hi:[R] estimates}
+
+{p 4 13 2}Online:  help for
+ {helpb estimates},
+ {helpb estout},
+ {helpb esttab},
+ {helpb eststo},
+ {helpb estadd}
+{p_end}

--- a/analysis/extra_ados/eststo.ado
+++ b/analysis/extra_ados/eststo.ado
@@ -1,0 +1,343 @@
+*! version 1.1.0  05nov2008  Ben Jann
+
+program define eststo, byable(onecall)
+    version 8.2
+    local caller : di _caller()
+// --- eststo clear ---
+    if `"`1'"'=="clear" {
+        if `"`0'"'!="clear" {
+            di as err "invalid syntax"
+            exit 198
+        }
+        if "`_byvars'"!="" error 190
+        _eststo_clear
+        exit
+    }
+// --- update globals ---
+    _eststo_cleanglobal
+// --- eststo dir ---
+    if `"`1'"'=="dir" {
+        if `"`0'"'!="dir" {
+            di as err "invalid syntax"
+            exit 198
+        }
+        if "`_byvars'"!="" error 190
+        _eststo_dir
+        exit
+    }
+// --- eststo drop ---
+    if `"`1'"'=="drop" {
+        if "`_byvars'"!="" error 190
+        _eststo_`0'
+        exit
+    }
+// --- eststo store (no by) ---
+    if "`_byvars'"=="" {
+        version `caller': _eststo_store `0'
+        exit
+    }
+// --- eststo store (by) ---
+// - check sorting
+    local sortedby : sortedby
+    local i 0
+    foreach byvar of local _byvars {
+        local sortedbyi : word `++i' of `sortedby'
+        if "`byvar'"!="`sortedbyi'" error 5
+    }
+// - parse command on if qualified
+    capt _on_colon_parse `0'
+    if _rc error 190
+    if `"`s(after)'"'=="" error 190
+    local estcom `"`s(after)'"'
+    local 0 `"`s(before)'"'
+    if substr(trim(`"`estcom'"'),1,3)=="svy" {
+        di as err "svy commands not allowed with by ...: eststo:"
+        exit 190
+    }
+    AddBygrpToIfqualifier `estcom'
+// - parse syntax of _eststo_store call in order to determine
+//   whether title() or missing was specified (note that
+//   -estimates change- cannot be used to set the titles since
+//   it does not work with -noesample-)
+    TitleAndMissing `0'
+// - generate byindex
+    tempname _byindex
+    qui egen long `_byindex' = group(`_byvars'), label `missing'
+    qui su `_byindex', meanonly
+    if r(N)==0 error 2000
+    local Nby = r(max)
+// - loop over bygroups
+    forv i = 1/`Nby' {
+        local ibylab: label (`_byindex') `i'
+        di as txt _n "{hline}"
+        di as txt `"-> `ibylab'"'   // could be improved
+        if `titleopt'==0 local ibytitle
+        else if `titleopt'==1 local ibytitle `" title(`ibylab')"'
+        else if `titleopt'==2 local ibytitle `", title(`ibylab')"'
+        capture noisily {
+            version `caller': _eststo_store `0'`ibytitle' : `estcmd'
+        }
+        if _rc {
+            if "`_byrc0'"=="" error _rc
+        }
+    }
+end
+
+prog TitleAndMissing
+    capt syntax [anything] , Title(string) [ MISsing * ]
+    if _rc==0 {
+        c_local titleopt 0
+        c_local missing "`missing'"
+    }
+    else {
+        syntax [anything] [ , MISsing * ]
+        if `"`missing'`options'"'!="" c_local titleopt 1
+        else c_local titleopt 2
+        c_local missing "`missing'"
+    }
+end
+
+program AddBygrpToIfqualifier
+    syntax anything(equalok) [if/] [in] [using] [fw aw pw iw] [, * ]
+    local estcom `"`macval(anything)' if (\`_byindex'==\`i')"'
+    if `"`macval(if)'"'!="" {
+        local estcom `"`macval(estcom)' & (`macval(if)')"'
+    }
+    if `"`macval(in)'"'!="" {
+        local estcom `"`macval(estcom)' `macval(in)'"'
+    }
+    if `"`macval(using)'"'!="" {
+        local estcom `"`macval(estcom)' `macval(using)'"'
+    }
+    if `"`macval(weight)'"'!="" {
+        local estcom `"`macval(estcom)' [`macval(weight)'`macval(exp)']"'
+    }
+    if `"`macval(options)'"'!="" {
+        local estcom `"`macval(estcom)', `macval(options)'"'
+    }
+    c_local estcmd `"`macval(estcom)'"'
+end
+
+program define _eststo_clear
+    local names $eststo
+    foreach name of local names {
+        capt estimates drop `name'
+    }
+    global eststo
+    global eststo_counter
+end
+
+program define _eststo_dir
+    if `"$eststo"'!="" {
+        estimates dir $eststo
+    }
+end
+
+program define _eststo_cleanglobal
+    local enames $eststo
+    if `"`enames'"'!="" {
+        tempname hcurrent
+        _return hold `hcurrent'
+        qui _estimates dir
+        local snames `r(names)'
+        _return restore `hcurrent'
+    }
+    local names: list enames & snames
+    global eststo `names'
+    if "`names'"=="" global eststo_counter
+end
+
+program define _eststo_drop
+    local droplist `0'
+    if `"`droplist'"'=="" {
+        di as error "someting required"
+        exit 198
+    }
+    local names $eststo
+    foreach item of local droplist {
+        capt confirm integer number `item'
+        if _rc {
+            local dropname `item'
+        }
+        else {
+            if `item'<1 {
+                di as error "`item' not allowed"
+                exit 198
+            }
+            local dropname est`item'
+        }
+        local found 0
+        foreach name in `names' {
+            if match("`name'",`"`dropname'"') {
+                local found 1
+                estimates drop `name'
+                local names: list names - name
+                di as txt "(" as res "`name'" as txt " dropped)"
+            }
+        }
+        if `found'==0 {
+            di as txt "(no matches found for " as res `"`dropname'"' as txt ")"
+        }
+    }
+    global eststo `names'
+end
+
+
+program define _eststo_store, eclass
+    local caller : di _caller()
+    capt _on_colon_parse `0'
+    if !_rc {
+        local command `"`s(after)'"'
+        local 0 `"`s(before)'"'
+    }
+    syntax [name] [, ///
+        Title(passthru) ///
+        Prefix(name) ///
+        Refresh Refresh2(numlist integer max=1 >0) ///
+        ADDscalars(string asis) ///
+        noEsample ///
+        noCopy ///
+        MISsing svy /// doesn't do anything
+        ]
+    if `"`prefix'"'=="" local prefix "est"
+
+// get previous eststo names and counter
+    local names $eststo
+    local counter $eststo_counter
+    if `"`counter'"'=="" local counter 0
+
+// if name provided; set refresh on if name already in list
+    if "`namelist'"!="" {
+        if "`refresh2'"!="" {
+            di as error "refresh() not allowed"
+            exit 198
+        }
+        local name `namelist'
+        if `:list name in names' local refresh refresh
+        else {
+            if "`refresh'"!="" {
+                di as txt "(" as res "`name'" as txt " not found)"
+            }
+            local refresh
+        }
+        if "`refresh'"=="" local ++counter
+    }
+// if no name provided
+    else {
+        if "`refresh2'"!="" local refresh refresh
+        if "`refresh'"!="" {
+// refresh2 not provided => refresh last (if available)
+            if "`refresh2'"=="" {
+                if "`names'"=="" {
+                    di as txt "(nothing to refresh)"
+                    local refresh
+                }
+                else local name: word `:list sizeof names' of `names'
+            }
+// refresh2 provided => check availability
+            else {
+                if `:list posof "`prefix'`refresh2'" in names' {
+                    local name `prefix'`refresh2'
+                }
+                else {
+                    di as txt "(" as res "`prefix'`refresh2'" as txt " not found)"
+                    local refresh
+                }
+            }
+        }
+        if "`refresh'"=="" local ++counter
+// set default name
+        if "`name'"=="" local name `prefix'`counter'
+    }
+
+// run estimation command if provided
+    if `"`command'"'!="" {
+        version `caller': `command'
+    }
+
+// add scalars to e()
+    if `"`addscalars'"'!="" {
+        capt ParseAddscalars `addscalars'
+        if _rc {
+            di as err `"addscalars() invalid"'
+            exit 198
+        }
+        if "`replace'"=="" {
+            local elist `: e(scalars)' `: e(macros)' `: e(matrices)' `: e(functions)'
+        }
+        local forbidden b V sample
+        while (1) {
+            gettoken lhs rest: rest
+            if `:list lhs in forbidden' {
+                di as err `"`lhs' not allowed in addscalars()"'
+                exit 198
+            }
+            if "`replace'"=="" {
+                if `:list lhs in elist' {
+                    di as err `"e(`lhs') already defined"'
+                    exit 110
+                }
+            }
+            gettoken rhs rest: rest, bind
+            capt eret scalar `lhs' = `rhs'
+            if _rc {
+                di as err `"addscalars() invalid"'
+                exit 198
+            }
+            capture local result = e(`lhs')
+            di as txt "(e(" as res `"`lhs'"' as txt ") = " ///
+             as res `result' as txt " added)"
+            if `"`rest'"'=="" continue, break
+        }
+    }
+// add e(cmd) if missing
+    if `"`e(cmd)'"'=="" {
+        if `"`: e(scalars)'`: e(macros)'`: e(matrices)'`: e(functions)'"'!="" {
+            eret local cmd "."
+        }
+    }
+
+// store estimates with e(sample)
+    estimates store `name' , `copy' `title'
+
+// remove e(sample) if -noesample- specified
+    if "`esample'"!="" {
+        capt confirm new var _est_`name'
+        if _rc {
+            tempname hcurrent
+            _est hold `hcurrent', restore estsystem nullok
+            qui replace _est_`name' = . in 1
+            _est unhold `name'
+            capt confirm new var _est_`name'
+            if _rc qui drop _est_`name'
+            else {
+                di as error "somethings wrong; please contact author of -eststo- " ///
+                 "(see e-mail in help {help eststo})"
+                exit 498
+            }
+            _est hold `name', estimates varname(_est_`name')
+                // varname() only needed so that _est hold does not return error
+                // if variable `name' exists
+        }
+    }
+
+// report
+    if "`refresh'"=="" {
+        global eststo `names' `name'
+        global eststo_counter `counter'
+        if `"`namelist'"'=="" {
+            di as txt "(" as res "`name'" as txt " stored)"
+        }
+    }
+    else {
+        if `"`namelist'"'=="" {
+            di as txt "(" as res "`name'" as txt " refreshed)"
+        }
+    }
+end
+
+program ParseAddscalars
+    syntax anything [ , Replace ]
+    c_local rest `"`anything'"'
+    c_local replace `replace'
+end

--- a/analysis/extra_ados/eststo.hlp
+++ b/analysis/extra_ados/eststo.hlp
@@ -1,0 +1,347 @@
+{smcl}
+{* 01feb2017}{...}
+{hi:help eststo}{right:also see: {helpb esttab}, {helpb estout}, {helpb estadd}, {helpb estpost}}
+{right: {browse "http://repec.sowi.unibe.ch/stata/estout/"}}
+{hline}
+
+{title:Title}
+
+{p 4 4 2}{hi:eststo} {hline 2} Store estimates
+
+
+{title:Syntax}{smcl}
+
+{p 8 15 2}
+[{cmd:_}]{cmd:eststo} [{it:name}]
+[{cmd:,} {it:{help eststo##options:options}} ]
+[ {cmd::} {it:{help estimation_command}} ]
+
+{p 8 15 2}
+[{cmd:_}]{cmd:eststo dir}
+
+{p 8 15 2}
+[{cmd:_}]{cmd:eststo drop} {{it:#}|{it:name}} [ {{it:#}|{it:name}} ... ]
+
+{p 8 15 2}
+[{cmd:_}]{cmd:eststo clear}
+
+{marker options}
+    {it:options}{col 23}description
+    {hline 56}
+    [{ul:{cmd:no}}]{cmdab:e:sample}{col 23}{...}
+do not/do store {cmd:e(sample)}
+    {cmdab:t:itle:(}{it:string}{cmd:)}{col 23}{...}
+specify a title for the stored set
+    {cmdab:p:refix:(}{it:prefix}{cmd:)}{col 23}{...}
+specify a name prefix; default is {cmd:est}
+    {cmdab:add:scalars(}{it:...}{cmd:)}{col 23}{...}
+add scalar statistics
+    {cmdab:r:efresh}[{cmd:(}{it:#}{cmd:)}]{col 23}{...}
+overwrite a previously stored set
+    {cmdab:noc:opy}{col 23}{...}
+clear {cmd:e()} after storing the set
+    {cmdab:mis:sing}{col 23}{...}
+use missing values in the {cmd:by} groups
+    {hline 56}
+        
+{p 4 4 2}
+{cmd:by} is allowed with {cmd:eststo} if {cmd:eststo} 
+is used as a prefix command, i.e. specify
+
+        {cmd:by} {it:...} {cmd::} {cmd:eststo} {it:...} {cmd::} {it:estimation_command}
+        
+{p 4 4 2}
+to apply {it:estimation_command} to each {cmd:by} group and store an estimation
+set for each group; see help {help by}. Note that the implementation of {cmd:by} 
+with {cmd:eststo} requires {it:estimation_command} 
+to follow {help language:standard Stata syntax} and 
+allow the {it:{help if}} qualifier. Do not use the 
+{bind:{cmd:by} {it:...}{cmd:: eststo:}} construct with
+{cmd:svy} commands.   
+
+
+{title:Description}
+
+{p 4 4 2}
+{cmd:eststo} stores a  copy of the active estimation results for later
+tabulation. If {it:name} is provided, the estimation set is stored
+under {it:name}. If {it:name} is not provided, the estimation set is
+stored under {cmd:est}{it:#}, where {it:#} is a counter for the
+number of stored estimation sets.  
+
+{p 4 4 2}
+{cmd:eststo} may be used in two ways: Either after fitting a model as
+in
+
+        {com}. regress y x
+        . eststo{txt}
+
+{p 4 4 2}
+or as a prefix command (see help {help prefix}):
+
+        {com}. eststo: regress y x{txt}
+
+{p 4 4 2}
+{cmd:_eststo} is a variant on {cmd:eststo} that, by default, does not
+store the estimation sample information contained in {cmd:e(sample)}.
+Essentially, {cmd:_eststo} is a shortcut to {cmd:eststo, noesample}.
+
+{p 4 4 2}
+{cmd:eststo dir} displays a list of the stored estimates.
+
+{p 4 4 2}
+{cmd:eststo drop} drops estimation sets stored by {cmd:eststo}. If {it:name} is
+provided, the estimation set stored under {it:name}
+is dropped (if {cmd:*} or {cmd:?} wildcards are used {it:name}, 
+all matching sets are dropped). Alternatively, if {it:#} is provided, 
+the estimation set stored as {cmd:est}{it:#} is dropped.
+
+{p 4 4 2}
+{cmd:eststo clear} drops all estimation sets stored by {cmd:eststo} (and clears
+{cmd:eststo}'s global macros).
+
+{p 4 4 2}
+{cmd:eststo} is an alternative to official Stata's
+{helpb estimates store}. The main differences are:
+
+{p 8 12 2}
+{space 1}o{space 2}{cmd:eststo} does not require the user to specify a
+name for the stored estimation set.
+
+{p 8 12 2}
+{space 1}o{space 2}{cmd:eststo} may be used as a prefix command (see
+help {help prefix}).
+
+{p 8 12 2}
+{space 1}o{space 2}{cmd:eststo} provides the possibility to store
+estimates without the {cmd:e(sample)} function (either specify the
+{cmd:noesample} option or use the {cmd:_eststo} command). Omitting
+{cmd:e(sample)} saves memory and also speeds up tabulation programs
+such as {helpb estimates table}, {helpb estout} or {helpb esttab}.
+{hi:Warning:} Some post-estimation commands may not work with
+estimation sets that do not contain the {cmd:e(sample)}.
+
+{p 8 12 2}
+{space 1}o{space 2}{cmd:eststo} can add additional scalar statistics to
+be stored with the estimation set.
+
+
+{title:Options}
+{marker esample}
+{p 4 8 2}
+{cmd:esample} causes the information in {cmd:e(sample)} to be stored
+with the estimates. This is the default in {cmd:eststo}. Type
+{cmd:noesample} or use the {cmd:_eststo} command to omit the
+{cmd:e(sample)}. Note that some post-estimation commands may not be
+working correctly with estimation sets that have been stored without
+{cmd:e(sample)}.
+
+{p 4 8 2}
+{cmd:title(}{it:string}{cmd:)} specifies a title for the stored
+estimation set.
+{p_end}
+{marker addscalars}
+{p 4 8 2}
+{cmd:addscalars(}{it:name exp} [{it:...}] [{cmd:,} {cmdab:r:eplace}]{cmd:)}
+may be used to add additional results to the {cmd:e()}-scalars of the
+estimation set before storing it. Specify the names and values of the
+scalars in pairs. For example, {cmd:addscalars(one 1 two 2)} would
+add {cmd:e(one)} = {cmd:1} and {cmd:e(two)} = {cmd:2}. See below for
+an example. The {cmd:replace} suboption permits overwriting existing
+{cmd:e()}-returns. Not allowed as names are "b", "V", or "sample".
+See {helpb estadd} for a more sophisticated tool to add additional
+results to {cmd:e()}-returns.
+
+{p 4 8 2}
+{cmd:prefix(}{it:prefix}{cmd:)} specifies a custom prefix for the 
+automatic names of the stored estimation sets. The default prefix 
+is {cmd:est}. 
+
+{p 4 8 2}
+{cmd:refresh}[{cmd:(}{it:#}{cmd:)}] may be used to overwrite a
+previously stored estimation set instead of storing the estimates
+under a new name. {cmd:refresh}, specified without argument, will
+overwrite the last saved set. Alternatively,
+{cmd:refresh(}{it:#}{cmd:)} will overwrite the set named
+{cmd:est}{it:#} if it exists. If {it:name} is provided to {cmd:eststo},
+existing sets of the same name will always be overwritten whether or
+not {cmd:refresh} is specified. {cmd:refresh()} with argument is not
+allowed in this case.
+
+{p 4 8 2}
+{cmd:nocopy} specifies that after the estimation set has been stored,
+it no longer be available as the active estimation set.
+
+{p 4 8 2}
+{cmd:missing} is for use of {cmd:eststo} with the {cmd:by} prefix command and 
+causes missing values to be treated like any other values in the {cmd:by} 
+variables. The default is to discard observations with missing values in the 
+{cmd:by} variables.
+
+
+{title:Examples}
+
+{p 4 4 2}
+Applying {cmd:eststo} after fiting a model to store the model's results, 
+as in the following example:
+
+        {com}. sysuse auto
+        {txt}(1978 Automobile Data)
+        
+        {com}. quietly regress price weight
+        {txt}
+        {com}. eststo model1
+        {txt}
+        {com}. quietly regress turn weight foreign
+        {txt}
+        {com}. eststo model2
+        {txt}
+        {com}. estout
+        {res}
+        {txt}{hline 38}
+        {txt}                   model1       model2
+        {txt}                        b            b
+        {txt}{hline 38}
+        {txt}weight      {res}     2.044063     .0042183{txt}
+        {txt}foreign     {res}                 -1.809802{txt}
+        {txt}_cons       {res}    -6.707353     27.44963{txt}
+        {txt}{hline 38}
+
+
+{p 4 4 2}
+Applying {cmd:eststo} as a prefix commmand to fit and store a model in one step:
+
+        {com}. eststo model1: quietly regress price weight
+        {txt}
+        {com}. eststo model2: quietly regress turn weight foreign
+        {txt}
+        {com}. estout
+        {res}
+        {txt}{hline 38}
+        {txt}                   model1       model2
+        {txt}                        b            b
+        {txt}{hline 38}
+        {txt}weight      {res}     2.044063     .0042183{txt}
+        {txt}foreign     {res}                 -1.809802{txt}
+        {txt}_cons       {res}    -6.707353     27.44963{txt}
+        {txt}{hline 38}
+        
+        
+{p 4 4 2}
+Using {cmd:eststo} with automatic names:
+
+        {com}. eststo clear
+        {txt}
+        {com}. eststo: quietly regress price weight
+        {txt}({res}est1{txt} stored)
+        
+        {com}. eststo: quietly regress turn weight foreign
+        {txt}({res}est2{txt} stored)
+        
+        {com}. estout
+        {res}
+        {txt}{hline 38}
+        {txt}                     est1         est2
+        {txt}                        b            b
+        {txt}{hline 38}
+        {txt}weight      {res}     2.044063     .0042183{txt}
+        {txt}foreign     {res}                 -1.809802{txt}
+        {txt}_cons       {res}    -6.707353     27.44963{txt}
+        {txt}{hline 38}
+        
+
+{p 4 4 2}
+Adding ancillary statistics:
+
+        {com}. eststo clear
+        {txt}
+        {com}. quietly regress price weight mpg
+        {txt}
+        {com}. test weight = mpg
+        
+        {txt} ( 1)  {res}weight - mpg = 0
+        
+        {txt}       F(  1,    71) ={res}    0.36
+        {txt}{col 13}Prob > F ={res}    0.5514
+        {txt}
+        {com}. eststo, add(p_diff r(p))
+        {txt}(e({res}p_diff{txt}) = {res}.55138216{txt} added)
+        ({res}est1{txt} stored)
+        
+        {com}. estout, stat(p_diff)
+        {res}
+        {txt}{hline 25}
+        {txt}                     est1
+        {txt}                        b
+        {txt}{hline 25}
+        {txt}weight      {res}     1.746559{txt}
+        {txt}mpg         {res}    -49.51222{txt}
+        {txt}_cons       {res}     1946.069{txt}
+        {txt}{hline 25}
+        {txt}p_diff      {res}     .5513822{txt}
+        {txt}{hline 25}
+        
+
+{p 4 4 2}
+Using the {cmd:by} prefix to store subbroup models:
+
+        {com}. eststo clear
+        {txt}
+        {com}. quietly by foreign: eststo: quietly reg price weight mpg
+        {txt}
+        {com}. esttab, label nodepvar nonumber
+        {res}
+        {txt}{hline 52}
+        {txt}                         Domestic         Foreign   
+        {txt}{hline 52}
+        {txt}Weight (lbs.)       {res}        4.415***        5.156***{txt}
+                            {res} {ralign 12:{txt:(}4.66{txt:)}}    {ralign 12:{txt:(}5.85{txt:)}}   {txt}
+        
+        {txt}Mileage (mpg)       {res}        237.7          -19.78   {txt}
+                            {res} {ralign 12:{txt:(}1.71{txt:)}}    {ralign 12:{txt:(}-0.34{txt:)}}   {txt}
+        
+        {txt}Constant            {res}     -13285.4*        -5065.8   {txt}
+                            {res} {ralign 12:{txt:(}-2.32{txt:)}}    {ralign 12:{txt:(}-1.58{txt:)}}   {txt}
+        {txt}{hline 52}
+        {txt}Observations        {res}           52              22   {txt}
+        {txt}{hline 52}
+        {txt}t statistics in parentheses
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+
+
+{title:Returned results}
+
+{p 4 4 2}
+The name under which an estimation set is stored, is added to the set in 
+{cmd:e(_estimates_name)}.
+
+{p 4 4 2}
+In addition, {cmd:eststo} maintains two global macros. {cmd:$eststo} contains a list
+of the names of the stored estimation sets. {cmd:$eststo_counter}
+contains the count of stored estimation sets.
+
+
+{title:Acknowledgements}
+
+{p 4 4 2}
+Bill Gould suggested to make {cmd:eststo} "byable". 
+
+
+{title:Author}
+
+{p 4 4 2}
+Ben Jann, Institute of Sociology, University of Bern, jann@soz.unibe.ch
+
+
+{title:Also see}
+
+    Manual:  {hi:[R] estimates}
+
+{p 4 13 2}Online:  help for
+ {helpb estimates},
+ {helpb esttab},
+ {helpb estout},
+ {helpb estadd},
+ {helpb estpost}
+{p_end}
+

--- a/analysis/extra_ados/esttab.ado
+++ b/analysis/extra_ados/esttab.ado
@@ -1,0 +1,1337 @@
+*! version 2.1.1  10jun2022  Ben Jann
+*! wrapper for estout
+
+program define esttab
+    version 8.2
+    local caller : di _caller()
+
+// mode specific defaults
+    local cdate "`c(current_date)'"
+    local ctime "`c(current_time)'"
+// - fixed
+    local fixed_open0         `""% `cdate' `ctime'""'
+    local fixed_close0        `""""'
+    local fixed_open          `""'
+    local fixed_close         `""'
+    local fixed_caption       `""@title""'
+    local fixed_open2         `""'
+    local fixed_close2        `""'
+    local fixed_toprule       `""@hline""'
+    local fixed_midrule       `""@hline""'
+    local fixed_bottomrule    `""@hline""'
+    local fixed_topgap        `""""'
+    local fixed_midgap        `""""'
+    local fixed_bottomgap     `""""'
+    local fixed_eqrule        `"begin(@hline "")"'
+    local fixed_ssl           `"N R-sq "adj. R-sq" "pseudo R-sq" AIC BIC"'
+    local fixed_lsl           `"Observations R-squared "Adjusted R-squared" "Pseudo R-squared" AIC BIC"'
+    local fixed_starlevels    `"* 0.05 ** 0.01 *** 0.001"'
+    local fixed_starlevlab    `""'
+    local fixed_begin         `""'
+    local fixed_delimiter     `"" ""'
+    local fixed_end           `""'
+    local fixed_incelldel     `"" ""'
+    local fixed_varwidth      `"\`= cond("\`label'"=="", 12, 20)'"'
+    local fixed_modelwidth    `"12"'
+    local fixed_abbrev        `"abbrev"'
+    local fixed_substitute    `""'
+    local fixed_interaction   `"" # ""'
+    local fixed_tstatlab      `"t statistics"'
+    local fixed_zstatlab      `"z statistics"'
+    local fixed_pvallab       `"p-values"'
+    local fixed_cilab         `"\`level'% confidence intervals"'
+// - smcl
+    local smcl_open0          `"{smcl} "{* % `cdate' `ctime'}{...}""'
+    local smcl_close0         `""""'
+    local smcl_open           `""'
+    local smcl_close          `""'
+    local smcl_caption        `""@title""'
+    local smcl_open2          `""'
+    local smcl_close2         `""'
+    local smcl_toprule        `""{hline @width}""'
+    local smcl_midrule        `""{hline @width}""'
+    local smcl_bottomrule     `""{hline @width}""'
+    local smcl_topgap         `""""'
+    local smcl_midgap         `""""'
+    local smcl_bottomgap      `""""'
+    local smcl_eqrule         `"begin("{hline @width}" "")"'
+    local smcl_ssl            `"`macval(fixed_ssl)'"'
+    local smcl_lsl            `"`macval(fixed_lsl)'"'
+    local smcl_starlevels     `"`macval(fixed_starlevels)'"'
+    local smcl_starlevlab     `""'
+    local smcl_begin          `""'
+    local smcl_delimiter      `"" ""'
+    local smcl_end            `""'
+    local smcl_incelldel      `"" ""'
+    local smcl_varwidth       `"`macval(fixed_varwidth)'"'
+    local smcl_modelwidth     `"`macval(fixed_modelwidth)'"'
+    local smcl_abbrev         `"`macval(fixed_abbrev)'"'
+    local smcl_substitute     `""'
+    local smcl_interaction    `"" # ""'
+    local smcl_tstatlab       `"`macval(fixed_tstatlab)'"'
+    local smcl_zstatlab       `"`macval(fixed_zstatlab)'"'
+    local smcl_pvallab        `"`macval(fixed_pvallab)'"'
+    local smcl_cilab          `"`macval(fixed_cilab)'"'
+// - tab
+    local tab_open0           `"`macval(fixed_open0)'"'
+    local tab_close0          `""""'
+    local tab_open            `""'
+    local tab_close           `""'
+    local tab_caption         `""@title""'
+    local tab_open2           `""'
+    local tab_close2          `""'
+    local tab_topgap          `""""'
+    local tab_midgap          `""""'
+    local tab_bottomgap       `""""'
+    local tab_ssl             `"`macval(fixed_ssl)'"'
+    local tab_lsl             `"`macval(fixed_lsl)'"'
+    local tab_starlevels      `"`macval(fixed_starlevels)'"'
+    local tab_starlevlab      `""'
+    local tab_begin           `""'
+    local tab_delimiter       `"_tab"'
+    local tab_end             `""'
+    local tab_incelldel       `"" ""'
+    local tab_varwidth        `""'
+    local tab_modelwidth      `""'
+    local tab_abbrev          `""'
+    local tab_substitute      `""'
+    local tab_interaction     `"" # ""'
+    local tab_tstatlab        `"`macval(fixed_tstatlab)'"'
+    local tab_zstatlab        `"`macval(fixed_zstatlab)'"'
+    local tab_pvallab         `"`macval(fixed_pvallab)'"'
+    local tab_cilab           `"`macval(fixed_cilab)'"'
+// - csv
+    local csv_open0           `"`"\`csvlhs'% `cdate' `ctime'""'"'
+    local csv_close0          `""""'
+    local csv_open            `""'
+    local csv_close           `""'
+    local csv_caption         `"`"\`csvlhs'@title""'"'
+    local csv_open2           `""'
+    local csv_close2          `""'
+    local csv_topgap          `""""'
+    local csv_midgap          `""""'
+    local csv_bottomgap       `""""'
+    local csv_ssl             `"`macval(fixed_ssl)'"'
+    local csv_lsl             `"`macval(fixed_lsl)'"'
+    local csv_starlevels      `"`macval(fixed_starlevels)'"'
+    local csv_starlevlab      `""'
+    local csv_begin           `"`"\`csvlhs'"'"'
+    local csv_delimiter       `"`"",\`csvlhs'"'"'
+    local scsv_delimiter      `"`"";\`csvlhs'"'"'
+    local csv_end             `"`"""'"'
+    local csv_incelldel       `"" ""'
+    local csv_varwidth        `""'
+    local csv_modelwidth      `""'
+    local csv_abbrev          `""'
+    local csv_substitute      `""'
+    local csv_interaction     `"" # ""'
+    local csv_tstatlab        `"`macval(fixed_tstatlab)'"'
+    local csv_zstatlab        `"`macval(fixed_zstatlab)'"'
+    local csv_pvallab         `"`macval(fixed_pvallab)'"'
+    local csv_cilab           `"`macval(fixed_cilab)'"'
+// - rtf
+    local rtf_open0           `""'
+    local rtf_close0          `""'
+      local rtf_ct            `"\yr`=year(d(`cdate'))'\mo`=month(d(`cdate'))'\dy`=day(d(`cdate'))'\hr`=substr("`ctime'",1,2)'\min`=substr("`ctime'",4,2)'"'
+      local rtf_fonttbl       "\f0\fnil Times New Roman;"
+      local rtf_open_l1       `"`"{\rtf1`=cond("`c(os)'"=="MacOSX", "\mac", "\ansi")'\deff0 {\fonttbl\`rtf_fonttbl'}"'"'
+      local rtf_open_l2       `" `"{\info {\author .}{\company .}{\title .}{\creatim`rtf_ct'}}"'"'
+      local rtf_open_l3       `" `"\deflang1033\plain\fs24"'"'
+      local rtf_open_l4       `" `"{\footer\pard\qc\plain\f0\fs24\chpgn\par}"'"'
+    local rtf_open            `"\`rtf_open_l1'`rtf_open_l2'`rtf_open_l3'`rtf_open_l4'"'
+    local rtf_close           `""{\pard \par}" "}""'
+    local rtf_caption         `"`"{\pard\keepn\ql @title\par}"'"'
+    local rtf_open2           `""{""'
+    local rtf_close2          `""}""'
+    local rtf_toprule         `""'
+    local rtf_midrule         `""'
+    local rtf_bottomrule      `""'
+    local rtf_topgap          `""'
+    local rtf_midgap          `"{\trowd\trgaph108\trleft-108@rtfemptyrow\row}"'
+    local rtf_bottomgap       `""'
+    local rtf_eqrule          `"begin("{\trowd\trgaph108\trleft-108@rtfrowdefbrdrt\pard\intbl\ql {") replace"'
+    local rtf_ssl             `""{\i N}" "{\i R}{\super 2}" "adj. {\i R}{\super 2}" "pseudo {\i R}{\super 2}" "{\i AIC}" "{\i BIC}""'
+    local rtf_lsl             `"Observations "{\i R}{\super 2}" "Adjusted {\i R}{\super 2}" "Pseudo {\i R}{\super 2}" "{\i AIC}" "{\i BIC}""'
+    local rtf_starlevels      `""{\super *}" 0.05 "{\super **}" 0.01 "{\super ***}" 0.001"'
+    local rtf_starlevlab      `", label(" {\i p} < ")"'
+      local rtf_rowdef        `"\`=cond("\`lines'"=="", "@rtfrowdef", "@rtfrowdefbrdr")'"'
+    local rtf_begin           `"{\trowd\trgaph108\trleft-108\`rtf_rowdef'\pard\intbl\ql {"'
+    local rtf_delimiter       `"}\cell \pard\intbl\q\`=cond(`"\`alignment'"'!="", `"\`alignment'"', "c")' {"'
+    local rtf_end             `"}\cell\row}"'
+    local rtf_incelldel       `""\line ""'
+    local rtf_varwidth        `"\`= cond("\`label'"=="", 12, 20)'"'
+    local rtf_modelwidth      `"12"'
+    local rtf_abbrev          `""'
+    local rtf_substitute      `""'
+    local rtf_interaction     `"" # ""'
+    local rtf_tstatlab        `"{\i t} statistics"'
+    local rtf_zstatlab        `"{\i z} statistics"'
+    local rtf_pvallab         `"{\i p}-values"'
+    local rtf_cilab           `"\`level'% confidence intervals"'
+// - html
+    local html_open0          `"<html> <head> "<title>`=cond(`"\`macval(title)'"'=="","estimates table, created `cdate' `ctime'","@title")'</title>" </head> <body> """'
+    local html_close0         `""" </body> </html> """'
+    local html_open           `"`"<table border="0" width="\`=cond("\`width'"=="","*","\`width'")'">"'"'
+    local html_close          `""</table>""'
+    local html_caption        `""<caption>@title</caption>""'
+    local html_open2          `""'
+    local html_close2         `""'
+    local html_toprule        `""<tr><td colspan=@span><hr></td></tr>""'
+    local html_midrule        `""<tr><td colspan=@span><hr></td></tr>""'
+    local html_bottomrule     `""<tr><td colspan=@span><hr></td></tr>""'
+    local html_topgap         `""'
+    local html_midgap         `""<tr><td colspan=@span>&nbsp;</td></tr>""'
+    local html_bottomgap      `""'
+    local html_eqrule         `"begin("<tr><td colspan=@span><hr></td></tr>" "")"'
+    local html_ssl            `"<i>N</i> <i>R</i><sup>2</sup> "adj. <i>R</i><sup>2</sup>" "pseudo <i>R</i><sup>2</sup>" <i>AIC</i> <i>BIC</i>"'
+    local html_lsl            `"Observations <i>R</i><sup>2</sup> "Adjusted <i>R</i><sup>2</sup>" "Pseudo <i>R</i><sup>2</sup>" <i>AIC</i> <i>BIC</i>"'
+    local html_starlevels     `"<sup>*</sup> 0.05 <sup>**</sup> 0.01 <sup>***</sup> 0.001"'
+    local html_starlevlab     `", label(" <i>p</i> < ")"'
+    local html_begin          `"<tr><td>"'
+    local html_delimiter      `"</td><td\`=cond(`"\`alignment'"'!="", `" align="\`alignment'""', "")'>"'
+    local html_end            `"</td></tr>"'
+    local html_incelldel      `"<br />"'
+    local html_varwidth       `"\`= cond("\`label'"=="", 12, 20)'"'
+    local html_modelwidth     `"12"'
+    local html_abbrev         `""'
+    local html_substitute     `""'
+    local html_interaction    `"" # ""'
+    local html_tstatlab       `"<i>t</i> statistics"'
+    local html_zstatlab       `"<i>z</i> statistics"'
+    local html_pvallab        `"<i>p</i>-values"'
+    local html_cilab          `"\`level'% confidence intervals"'
+// - tex
+    local tex_open0           `""% `cdate' `ctime'" `"\documentclass\`texclass'"' \`texpkgs' \`=cond("\`longtable'"!="","\usepackage{longtable}","")' \begin{document} """'
+    local tex_close0          `""" \end{document} """'
+    local tex_open            `"`"\`=cond("\`longtable'"=="", "\begin{table}[htbp]\centering", "{")'"'"'
+    local tex_close           `"`"\`=cond("\`longtable'"=="", "\end{table}", "}")'"'"'
+    local tex_caption         `"\caption{@title}"'
+    local tex_open2           `"\`=cond("\`longtable'"!="", "\begin{longtable}", "\begin{tabular" + cond("\`width'"=="", "}", "*}{\`width'}"))'"'
+    local tex_close2          `"`"\`=cond("\`longtable'"!="", "\end{longtable}", "\end{tabular" + cond("\`width'"=="", "}", "*}"))'"'"'
+    local tex_toprule         `"`"\`="\hline\hline" + cond("\`longtable'"!="", "\endfirsthead\hline\endhead\hline\endfoot\endlastfoot", "")'"'"'
+    local tex_midrule         `""\hline""'
+    local tex_bottomrule      `""\hline\hline""'
+    local tex_topgap          `""'
+    local tex_midgap          `"[1em]"' // `"\\\"'
+    local tex_bottomgap       `""'
+    local tex_eqrule          `"begin("\hline" "")"'
+    local tex_ssl             `"\(N\) \(R^{2}\) "adj. \(R^{2}\)" "pseudo \(R^{2}\)" \textit{AIC} \textit{BIC}"'
+    local tex_lsl             `"Observations \(R^{2}\) "Adjusted \(R^{2}\)" "Pseudo \(R^{2}\)" \textit{AIC} \textit{BIC}"'
+    local tex_starlevels      `"\sym{*} 0.05 \sym{**} 0.01 \sym{***} 0.001"'
+    local tex_starlevlab      `", label(" \(p<@\)")"'
+    local tex_begin           `""'
+    local tex_delimiter       `"&"'
+    local tex_end             `"\\\"'
+    local tex_incelldel       `"" ""'
+    local tex_varwidth        `"\`= cond("\`label'"=="", 12, 20)'"'
+    local tex_modelwidth      `"12"'
+    local tex_abbrev          `""'
+    local tex_tstatlab        `"\textit{t} statistics"'
+    local tex_zstatlab        `"\textit{z} statistics"'
+    local tex_pvallab         `"\textit{p}-values"'
+    local tex_cilab           `"\`level'\% confidence intervals"'
+    local tex_substitute      `"_ \_ "\_cons " \_cons"'
+    local tex_interaction     `"" $\times$ ""'
+// - booktabs
+    local booktabs_open0      `""% `cdate' `ctime'" `"\documentclass\`texclass'"' \`texpkgs' \usepackage{booktabs} \`=cond("\`longtable'"!="","\usepackage{longtable}","")' \begin{document} """'
+    local booktabs_close0     `"`macval(tex_close0)'"'
+    local booktabs_open       `"`macval(tex_open)'"'
+    local booktabs_close      `"`macval(tex_close)'"'
+    local booktabs_caption    `"`macval(tex_caption)'"'
+    local booktabs_open2      `"`macval(tex_open2)'"'
+    local booktabs_close2     `"`macval(tex_close2)'"'
+    local booktabs_toprule    `"`"\`="\toprule" + cond("\`longtable'"!="", "\endfirsthead\midrule\endhead\midrule\endfoot\endlastfoot", "")'"'"'
+    local booktabs_midrule    `""\midrule""'
+    local booktabs_bottomrule `""\bottomrule""'
+    local booktabs_topgap     `"`macval(tex_topgap)'"'
+    local booktabs_midgap     `"\addlinespace"'
+    local booktabs_bottomgap  `"`macval(tex_bottomgap)'"'
+    local booktabs_eqrule     `"begin("\midrule" "")"'
+    local booktabs_ssl        `"`macval(tex_ssl)'"'
+    local booktabs_lsl        `"`macval(tex_lsl)'"'
+    local booktabs_starlevels `"`macval(tex_starlevels)'"'
+    local booktabs_starlevlab `"`macval(tex_starlevlab)'"'
+    local booktabs_begin      `"`macval(tex_begin)'"'
+    local booktabs_delimiter  `"`macval(tex_delimiter)'"'
+    local booktabs_end        `"`macval(tex_end)'"'
+    local booktabs_incelldel  `"`macval(tex_incelldel)'"'
+    local booktabs_varwidth   `"`macval(tex_varwidth)'"'
+    local booktabs_modelwidth `"`macval(tex_modelwidth)'"'
+    local booktabs_abbrev     `"`macval(tex_abbrev)'"'
+    local booktabs_tstatlab   `"`macval(tex_tstatlab)'"'
+    local booktabs_zstatlab   `"`macval(tex_zstatlab)'"'
+    local booktabs_pvallab    `"`macval(tex_pvallab)'"'
+    local booktabs_cilab      `"`macval(tex_cilab)'"'
+    local booktabs_substitute `"`macval(tex_substitute)'"'
+    local booktabs_interaction `"`macval(tex_interaction)'"'
+// - mmd
+    local mmd_open0          `""'
+    local mmd_close0         `""'
+    local mmd_open           `""""'
+    local mmd_close          `""""'
+    local mmd_caption        `""@title" """'
+    local mmd_open2          `""'
+    local mmd_close2         `""'
+    local mmd_toprule        `""'
+    local mmd_midrule        `""'
+    local mmd_bottomrule     `""'
+    local mmd_topgap         `""'
+    local mmd_midgap         `""'
+    local mmd_bottomgap      `""'
+    local mmd_eqrule         `""'
+    local mmd_ssl            `"*N* *R*<sup>2</sup> "adj. *R*<sup>2</sup>" "pseudo *R*<sup>2</sup>" *AIC* *BIC*"'
+    local mmd_lsl            `"Observations *R*<sup>2</sup> "Adjusted *R*<sup>2</sup>" "Pseudo *R*<sup>2</sup>" *AIC* *BIC*"'
+    local mmd_starlevels     `"<sup>\*</sup> 0.05 <sup>\*\*</sup> 0.01 <sup>\*\*\*</sup> 0.001"'
+    local mmd_starlevlab     `", label(" *p* < ")"'
+    local mmd_begin          `"| "'
+    local mmd_delimiter      `" | "'
+    local mmd_end            `" |"'
+    local mmd_incelldel      `" "'
+    local mmd_varwidth       `"\`= cond("\`label'"=="", 12, 20)'"'
+    local mmd_modelwidth     `"12"'
+    local mmd_abbrev         `""'
+    local mmd_substitute     `"_ \_ "\_cons " \_cons"'
+    local mmd_interaction    `"" # ""'
+    local mmd_tstatlab       `"*t* statistics"'
+    local mmd_zstatlab       `"*z* statistics"'
+    local mmd_pvallab        `"*p*-values"'
+    local mmd_cilab          `"\`level'\% confidence intervals"'
+// syntax
+    syntax [anything] [using] [ , ///
+ /// coefficients and t-stats, se, etc.
+     b Bfmt(string) ///
+     noT Tfmt(string) ///
+     z Zfmt(string) ///
+     se SEfmt(string) ///
+     p Pfmt(string) ///
+     ci CIfmt(string) ///
+     BEta BEtafmt(string) ///
+     main(string) /// syntax: name format
+     aux(string) /// syntax: name format
+     abs  /// absolute t-values
+     wide ///
+     NOSTAr STAR STAR2(string asis) ///
+     staraux ///
+     NOCONstant CONstant ///
+     COEFlabels(string asis) ///
+ /// summary statistics
+     noOBS obslast ///
+     r2 R2fmt(string) ar2 AR2fmt(string) pr2 PR2fmt(string) ///
+     aic AICfmt(string) bic BICfmt(string) ///
+     SCAlars(string asis) /// syntax: "name1 [label1]" "name2 [label2]" etc.
+     sfmt(string) ///
+ /// layout
+     NOMTItles MTItles MTItles2(string asis) ///
+     NOGAPs GAPs ///
+     NOLInes LInes ///
+     ADDNotes(string asis) ///
+     COMpress ///
+     plain ///
+     smcl FIXed tab csv SCsv rtf HTMl tex BOOKTabs md mmd ///
+     Fragment ///
+     page PAGE2(str) ///
+     STANDalone STANDalone2(str asis) ///
+     ALIGNment(str asis) ///
+     width(str asis) ///
+     fonttbl(str) ///
+ /// other
+     Noisily ///
+     * ]
+    _more_syntax , `macval(options)'
+    _estout_options , `macval(options)'
+
+// matrix mode
+    MatrixMode, `anything'
+
+// syntax consistency etc
+    gettoken chunk using0: using
+    if `"`macval(star2)'"'!="" local star star
+    foreach opt in constant gaps lines star abbrev depvars numbers parentheses ///
+        notes mtitles type outfilenoteoff float {
+        NotBothAllowed "``opt''" `no`opt''
+    }
+    NotBothAllowed "`staraux'" `nostar'
+    if `"`macval(mtitles2)'"'!="" NotBothAllowed "mtitles" `nomtitles'
+    if `"`standalone2'"'!="" local standalone standalone
+    if "`standalone'"!="" {
+        if      `"`standalone2'"'==""     local standalone2 "[varwidth]"
+        else if `"`standalone2'"'==`""""' local standalone2
+        else                              local standalone2 `"[`standalone2']"'
+        local page page
+    }
+    if `"`page2'"'!="" local page page
+    NotBothAllowed "`fragment'" `page'
+    if `"`pfmt'"'!=""    local p p
+    if `"`zfmt'"'!=""    local z z
+    if `"`sefmt'"'!=""   local se se
+    if `"`cifmt'"'!=""   local ci ci
+    if `"`betafmt'"'!="" local beta beta
+    if "`level'"==""     local level $S_level
+    if ((("`margin'"!="" | `"`margin2'"'!="") & "`nomargin'"=="") | ///
+       ("`beta'"!="") | ("`eform'"!="" & "`noeform'"=="")) ///
+       & "`constant'"==""  local noconstant noconstant
+    if `"`r2fmt'"'!="" local r2 r2
+    if `"`ar2fmt'"'!="" local ar2 ar2
+    if `"`pr2fmt'"'!="" local pr2 pr2
+    if `"`aicfmt'"'!="" local aic aic
+    if `"`bicfmt'"'!="" local bic bic
+    if "`type'"=="" & `"`using'"'!="" local notype notype
+    local nocellsopt = `"`macval(cells)'"'==""
+    if `"`width'"'!="" & `"`longtable'"'!="" {
+        di as err "width() and longtable not both allowed"
+        exit 198
+    }
+
+// format modes
+    local mode `smcl' `fixed' `tab' `csv' `scsv' `rtf' `html' `tex' `booktabs' `md' `mmd'
+    if `:list sizeof mode'>1 {
+        di as err "only one allowed of smcl, fixed, tab, csv, scsv, rtf, html, tex, booktabs, md, or mmd"
+        exit 198
+    }
+    if `"`using'"'!="" {
+        _getfilename `"`using0'"'
+        local fn `"`r(filename)'"'
+        _getfilesuffix `"`fn'"'
+        local suffix `"`r(suffix)'"'
+    }
+    if "`mode'"=="" {
+        if `"`using'"'!="" {
+            if inlist(`"`suffix'"', ".html", ".htm") local mode html
+            else if `"`suffix'"'==".tex"             local mode tex
+            else if `"`suffix'"'==".csv"             local mode csv
+            else if `"`suffix'"'==".rtf"             local mode rtf
+            else if `"`suffix'"'==".smcl"            local mode smcl
+            else if `"`suffix'"'== ".md"             local mode md
+            else if `"`suffix'"'== ".mmd"            local mode mmd
+            else local mode fixed
+        }
+        else local mode smcl
+    }
+    else {
+        if "`mode'"=="scsv" {
+            local csv_delimiter `"`macval(`mode'_delimiter)'"'
+            local mode "csv"
+        }
+    }
+    if `"`using'"'!="" & `"`suffix'"'=="" {
+        if inlist("`mode'","fixed","tab")         local suffix ".txt"
+        else if inlist("`mode'","csv","scsv")     local suffix ".csv"
+        else if "`mode'"=="rtf"                   local suffix ".rtf"
+        else if "`mode'"=="html"                  local suffix ".html"
+        else if inlist("`mode'","tex","booktabs") local suffix ".tex"
+        else if "`mode'"=="smcl"                  local suffix ".smcl"
+        else if "`mode'"=="md"                    local suffix ".md"
+        else if "`mode'"=="mmd"                   local suffix ".mmd"
+        local using `"using `"`fn'`suffix'"'"'
+        local using0 `" `"`fn'`suffix'"'"'
+    }
+    if "`mode'"=="md" local mode "mmd"  // !
+    if "`mode'"=="smcl" local smcltags smcltags
+    local mode0 `mode'
+    if "`mode0'"=="booktabs" local mode0 tex
+    else if "`mode0'"=="csv" {
+        if "`plain'"=="" local csvlhs `"=""'
+        else local csvlhs `"""'
+    }
+    if "`compress'"!="" {
+        if "``mode'_modelwidth'"!="" {
+            local `mode'_modelwidth = ``mode'_modelwidth' - 3
+        }
+        if "``mode'_varwidth'"!="" {
+            local `mode'_varwidth = ``mode'_varwidth' - cond("`label'"!="", 4, 2)
+        }
+    }
+    if `"`modelwidth'"'=="" {
+        if `nocellsopt' & `"``mode'_modelwidth'"'!="" & "`ci'"!="" {
+            local modelwidth = 2*``mode'_modelwidth' - 2
+            if "`wide'"!="" local modelwidth "``mode'_modelwidth' `modelwidth'"
+        }
+        else {
+            local modelwidth "``mode'_modelwidth'"
+        }
+    }
+    if `"`varwidth'"'=="" {
+        local varwidth "``mode'_varwidth'"
+    }
+    if "`plain'"=="" & `matrixmode'==0 {
+        foreach opt in star depvars numbers parentheses notes {
+            SwitchOnIfEmpty `opt' `no`opt''
+        }
+        if "`wide'"=="" & ("`t'"=="" | "`z'`se'`p'`ci'`aux'"!="") & `nocellsopt'==1 ///
+         SwitchOnIfEmpty gaps `nogaps'
+    }
+    if "`plain'"=="" {
+        SwitchOnIfEmpty lines `nolines'
+    }
+    if `"`lines'"'!="" {
+        SwitchOnIfEmpty eqlines `noeqlines'
+    }
+    if inlist("`mode0'", "tab", "csv") {
+        local lines
+        local eqlines
+    }
+    if "`notes'"!="" & "`nolegend'"=="" & `nocellsopt'==1 & `matrixmode'==0 local legend legend
+    if "`plain'"!="" {
+        if "`bfmt'"==""    local bfmt %9.0g
+        if "`tfmt'"==""    local tfmt `bfmt'
+        if "`zfmt'"==""    local zfmt `bfmt'
+        if "`sefmt'"==""   local sefmt `bfmt'
+        if "`pfmt'"==""    local pfmt `bfmt'
+        if "`cifmt'"==""   local cifmt `bfmt'
+        if "`betafmt'"=="" local betafmt `bfmt'
+    }
+    //if "`nomtitles'"!="" local depvars
+    //else if "`depvars'"=="" local mtitles mtitles
+
+// prepare append for rtf, tex, and html
+    local outfilenoteoff2 "`outfilenoteoff'"
+    if "`outfilenoteoff2'"=="" local outfilenoteoff2 "`nooutfilenoteoff'"
+    if `"`using'"'!="" & "`append'"!="" &  ///
+     (("`mode0'"=="rtf" & "`fragment'"=="") | ///
+     ("`page'"!="" & inlist("`mode0'", "tex", "html"))) {
+        capture confirm file `using0'
+        if _rc==0 {
+            tempfile appendfile
+            if "`mode'"=="rtf" local `mode'_open
+            else local `mode'_open0
+            local append
+            if "`outfilenoteoff2'"=="" local outfilenoteoff2 outfilenoteoff
+        }
+    }
+
+// cells() option
+    if "`notes'"!="" {
+        if ("`margin'"!="" | `"`margin2'"'!="") & "`nomargin'"=="" ///
+         local thenote "`thenote'Marginal effects"
+        if "`eform'"!="" & "`noeform'"=="" ///
+         local thenote "`thenote'Exponentiated coefficients"
+    }
+    if "`bfmt'"=="" local bfmt a3
+    if `nocellsopt' & `matrixmode'==0 {
+        if "`star'"!="" & "`staraux'"=="" local bstar star
+        if "`beta'"!="" {
+            if "`main'"!="" {
+                di as err "beta() and main() not allowed both"
+                exit 198
+            }
+            if "`betafmt'"==""  local betafmt 3
+            local cells fmt(`betafmt') `bstar'
+            local cells beta(`cells')
+            if "`notes'"!="" {
+                if `"`thenote'"'!="" local thenote "`thenote'; "
+                local thenote "`thenote'Standardized beta coefficients"
+            }
+        }
+        else if "`main'"!="" {
+            tokenize "`main'"
+            if "`2'"=="" local 2 "`bfmt'"
+            local cells fmt(`2') `bstar'
+            local cells `1'(`cells')
+            if "`notes'"!="" {
+                if `"`thenote'"'!="" local thenote "`thenote'; "
+                local thenote "`thenote'`1' coefficients"
+            }
+        }
+        else {
+            local cells fmt(`bfmt') `bstar'
+            local cells b(`cells')
+        }
+        if "`t'"=="" | "`z'`se'`p'`ci'`aux'"!="" {
+            if "`onecell'"!="" {
+                local cells `cells' &
+            }
+// parse aux option
+            tokenize "`aux'"
+            local auxname `1'
+            local auxfmt `2'
+// type of auxiliary statistic
+            local aux `z' `se' `p' `ci' `auxname'
+            if `"`aux'"'=="" local aux t
+            else {
+                if `:list sizeof aux'>1 {
+                    di as err "only one allowed of z, se, p, ci, and aux()"
+                    exit 198
+                }
+            }
+            if !inlist(`"`aux'"', "t", "z")  local abs
+// parentheses/brackets
+            if "`parentheses'"!="" | "`brackets'"!="" {
+                if `"`aux'"'=="ci" {
+                    local brackets brackets
+                    if "`mode'"!="smcl" | "`onecell'"!="" local paren par
+                    else local paren `"par("{ralign @modelwidth:{txt:[}" "{txt:,}" "{txt:]}}")"'
+                }
+                else if "`brackets'"!="" {
+                    if "`mode'"!="smcl" | "`onecell'"!="" local paren "par([ ])"
+                    else local paren `"par("{ralign @modelwidth:{txt:[}" "{txt:]}}")"'
+                }
+                else {
+                    if "`mode'"!="smcl" | "`onecell'"!="" local paren par
+                    else local paren `"par("{ralign @modelwidth:{txt:(}" "{txt:)}}")"'
+                }
+            }
+// compose note
+            if "`notes'"!="" {
+                if `"`thenote'"'!="" local thenote "`thenote'; "
+                if `"`auxname'"'!="" {
+                    local thenote `"`macval(thenote)'`auxname'"'
+                }
+                else if inlist(`"`aux'"', "t", "z")  {
+                    if "`abs'"!="" local thenote `"`macval(thenote)'Absolute "'
+                    local thenote `"`macval(thenote)'``mode'_`aux'statlab'"'
+                }
+                else if `"`aux'"'=="se" {
+                    local thenote `"`macval(thenote)'Standard errors"'
+                }
+                else if `"`aux'"'=="p" {
+                    local thenote `"`macval(thenote)'``mode'_pvallab'"'
+                }
+                else if `"`aux'"'=="ci" {
+                    local thenote `"`macval(thenote)'``mode'_cilab'"'
+                }
+                if "`parentheses'"=="" {
+                    if "`wide'"=="" local thenote `"`macval(thenote)' in second row"'
+                    else local thenote `"`macval(thenote)' in second column"'
+                }
+                else if "`brackets'"!="" {
+                    local thenote `"`macval(thenote)' in brackets"'
+                }
+                else local thenote `"`macval(thenote)' in parentheses"'
+            }
+// formats
+            if "`tfmt'"==""     local tfmt 2
+            if "`zfmt'"==""     local zfmt 2
+            if "`sefmt'"==""    local sefmt `bfmt'
+            if "`pfmt'"==""     local pfmt 3
+            if "`cifmt'"==""    local cifmt `bfmt'
+            if `"`auxfmt'"'=="" local auxfmt `bfmt'
+            if `"`auxname'"'=="" {
+                local auxfmt ``aux'fmt'
+            }
+// stars
+            if "`staraux'"!="" local staraux star
+// put together
+            local temp fmt(`auxfmt') `paren' `abs' `staraux'
+            local cells `cells' `aux'(`temp')
+        }
+        if "`wide'"!="" local cells cells(`"`cells'"')
+        else            local cells cells(`cells')
+    }
+
+// stats() option
+    if `"`macval(stats)'"'=="" & `matrixmode'==0 {
+        if `"`sfmt'"'=="" local sfmt `bfmt'
+        if `"`r2fmt'"'=="" local r2fmt = cond("`plain'"!="", "`bfmt'", "3")
+        if `"`ar2fmt'"'=="" local ar2fmt = cond("`plain'"!="", "`bfmt'", "3")
+        if `"`pr2fmt'"'=="" local pr2fmt = cond("`plain'"!="", "`bfmt'", "3")
+        if `"`aicfmt'"'=="" local aicfmt `bfmt'
+        if `"`bicfmt'"'=="" local bicfmt `bfmt'
+        if "`label'"=="" {
+            local stalabs `"``mode'_ssl'"'
+        }
+        else {
+            local stalabs `"``mode'_lsl'"'
+        }
+        gettoken obslab stalabs: stalabs
+        if "`obs'"=="" & "`obslast'"=="" {
+            local sta N
+            local stalab `"`"`macval(obslab)'"'"'
+            local stafmt %18.0g
+        }
+        local i 0
+        foreach s in r2 ar2 pr2 aic bic {
+            local ++i
+            if "``s''"!="" {
+                local sta `sta' `:word `i' of r2 r2_a r2_p aic bic'
+                local chunk: word `i' of `macval(stalabs)'
+                local stalab `"`macval(stalab)' `"`macval(chunk)'"'"'
+                local stafmt `stafmt' ``s'fmt'
+            }
+        }
+        local i 0
+        CheckScalarOpt `macval(scalars)'
+        foreach addstat of local scalars {
+            local ++i
+            gettoken addstatname addstatlabel: addstat
+            local addstatlabel = substr(`"`macval(addstatlabel)'"',2,.)
+            if `: list posof `"`addstatname'"' in sta' continue
+            if `"`addstatname'"'=="N" & "`obs'"=="" & "`obslast'"!="" continue
+            if trim(`"`macval(addstatlabel)'"')=="" local addstatlabel `addstatname'
+            local addstatfmt: word `i' of `sfmt'
+            if `"`addstatfmt'"'=="" {
+                local addstatfmt: word `: list sizeof sfmt' of `sfmt'
+            }
+            local sta `sta' `addstatname'
+            local stalab `"`macval(stalab)' `"`macval(addstatlabel)'"'"'
+            local stafmt `stafmt' `addstatfmt'
+        }
+        if "`obs'"=="" & "`obslast'"!="" {
+            local sta `sta' N
+            local stalab `"`macval(stalab)' `"`macval(obslab)'"'"'
+            local stafmt `stafmt' %18.0g
+        }
+        if "`sta'"!="" {
+            local stats stats(`sta', fmt(`stafmt') labels(`macval(stalab)'))
+        }
+    }
+
+// table header
+    if `"`macval(mlabels)'"'=="" {
+        if "`mode0'"=="tex" local mspan " span prefix(\multicolumn{@span}{c}{) suffix(})"
+        if `"`depvars'"'!="" {
+            local mlabels `"mlabels(, depvar`mspan')"'
+        }
+        if `"`nomtitles'"'!="" local mlabels `"mlabels(none)"'
+        if "`mtitles'"!="" {
+            local mlabels `"mlabels(, titles`mspan')"'
+        }
+        if `"`macval(mtitles2)'"'!="" {
+            local mlabels `"mlabels(`macval(mtitles2)', titles`mspan')"'
+        }
+    }
+    if `"`macval(collabels)'"'=="" & `nocellsopt' & `matrixmode'==0 & "`plain'"=="" {
+        local collabels `"collabels(none)"'
+    }
+    if "`mode0'"=="tex" & "`numbers'"!="" {
+        local numbers "numbers(\multicolumn{@span}{c}{( )})"
+    }
+
+// pre-/posthead, pre-/postfoot, gaps and lines
+// - complete note
+    if `"`macval(thenote)'"'!="" {
+        local thenote `"`"`macval(thenote)'"'"'
+    }
+    if `"`macval(note)'"'!="" {
+        local thenote `""@note""'
+    }
+    if `"`macval(addnotes)'"'!="" {
+        if index(`"`macval(addnotes)'"', `"""')==0 {
+            local addnotes `"`"`macval(addnotes)'"'"'
+        }
+        local thenote `"`macval(thenote)' `macval(addnotes)'"'
+    }
+    if "`legend'"!="" {
+        if ("`margin'"!="" | `"`margin2'"'!="") & ///
+           "`nomargin'"=="" & "`nodiscrete'"=="" {
+            local thenote `"`macval(thenote)' "@discrete""'
+        }
+        if "`star'"!="" | `nocellsopt'==0 {
+            local thenote `"`macval(thenote)' "@starlegend""'
+        }
+    }
+// - mode specific settings
+    if "`star'"!="" {
+        if `"`macval(star2)'"'!="" {
+            FormatStarSym "`mode0'" `"`macval(star2)'"'
+            local `mode'_starlevels `"`macval(star2)'"'
+        }
+        if `"`macval(starlevels)'"'=="" {
+            local starlevels `"starlevels(`macval(`mode'_starlevels)'`macval(`mode'_starlevlab)')"'
+        }
+    }
+    foreach opt in begin delimiter end substitute interaction {
+        if `"`macval(`opt')'"'=="" & `"``mode'_`opt''"'!="" {
+            local `opt' `"`opt'(``mode'_`opt'')"'
+        }
+    }
+    if "`onecell'"!="" {
+        if `"`macval(incelldelimiter)'"'=="" {
+            local incelldelimiter `"incelldelimiter(``mode'_incelldel')"'
+        }
+    }
+    if "`noabbrev'`abbrev'"=="" {
+        local abbrev ``mode'_abbrev'
+    }
+    if `"`fragment'"'=="" {
+        if `"`fonttbl'"'!="" {
+            local rtf_fonttbl `"`fonttbl'"'
+        }
+        if "`page'"!="" {
+            local texclass "{article}"
+            if "`standalone'"!="" local texclass "`standalone2'{standalone}"
+            else                  local texclass "{article}"
+            if `"`page2'"'!="" {
+                local texpkgs `""\usepackage{`page2'}""'
+            }
+            local opening `"``mode'_open0'"'
+        }
+        if "`mode0'"=="tex" {
+            if (`"`macval(title)'"'!="" | "`float'"!="") & "`nofloat'"=="" {
+                local opening `"`macval(opening)' ``mode'_open'"'
+            }
+            else if "`star'"!="" {
+                local opening `"`macval(opening)' "{""'
+            }
+            if "`star'"!="" {
+                local opening `"`macval(opening)' "\def\sym#1{\ifmmode^{#1}\else\(^{#1}\)\fi}""'
+            }
+            if `"`macval(title)'"'!="" & "`longtable'"=="" {
+                local opening `"`macval(opening)' `"``mode'_caption'"'"'
+            }
+        }
+        else {
+            local opening `"`macval(opening)' ``mode'_open'"'
+            if `"`macval(title)'"'!="" {
+                local opening `"`macval(opening)' ``mode'_caption'"'
+            }
+        }
+        if  "`mode0'"=="tex" {
+            if `"`labcol2'"'!="" local lstubtex "lc"
+            else local lstubtex "l"
+            if `"`width'"'!="" local extracolsep "@{\hskip\tabcolsep\extracolsep\fill}"
+            if `matrixmode' {
+                if `"`macval(alignment)'"'!="" {
+                    local opening `"`macval(opening)' `"``mode'_open2'{`extracolsep'`lstubtex'`macval(alignment)'}"'"'
+                }
+                else {
+                    MakeTeXColspecMat, `anything'
+                    local opening `"`macval(opening)' `"``mode'_open2'{`extracolsep'`lstubtex'`value'}"'"'
+                }
+            }
+            else {
+                if `"`macval(alignment)'"'!="" {
+                    local opening `"`macval(opening)' `"``mode'_open2'{`extracolsep'`lstubtex'*{@E}{`macval(alignment)'}}"'"'
+                }
+                else {
+                    if `nocellsopt' {
+                        MakeTeXColspec "`wide'" "`not'" "`star'" "`stardetach'" "`staraux'"
+                    }
+                    else {
+                        MakeTeXColspecAlt, `cells'
+                    }
+                    local opening `"`macval(opening)' `"``mode'_open2'{`extracolsep'`lstubtex'*{@E}{`value'}}"'"'
+                }
+            }
+            if "`longtable'"!="" {
+                if `"`macval(title)'"'!="" {
+                    local opening `"`macval(opening)' `"``mode'_caption'\\\"'"'
+                }
+            }
+        }
+        else {
+            local opening `"`macval(opening)' ``mode'_open2'"'
+        }
+        if "`mode0'"=="html" {
+            local brr
+            foreach chunk of local thenote {
+                local closing `"`macval(closing)' `"`brr'`macval(chunk)'"'"'
+                local brr "<br />"
+            }
+            if `"`macval(closing)'"'!="" {
+                local closing `""<tr><td colspan=@span>" `macval(closing)' "</td></tr>""'
+            }
+        }
+        else if "`mode0'"=="tex" {
+            foreach chunk of local thenote {
+                local closing `"`macval(closing)' `"\multicolumn{@span}{l}{\footnotesize `macval(chunk)'}\\\"'"'
+            }
+        }
+        else if "`mode0'"=="csv" {
+            foreach chunk of local thenote {
+                local closing `"`macval(closing)' `"`csvlhs'`macval(chunk)'""'"'
+            }
+        }
+        else if "`mode0'"=="rtf" {
+            foreach chunk of local thenote {
+                local closing `"`macval(closing)' `"{\pard\ql\fs20 `macval(chunk)'\par}"'"'
+            }
+        }
+        else if "`mode0'"=="mmd" {
+            local n_chunks: list sizeof thenote
+            if `n_chunks' {
+                local closing `"`macval(closing)' """'
+                local i 0
+                foreach chunk of local thenote {
+                    local ++i
+                    if `i'<`n_chunks' {
+                        local chunk `"`macval(chunk)'<br>"'
+                    }
+                    local closing `"`macval(closing)' `"`macval(chunk)'"'"'
+                }
+            }
+        }
+        else {
+            local closing `"`macval(thenote)'"'
+        }
+        local closing `"`macval(closing)' ``mode'_close2'"'
+        if "`mode0'"=="tex" {
+            if (`"`macval(title)'"'!="" | "`float'"!="") & "`nofloat'"=="" {
+                local closing `"`macval(closing)' ``mode'_close'"'
+            }
+            else if "`star'"!="" {
+                local closing `"`macval(closing)' "}""'
+            }
+        }
+        else {
+            local closing `"`macval(closing)' ``mode'_close'"'
+        }
+        if "`page'`standalone'"!="" {
+            local closing `"`macval(closing)' ``mode'_close0'"'
+        }
+        local toprule    `"``mode'_toprule'"'
+        local bottomrule `"``mode'_bottomrule'"'
+        local topgap     `"``mode'_topgap'"'
+        local bottomgap  `"``mode'_bottomgap'"'
+    }
+    local midrule `"``mode'_midrule'"'
+    local midgap  `"``mode'_midgap'"'
+    local eqrule  `"``mode'_eqrule'"'
+// - compose prehead()
+    if `"`macval(prehead)'"'=="" {
+        if `"`lines'"'!="" {
+            local opening `"`macval(opening)' `macval(toprule)'"'
+        }
+        else if `"`gaps'"'!="" {
+            local opening `"`macval(opening)' `macval(topgap)'"'
+        }
+        SaveRetok `macval(opening)'
+        local opening `"`macval(value)'"'
+        if `"`macval(opening)'"'!="" {
+            local prehead `"prehead(`macval(opening)')"'
+        }
+    }
+// - compose posthead()
+    if `"`macval(posthead)'"'=="" {
+        if `"`lines'"'!="" {
+            local posthead `"posthead(`macval(midrule)')"'
+        }
+        else if `"`gaps'"'!="" {
+            local posthead `"posthead(`macval(midgap)')"'
+        }
+    }
+// - compose prefoot()
+    if `"`macval(prefoot)'"'=="" & `"`macval(stats)'"'!="" {
+        if `"`lines'"'!="" {
+            local prefoot `"prefoot(`macval(midrule)')"'
+        }
+        else if `"`gaps'"'!="" {
+            local prefoot `"prefoot(`macval(midgap)')"'
+        }
+        if `"`cells'"'=="cells(none)" local prefoot
+    }
+// - compose postfoot()
+    if `"`macval(postfoot)'"'=="" {
+        if `"`lines'"'!="" {
+            local closing `"`macval(bottomrule)' `macval(closing)'"'
+        }
+        else if `"`gaps'"'!="" {
+            local closing `"`macval(bottomgap)' `macval(closing)'"'
+        }
+        SaveRetok `macval(closing)'
+        local closing `"`macval(value)'"'
+        if `"`macval(closing)'"'!="" {
+            local postfoot postfoot(`macval(closing)')
+        }
+    }
+// - varlabels
+    if `"`macval(varlabels)'"'=="" {
+        if `"`gaps'"'!="" {
+            local varl `", end("" `macval(midgap)') nolast"'
+        }
+        if "`label'"!=""  {
+            local varl `"_cons Constant`macval(varl)'"'
+        }
+        if `"`macval(coeflabels)'"'!="" {
+            local varl `"`macval(coeflabels)' `macval(varl)'"'
+        }
+        if trim(`"`macval(varl)'"')!="" {
+            local varlabels varlabels(`macval(varl)')
+        }
+    }
+// - equation labels
+    if ("`eqlines'"!="" | `"`gaps'"'!="") & "`unstack'"=="" {
+        if trim(`"`eqlabels'"')!="none" {
+            ParseEqLabels `macval(eqlabels)'
+            if `eqlabelsok' {
+                _parse comma eqllhs eqlrhs : eqlabels
+                if `"`eqlrhs'"'=="" local eqlabelscomma ", "
+                else                local eqlabelscomma " "
+                if "`eqlines'"!=""{
+                    local eqlabels `"`macval(eqlabels)'`eqlabelscomma'`macval(eqrule)' nofirst"'
+                }
+                else if `"`gaps'"'!="" {
+                    local eqlabels `"`macval(eqlabels)'`eqlabelscomma'begin(`macval(midgap)' "") nofirst"'
+                }
+            }
+        }
+    }
+    if `"`macval(eqlabels)'"'!="" {
+        local eqlabels `"eqlabels(`macval(eqlabels)')"'
+    }
+
+// noconstant option
+    if `"`drop'"'=="" {
+        if "`noconstant'"!="" {
+            local drop drop(_cons, relax)
+        }
+    }
+
+// compute beta coefficients (run estadd to add e(beta))
+    if "`beta'"!="" {
+        local estnames `"`anything'"'
+        if `"`estnames'"'=="" {
+            capt est_expand $eststo
+            if !_rc {
+                local estnames `"$eststo"'
+            }
+        }
+        version `caller': estadd beta, replace: `estnames'
+    }
+
+// use tempfile for new table
+    if `"`appendfile'"'!="" {
+        local using `"using `"`appendfile'"'"'
+    }
+
+// execute estout
+    if `"`varwidth'"'!="" local varwidth `"varwidth(`varwidth')"'
+    if `"`modelwidth'"'!="" local modelwidth `"modelwidth(`modelwidth')"'
+    if `"`style'"'=="" {
+        if "`mode'"=="mmd" local style "style(mmd)"
+        else               local style "style(esttab)"
+    }
+    CleanEstoutCmd `anything' `using' ,  ///
+     `macval(cells)' `drop' `nomargin' `margin' `margin2' `noeform' `eform'       ///
+     `nodiscrete' `macval(stats)' `stardetach' `macval(starlevels)'               ///
+     `varwidth' `modelwidth' `noabbrev' `abbrev' `unstack' `macval(begin)'        ///
+     `macval(delimiter)' `macval(end)' `macval(incelldelimiter)' `smcltags'       ///
+     `macval(title)' `macval(prehead)' `macval(posthead)' `macval(prefoot)'       ///
+     `macval(postfoot)' `label' `macval(varlabels)' `macval(mlabels)' `nonumbers' ///
+     `numbers' `macval(collabels)' `macval(eqlabels)' `macval(mgroups)'           ///
+     `macval(note)' `macval(labcol2)' `macval(substitute)' `macval(interaction)'  ///
+     `append' `notype'`type' `outfilenoteoff2' level(`level') `style'             ///
+     `macval(options)'
+    if "`noisily'"!="" {
+        gettoken chunk rest: cmd, parse(",")
+        di as txt _asis `"`chunk'"' _c
+        gettoken chunk rest: rest, bind
+        while `"`macval(chunk)'"'!="" {
+            di as txt _asis `" `macval(chunk)'"'
+            gettoken chunk rest: rest, bind
+        }
+    }
+    `macval(cmd)'
+
+// insert new table into existing document (tex, html, rtf)
+    if `"`appendfile'"'!="" {
+        local enddoctex "\end{document}"
+        local enddochtml "</body>"
+        local enddocrtf "}"
+        local enddoc "`enddoc`mode0''"
+        tempname fh
+        file open `fh' using `using0', read write
+        file seek `fh' query
+        local loc = r(loc)
+        file read `fh' line
+        while r(eof)==0 {
+            if `"`line'"'=="`enddoc'" {
+                if "`mode'"=="rtf" {
+                    file seek `fh' query
+                    local loc0 = r(loc)
+                    file read `fh' line
+                    if r(eof)==0 {
+                        local loc = `loc0'
+                        continue
+                    }
+                }
+                continue, break
+            }
+            file seek `fh' query
+            local loc = r(loc)
+            file read `fh' line
+        }
+        file seek `fh' `loc'
+        tempname new
+        file open `new' `using', read
+        file read `new' line
+        while r(eof)==0 {
+            file write `fh' `"`macval(line)'"' _n
+            file read `new' line
+        }
+        file close `fh'
+        file close `new'
+        if "`outfilenoteoff'"=="" {
+            di as txt `"(output written to {browse `using0'})"'
+        }
+    }
+end
+
+program _more_syntax
+// using subroutine (rather than second syntax call) to preserve 'using'
+    local theoptions ///
+        NODEPvars DEPvars ///
+        NOPArentheses PArentheses ///
+        BRackets ///
+        NONOTEs NOTEs /// without s in helpfile
+        LONGtable ///
+        NOFLOAT float ///
+        ONEcell ///
+        NOEQLInes ///
+        NOOUTFILENOTEOFF outfilenoteoff
+    syntax [, `theoptions' * ]
+    foreach opt of local theoptions {
+        local opt = lower("`opt'")
+        c_local `opt' "``opt''"
+    }
+    c_local options     `"`macval(options)'"'
+end
+
+program _estout_options
+    syntax [, ///
+     Cells(passthru) ///
+     Drop(passthru)  ///
+ ///  Keep(string asis) ///
+ ///  Order(string asis) ///
+ ///  REName(passthru) ///
+ ///  Indicate(string asis) ///
+ ///  TRansform(string asis) ///
+ ///  EQuations(passthru) ///
+     NOEFORM eform ///EFORM2(string) ///
+     NOMargin Margin Margin2(passthru) ///
+     NODIscrete /// DIscrete(string asis) ///
+ ///  MEQs(string) ///
+ ///  NODROPPED dropped DROPPED2(string) ///
+     level(numlist max=1 int >=10 <=99) ///
+     Stats(passthru) ///
+     STARLevels(passthru) ///
+ ///  NOSTARDetach ///
+     STARDetach ///
+ ///  STARKeep(string asis) ///
+ ///  STARDrop(string asis) ///
+     VARwidth(str) ///
+     MODELwidth(str) ///
+     NOABbrev ABbrev ///
+ ///  NOUNStack
+     UNStack ///
+     BEGin(passthru) ///
+     DELimiter(passthru) ///
+     INCELLdelimiter(passthru) ///
+     end(passthru) ///
+ ///  DMarker(string) ///
+ ///  MSign(string) ///
+ ///  NOLZ lz ///
+     SUBstitute(passthru) ///
+     INTERACTion(passthru) ///
+     TItle(passthru) ///
+     NOLEgend LEgend ///
+     PREHead(passthru) ///
+     POSTHead(passthru) ///
+     PREFoot(passthru) ///
+     POSTFoot(passthru) ///
+ ///  HLinechar(string) ///
+ ///  NOLabel
+     Label ///
+     VARLabels(passthru) ///
+ ///  REFcat(string asis) ///
+     MLabels(passthru) ///
+     NONUMbers NUMbers ///NUMbers2(string asis) ///
+     COLLabels(passthru) ///
+     EQLabels(string asis) ///
+     MGRoups(passthru) ///
+     LABCOL2(passthru) ///
+ ///  NOReplace Replace ///
+ ///  NOAppend
+     Append ///
+     NOTYpe TYpe ///
+ ///  NOSHOWTABS showtabs ///
+ ///  TOPfile(string) ///
+ ///  BOTtomfile(string) ///
+     STYle(passthru) ///
+ ///  DEFaults(string) ///
+ ///  NOASIS asis ///
+ ///  NOWRAP wrap ///
+ ///  NOSMCLTAGS smcltags ///
+ ///  NOSMCLRules SMCLRules ///
+ ///  NOSMCLMIDRules SMCLMIDRules ///
+ ///  NOSMCLEQRules SMCLEQRules ///
+     note(passthru) ///
+     * ]
+    foreach opt in ///
+     cells drop noeform eform nomargin margin margin2 nodiscrete ///
+     level stats starlevels stardetach varwidth modelwidth unstack ///
+     noabbrev abbrev begin delimiter incelldelimiter end substitute ///
+     interaction title nolegend legend prehead posthead prefoot postfoot ///
+     label varlabels mlabels labcol2 nonumbers numbers collabels eqlabels ///
+     mgroups append notype type style note options {
+        c_local `opt' `"`macval(`opt')'"'
+    }
+end
+
+program MatrixMode
+    capt syntax [, Matrix(str asis) e(str asis) r(str asis) ]
+    if _rc | `"`matrix'`e'`r'"'=="" {
+        c_local matrixmode 0
+        exit
+    }
+    c_local matrixmode 1
+end
+
+prog NotBothAllowed
+    args opt1 opt2
+    if `"`opt1'"'!="" {
+        if `"`opt2'"'!="" {
+            di as err `"options `opt1' and `opt2' not both allowed"'
+            exit 198
+        }
+    }
+end
+
+prog SwitchOnIfEmpty
+    args opt1 opt2
+    if `"`opt2'"'=="" {
+        c_local `opt1' `opt1'
+    }
+end
+
+prog _getfilesuffix, rclass // based on official _getfilename.ado
+    version 8
+    gettoken filename rest : 0
+    if `"`rest'"' != "" {
+        exit 198
+    }
+    local hassuffix 0
+    gettoken word rest : filename, parse(".")
+    while `"`rest'"' != "" {
+        local hassuffix 1
+        gettoken word rest : rest, parse(".")
+    }
+    if `"`word'"'=="." {
+        di as err `"incomplete filename; ends in ."'
+        exit 198
+    }
+    if index(`"`word'"',"/") | index(`"`word'"',"\") local hassuffix 0
+    if `hassuffix' return local suffix `".`word'"'
+    else           return local suffix ""
+end
+
+prog FormatStarSym
+    args mode list
+    if inlist("`mode'","rtf","html","tex") {
+        if "`mode'"=="rtf" {
+            local prefix "{\super "
+            local suffix "}"
+        }
+        else if "`mode'"=="html" {
+            local prefix "<sup>"
+            local suffix "</sup>"
+        }
+        else if "`mode'"=="tex" {
+            local prefix "\sym{"
+            local suffix "}"
+        }
+        local odd 1
+        foreach l of local list {
+            if `odd' {
+                local l `"`"`prefix'`macval(l)'`suffix'"'"'
+                local odd 0
+            }
+            else local odd 1
+            local newlist `"`macval(newlist)'`space'`macval(l)'"'
+            local space " "
+        }
+        c_local star2 `"`macval(newlist)'"'
+    }
+    //else do noting
+end
+
+prog CheckScalarOpt
+    capt syntax [anything]
+    if _rc error 198
+end
+
+program MakeTeXColspecMat
+    capt syntax [, Matrix(str asis) e(str asis) r(str asis) ]
+    ParseMatrixOpt `matrix'`e'`r'
+    if `"`e'"'!=""      local name "e(`name')"
+    else if `"`r'"'!="" local name "r(`name')"
+    confirm matrix `name'
+    tempname bc
+    mat `bc' = `name'
+    if "`transpose'"=="" local cols = colsof(`bc')
+    else                 local cols = rowsof(`bc')
+    c_local value "*{`cols'}{c}"
+end
+program ParseMatrixOpt
+    syntax name [, Fmt(str asis) Transpose ]
+    c_local name `"`namelist'"'
+    c_local fmt `"`fmt'"'
+    c_local transpose `"`transpose'"'
+end
+
+prog MakeTeXColspec
+    args wide not star detach aux
+    if "`star'"!="" & "`detach'"!="" & "`aux'"=="" local value "r@{}l"
+    else local value "c"
+    if "`wide'"!="" & "`not'"=="" {
+        if "`star'"!="" & "`detach'"!="" & "`aux'"!="" local value "`value'r@{}l"
+        else local value "`value'c"
+    }
+    c_local value "`value'"
+end
+
+prog MakeTeXColspecAlt
+    syntax, cells(string asis)
+    local count 1
+    while `count' {
+        local cells: subinstr local cells ") (" ")_(", all // preserve space in ") (" 
+        local cells: subinstr local cells "] (" "]_(", all // preserve space in ") [" 
+        local cells: subinstr local cells " (" "(", all count(local count)
+    }
+    local cells: subinstr local cells ")_(" ") (", all // restore space in ") (" 
+    local cells: subinstr local cells "]_(" "] (", all // restore space in ") [" 
+    local count 1
+    while `count' {
+        local cells: subinstr local cells " [" "[", all count(local count)
+    }
+    local count 1
+    while `count' {
+        local cells: subinstr local cells " &" "&", all count(local count)
+    }
+    local count 1
+    while `count' {
+        local cells: subinstr local cells "& " "&", all count(local count)
+    }
+    local count 1
+    while `"`macval(cells)'"'!="" {
+        gettoken row cells : cells, match(par)
+        local size 0
+        gettoken chunk row : row, bind
+        while `"`macval(chunk)'"'!="" {
+            local ++size
+            gettoken chunk row : row, bind
+        }
+        local count = max(`count',`size')
+    }
+    c_local value: di _dup(`count') "c"
+end
+
+prog SaveRetok
+    gettoken chunk 0: 0, q
+    local value `"`macval(chunk)'"'
+    gettoken chunk 0: 0, q
+    while `"`macval(chunk)'"'!="" {
+        local value `"`macval(value)' `macval(chunk)'"'
+        gettoken chunk 0: 0, q
+    }
+    c_local value `"`macval(value)'"'
+end
+
+prog CleanEstoutCmd
+    syntax [anything] [using] [ , * ]
+    local cmd estout
+    if `"`macval(anything)'"'!="" {
+        local cmd `"`macval(cmd)' `macval(anything)'"'
+    }
+    if `"`macval(using)'"'!="" {
+        local cmd `"`macval(cmd)' `macval(using)'"'
+    }
+    if `"`macval(options)'"'!="" {
+        local cmd `"`macval(cmd)', `macval(options)'"'
+    }
+    c_local cmd `"`macval(cmd)'"'
+end
+
+prog ParseEqLabels
+    syntax [anything] [, Begin(passthru) NOReplace Replace NOFirst First * ]
+    c_local eqlabelsok = `"`begin'`noreplace'`replace'`nofirst'`first'"'==""
+end

--- a/analysis/extra_ados/esttab.hlp
+++ b/analysis/extra_ados/esttab.hlp
@@ -1,0 +1,963 @@
+{smcl}
+{* 10jun2022}{...}
+{hi:help esttab}{right:also see: {helpb estout}, {helpb eststo}, {helpb estadd}, {helpb estpost}}
+{right: {browse "http://repec.sowi.unibe.ch/stata/estout/"}}
+{hline}
+
+{title:Title}
+
+{p 4 4 2}{hi:esttab} {hline 2} Display formatted regression table
+
+
+{title:Table of contents}
+
+    {help esttab##syn:Syntax}
+    {help esttab##des:Description}
+    {help esttab##opt:Options}
+    {help esttab##exa:Examples}
+    {help esttab##aut:Backmatter}
+
+{marker syn}
+{title:Syntax}
+
+{p 8 15 2}
+{cmd:esttab} [ {it:namelist} ] [ {cmd:using} {it:filename} ] [ {cmd:,}
+{it:options} ]
+
+
+{p 4 4 2}where {it:namelist} is a name, a list of names, or {cmd:_all}. The
+{cmd:*} and {cmd:?} wildcards are allowed in {it:namelist}. A name may also be {cmd:.},
+meaning the current (active) estimates.
+
+
+    {it:options}{col 26}description
+    {hline 70}
+    {help esttab##main:Main}
+      {cmd:b(}{it:{help esttab##fmt:fmt}}{cmd:)}{col 26}{...}
+specify format for point estimates
+      {cmd:beta}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display beta coefficients instead of point est's
+      {cmd:main(}{it:name} [{it:{help esttab##fmt:fmt}}]{cmd:)}{col 26}{...}
+display contents of {cmd:e(}{it:name}{cmd:)} instead of point e's
+      {cmd:t(}{it:{help esttab##fmt:fmt}}{cmd:)}{col 26}{...}
+specify format for t-statistics
+      {cmd:abs}{col 26}{...}
+use absolute value of t-statistics
+      {cmd:not}{col 26}{...}
+suppress t-statistics
+      {cmd:z}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display z-statistics (affects label only)
+      {cmd:se}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display standard errors instead of t-statistics
+      {cmd:p}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display p-values instead of t-statistics
+      {cmd:ci}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display confidence intervals instead of t-stat's
+      {cmd:aux(}{it:name} [{it:{help esttab##fmt:fmt}}]{cmd:)}{col 26}{...}
+display contents of {cmd:e(}{it:name}{cmd:)} instead of t-stat's
+      [{ul:{cmd:no}}]{cmdab:con:stant}{col 26}{...}
+do not/do report the intercept
+
+    {help esttab##stars:Significance stars}
+      [{cmd:no}]{cmd:star}[{cmd:(}{it:list}{cmd:)}]{col 26}{...}
+do not/do report significance stars
+      {cmd:staraux}{col 26}{...}
+attach stars to t-stat's instead of point est's
+
+    {help esttab##stat:Summary statistics}
+      {cmd:r2}|{cmd:ar2}|{cmd:pr2}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display (adjusted, pseudo) R-squared
+      {cmd:aic}|{cmd:bic}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]{col 26}{...}
+display Akaike's or Schwarz's information crit.
+      {cmdab:sca:lars:(}{it:list}{cmd:)}{col 26}{...}
+display any other scalars contained in {cmd:e()}
+      {cmd:sfmt(}{it:{help esttab##fmt:fmt}} [{it:...}]{cmd:)}{col 26}{...}
+set format(s) for {cmd:scalars()}
+      {cmd:noobs}{col 26}{...}
+do not display the number of observations
+      {cmd:obslast}{col 26}{...}
+place the number of observations last
+
+    {help esttab##layout:Layout}
+      {cmd:wide}{col 26}{...}
+place point est's and t-stat's beside one another
+      {cmdab:one:cell}{col 26}{...}
+combine point est's and t-stat's in a single cell
+      [{ul:{cmd:no}}]{cmdab:pa:rentheses}{col 26}{...}
+do not/do print parentheses around t-statistics
+      {cmdab:br:ackets}{col 26}{...}
+use brackets instead of parentheses
+      [{ul:{cmd:no}}]{cmdab:gap:s}{col 26}{...}
+suppress/add vertical spacing
+      [{ul:{cmd:no}}]{cmdab:li:nes}{col 26}{...}
+suppress/add horizontal lines
+      {cmdab:noeqli:nes}{col 26}{...}
+suppress lines between equations
+      {cmd:compress}{col 26}{...}
+reduce horizontal spacing
+      {cmd:plain}{col 26}{...}
+produce a minimally formatted table
+
+    {help esttab##label:Labeling}
+      {cmdab:l:abel}{col 26}{...}
+make use of variable labels
+      {cmdab:interact:ion:(}{it:str}{cmd:)}{col 26}{...}
+specify interaction operator
+      {cmdab:ti:tle:(}{it:string}{cmd:)}{col 26}{...}
+specify a title for the table
+      {cmdab:mti:tles}[{cmd:(}{it:list}{cmd:)}]{col 26}{...}
+specify model titles to appear in table header
+      {cmdab:nomti:tles}{col 26}{...}
+disable model titles
+      [{ul:{cmd:no}}]{cmdab:dep:vars}{col 26}{...}
+do not/do use dependent variables as model titles
+      [{ul:{cmd:no}}]{cmdab:num:bers}{col 26}{...}
+do not/do print model numbers in table header
+      {cmdab:coef:labels:(}{it:list}{cmd:)}{col 26}{...}
+specify labels for coefficients
+      [{ul:{cmd:no}}]{cmdab:note:s}{col 26}{...}
+suppress/add notes in the table footer
+      {cmdab:addn:otes:(}{it:list}{cmd:)}{col 26}{...}
+add lines at the end of the table
+
+    {help esttab##format:Document format}
+      {cmd:smcl} | {cmdab:fix:ed} | {cmd:tab} | {cmd:csv} | {cmdab:sc:sv} | {cmd:rtf} | {cmdab:htm:l} | {cmd:tex} | {cmdab:bookt:abs} | {cmdab:md}
+      {col 26}{...}
+set the document format ({cmd:smcl} is the default)
+      {cmdab:f:ragment}{col 26}{...}
+suppress table opening and closing (LaTeX, HTML)
+      [{cmd:no}]{cmd:float}{col 26}{...}
+whether to use a float environment or not (LaTeX)
+      {cmd:page}[{cmd:(}{it:packages}{cmd:)}]{col 26}{...}
+add page opening and closing (LaTeX, HTML)
+      {cmdab:stand:alone}[{cmd:(}{it:opts}{cmd:)}]{col 26}{...}
+use class {cmd:standalone} rather than {cmd:article} (LaTeX)
+      {cmdab:align:ment(}{it:string}{cmd:)}{col 26}{...}
+set alignment within columns (LaTeX, HTML, RTF)
+      {cmdab:width(}{it:string}{cmd:)}{col 26}{...}
+set width of table (LaTeX, HTML)
+      {cmdab:long:table}{col 26}{...}
+multi-page table (LaTeX)
+      {cmd:fonttbl(}{it:string}{cmd:)}{col 26}{...}
+set custom font table (RTF)
+      {cmd:nortfencode}{col 26}{...}
+do not escape non-ASCII characters (RTF)
+
+    {help esttab##output:Output}
+      {cmdab:r:eplace}{col 26}{...}
+overwrite an existing file
+      {cmdab:a:ppend}{col 26}{...}
+append the output to an existing file
+      {cmdab:ty:pe}{col 26}{...}
+force printing the table in the results window
+      {cmdab:n:oisily}{col 26}{...}
+display the executed {helpb estout} command
+
+    {help esttab##advanced:Advanced}
+      {cmdab:d:rop:(}{it:list}{cmd:)}{col 26}{...}
+drop individual coefficients
+      {cmdab:noomit:ted}{col 26}{...}
+drop omitted coefficients
+      {cmdab:nobase:levels}{col 26}{...}
+drop base levels of factor variables
+      {cmdab:k:eep:(}{it:list}{cmd:)}{col 26}{...}
+keep individual coefficients
+      {cmdab:o:rder:(}{it:list}{cmd:)}{col 26}{...}
+change order of coefficients
+      {cmdab:eq:uations:(}{it:list}{cmd:)}{col 26}{...}
+match the models' equations
+      {cmd:eform}{col 26}{...}
+report exponentiated coefficients
+      {cmdab:uns:tack}{col 26}{...}
+place multiple equations in separate columns
+      {it:estout_options}{col 26}{...}
+any other {helpb estout} options
+    {hline 70}
+
+{marker des}
+{title:Description}
+
+{p 4 4 2}
+{cmd:esttab} is a wrapper for {helpb estout}. It produces a
+pretty-looking publication-style regression table from stored
+estimates without much typing. The compiled table is displayed in the
+Stata results window or, optionally, written to a text file specified
+by {cmd:using} {it:filename}. If {it:filename} is specified without
+suffix, a default suffix is added depending on the specified document
+format (".smcl" for {cmd:smcl}, ".txt" for {cmd:fixed} and {cmd:tab}, ".csv" for {cmd:csv}
+and {cmd:scsv}, ".rtf" for {cmd:rft}, ".html" for {cmd:html},
+".tex" for {cmd:tex} and {cmd:booktabs}, ".md" for {cmd:md}).
+
+{p 4 4 2}
+{it:namelist} provides the names of the stored estimation sets to be
+tabulated. You may use the {cmd:*} and {cmd:?} wildcards in
+{it:namelist}. If {it:namelist} is omitted, {cmd:esttab} tabulates the
+estimation sets stored by {cmd:eststo} (see help {helpb eststo})
+or, if no such estimates are present, the currently active
+estimates (i.e. the model fit last).
+
+{p 4 4 2}
+See help {helpb estimates} for information about storing estimation
+results. An alternative to the {cmd:estimates store} command is
+provided by {helpb eststo}.
+
+{p 4 4 2}
+{cmd:esttab} can also be used to tabulate a Stata matrix applying syntax
+{bind:{cmd:esttab} {cmdab:m:atrix:(}{it:name}{cmd:)}}, where {it:name}
+is the name of the matrix. Furthermore, an {cmd:e()}-matrix or {cmd:r()}-matrix
+can be tabulated specifying {cmd:esttab e(}{it:name}{cmd:)} or
+{cmd:esttab r(}{it:name}{cmd:)}. Most options under the headings
+'Main', 'Significance stars', and 'Summary statistics' are irrelevant
+in this case. See help {helpb estout} for further details on tabulating matrices.
+
+{marker opt}
+{title:Options}
+{marker main}
+{dlgtab:Main}
+
+{p 4 8 2}
+{cmd:b(}{it:{help esttab##fmt:fmt}}{cmd:)} sets the numerical display format
+for the point estimates. The default format is {cmd:a3}. (See
+{help esttab##fmt:Numerical formats} below for details on available
+formats.)
+
+{p 4 8 2}
+{cmd:beta}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] requests that
+standardized beta coefficients be displayed in place of the raw point
+estimates and, optionally, sets the display format (the default is to
+print three decimal places). Note that {cmd:beta} causes the
+intercept to be dropped from the table (unless {cmd:constant} is
+specified).{p_end}
+{marker main}
+{p 4 8 2}
+{cmd:main(}{it:name} [{it:{help esttab##fmt:fmt}}]{cmd:)} requests that
+the statistics stored in {cmd:e(}{it:name}{cmd:)} be displayed in
+place of the point estimates and, optionally, sets the display format
+(the default is to use the display format for point estimates). For
+example, {cmd:e(}{it:name}{cmd:)} may contain statistics added by
+{cmd:estadd} (see help {helpb estadd}).
+
+{p 4 8 2}
+{cmd:t(}{it:{help esttab##fmt:fmt}}{cmd:)} sets the display format for
+t-statistics. The default is to display two decimal places.
+
+{p 4 8 2}
+{cmd:abs} causes absolute values of t-statistics to be reported.
+
+{p 4 8 2}
+{cmd:not} suppresses the printing of t-statistics.
+
+{p 4 8 2}
+{cmd:z}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] requests that
+z-statistics be displayed. z-statistics are the same as t-statistics. Hence,
+specifying {cmd:z} does not change the table contents, it only changes the
+label.
+
+{p 4 8 2}
+{cmd:se}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] requests that
+standard errors be displayed in place of t-statistics and,
+optionally, sets the display format (the default is to use the
+display format for point estimates).
+
+{p 4 8 2}
+{cmd:p}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] requests that
+p-values be displayed in place of t-statistics and, optionally, sets
+the display format (the default is to print three decimal places)
+
+{p 4 8 2}
+{cmd:ci}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] requests that
+confidence intervals be displayed in place of t-statistics and,
+optionally, sets the display format (the default is to use the
+display format for point estimates). {cmd:level(}{it:#}{cmd:)}
+assigns the confidence level, in percent. The default is
+{cmd:level(95)} or as set by {helpb set level}.{p_end}
+{marker aux}
+{p 4 8 2}
+{cmd:aux(}{it:name} [{it:{help esttab##fmt:fmt}}]{cmd:)} requests that
+the statistics stored in {cmd:e(}{it:name}{cmd:)} be displayed in
+place of t-statistics and, optionally, sets the display format (the
+default is to use the display format for point estimates). For
+example, {cmd:e(}{it:name}{cmd:)} may contain statistics added by
+{cmd:estadd} (see help {helpb estadd}, if installed).
+
+{p 4 8 2}
+{cmd:noconstant} causes the intercept be dropped from the table.
+Specify {cmd:constant} to include the constant in situations where it
+is dropped by default.
+
+{marker stars}
+{dlgtab:Significance stars}
+
+{p 4 8 2}
+{cmd:star}[{cmd:(}{it:symbol} {it:level} [{it:...}]{cmd:)}] causes
+stars denoting the significance of the coefficients to be printed
+next to the point estimates. This is the default. Type {cmd:nostar}
+to suppress the stars. The default symbols and thresholds are:
+{cmd:*} for p<.05, {cmd:**} for p<.01, and {cmd:***} for p<.001.
+Alternatively, for example, type {bind:{cmd:star(+ 0.10 * 0.05)}} to
+set the following thresholds: {cmd:+} for p<.10 and {cmd:*} for
+p<.05. Note that the thresholds must lie in the (0,1] interval and
+must be specified in descending order.
+
+{p 4 8 2}
+{cmd:staraux} causes the significance stars be printed next to the
+t-statistics (or standard errors, etc.) instead of the point estimates.
+
+{marker stat}
+{dlgtab:Summary statistics}
+
+{p 4 8 2}
+{cmd:r2}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}],
+{cmd:ar2}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}], and
+{cmd:pr2}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]
+include the R-squared, the adjusted R-squared, and the
+pseudo-R-squared in the table footer and, optionally, set the
+corresponding display formats (the default is to display three
+decimal places).
+
+{p 4 8 2}
+{cmd:aic}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}] and
+{cmd:bic}[{cmd:(}{it:{help esttab##fmt:fmt}}{cmd:)}]
+include Akaike's and Schwarz's information criterion in the table
+footer and, optionally, set the corresponding display formats (the
+default is to use the display format for point estimates).{p_end}
+{marker scalars}
+{p 4 8 2}
+{cmd:scalars(}{it:list}{cmd:)} may be used to add other
+{cmd:e()}-scalars to the table footer (type {cmd:ereturn list} to
+display a list of available {cmd:e()}-scalars after fitting a model;
+see help {helpb ereturn}). For example, {cmd:scalars(df_m)} would
+report the model degrees of freedom for each model. {it:list} may be
+a simple list of names of {cmd:e()}-scalars, e.g.
+
+            {com}. esttab, scalars(ll_0 ll chi2){txt}
+
+{p 8 8 2}
+or, alternatively, a list of quoted name-label pairs, e.g.
+
+            {com}. esttab, scalars({bind:"ll Log lik."} {bind:"chi2 Chi-squared"}){txt}
+
+{p 4 8 2}
+{cmd:sfmt(}{it:{help esttab##fmt:fmt}} [{it:...}]{cmd:)} sets the
+display format(s) for the statistics specified in {cmd:scalars()}
+(the default is to use the display format for point estimates). If
+{cmd:sfmt()} contains less elements than {cmd:scalars()}, the last
+specified format is used for the remaining scalars. That is, only one
+format needs to be specified if the same format be used for all
+scalars.
+
+{p 4 8 2}
+{cmd:noobs} suppresses displaying information on the number of
+observations. The default is to report the number of observations for
+each model in the table footer.
+
+{p 4 8 2}
+{cmd:obslast} displays the number of observations in the last row of
+the table footer. The default is to use the first row.
+
+{marker layout}
+{dlgtab:Layout}
+{marker wide}
+{p 4 8 2}
+{cmd:wide} causes point estimates and t-statistics (or standard errors,
+etc.) to be printed beside one another instead of beneath one another.
+{p_end}
+{marker onecell}
+{p 4 8 2}
+{cmd:onecell} causes point estimates and t-statistics (or standard errors,
+etc.) to be combined in a single table cell. This option is useful primarily
+in {cmd:rtf} or {cmd:html} mode. In these modes a line break is
+inserted between the two statistics. The benefit from using {cmd:onecell}
+in {cmd:rtf} or {cmd:html} mode is that long coefficients labels do not
+derange the table layout. The default for other modes is to insert
+a blank between the statistics. Use {cmd:estout}'s
+{helpb estout##incelldel:incelldelimiter()} option to change this.
+
+{p 4 8 2}
+{cmd:parentheses} encloses t-statistics (or standard errors, etc.) in
+parentheses. This is the default. Specify {cmd:noparentheses} to
+suppress the parentheses.
+
+{p 4 8 2}
+{cmd:brackets} uses square brackets, [], instead of parentheses. Note
+that brackets are the default for confidence intervals.
+
+{p 4 8 2}
+{cmd:gaps} adds empty rows (or, more generally, additional vertical
+space) between coefficients to increase readability (empty rows are
+also inserted between the table's header, body, and footer, unless
+{cmd:lines} is activated). This is the default unless {cmd:wide} or
+{cmd:not} is specified. Type {cmd:nogaps} to suppress the extra
+spacing.
+
+{p 4 8 2}
+{cmd:lines} adds horizontal lines to the table separating the table's
+header, body, and footer and, in the case of multiple
+equation models, the equations. This is the default. Specify {cmd:nolines}
+to suppress the lines. Lines are always suppressed in the {cmd:tab}
+and {cmd:csv} modes.
+
+{p 4 8 2}
+{cmd:noeqlines} suppresses the horizontal lines between equations
+in the case of multiple equation models.{p_end}
+{marker compress}
+{p 4 8 2}
+{cmd:compress} reduces the amount of horizontal spacing (so that more
+models fit on screen without line breaking). The option has no effect
+in the {cmd:tab} and {cmd:csv} modes. Furthermore, note that in the
+TeX and HTML modes the {cmd:compress} option only changes the
+arrangement the table's code, but not the look of the compiled
+end-product. In {cmd:rtf}, however, {cmd:compress} changes the look
+of the formatted table.{p_end}
+{marker plain}
+{p 4 8 2}
+{cmd:plain} produces a minimally formatted table. It is a shorthand
+to specifying {cmd:nostar}, {cmd:nodepvars}, {cmd:nonumbers},
+{cmd:noparentheses}, {cmd:nogaps}, {cmd:nolines} and {cmd:nonotes}
+and setting all formats to {cmd:%9.0g}. Note that the disabled
+options can be switched on again. For example, type
+
+            {com}. esttab, plain star{txt}
+
+{p 8 8 2}
+to produce a plain table including significance stars.
+
+{marker label}
+{dlgtab:Labeling}
+
+{p 4 8 2}
+{cmd:label} specifies that variable labels be used instead of
+variable names (and estimation set titles be used instead of
+estimation set names). Furthermore, {cmd:label} prints "Constant"
+instead of "_cons".
+
+{p 4 8 2}
+{cmd:interaction(}{it:string}{cmd:)} specifies the string to be used
+as delimiter for interaction terms (only relevant in Stata 11 or newer). The
+default is {cmd:interaction(" # ")}. For {cmd:tex} and {cmd:booktabs} the
+default is {cmd:interaction(" $\times$ ")}.
+{p_end}
+{marker title}
+{p 4 8 2}
+{cmd:title(}{it:string}{cmd:)} may be used to provide a title for the
+table. If specified, {it:string} is printed at the top of the table.
+Note that specifying a title causes the table to be set up as a
+floating object in LaTeX mode (unless the {cmd:nofloat} option
+is specified). You may want to set a label for
+referencing in this case. For example, if you type
+{cmd:title(...\label{tab1})}, then "\ref{tab1}" could be used in the
+LaTeX document to point to the table.
+
+{p 4 8 2}
+{cmd:mtitles}, without argument, specifies that for each model the title
+(or, if empty, the name) of the stored estimation set be printed as the model's
+title in the table header. If {cmd:mtitles} is omitted, the default is to
+use name or label of the dependent variable as the model's title (see the
+{cmd:depvar} option). Alternatively, use {cmd:mtitles(}{it:list}{cmd:)}
+specifies a list of model titles. Enclose the titles
+in double quotes if they contain spaces,
+e.g. {bind:{cmd:mtitles("Model 1" "Model 2")}}.
+
+{p 4 8 2}
+{cmd:nomtitles} suppresses printing of model titles.
+
+{p 4 8 2}
+{cmd:depvars} prints the name (or label) of the (first) dependent
+variable of a model as the model's title in the table header. This is
+the default. Specify {cmd:nodepvars} to use the names of
+the stored estimation sets as titles.
+
+{p 4 8 2}
+{cmd:numbers} includes a row containing consecutive model numbers in
+the table header. This is the default. Specify {cmd:nonumbers} to
+suppress printing the model numbers.
+
+{p 4 8 2}
+{cmd:coeflabels(}{it:name} {it:label} [...]{cmd:)} specifies labels
+for the coefficients. Specify names and labels in pairs and, if
+necessary, enclose labels in double quotes,
+e.g. {cmd:coeflabels(mpg Milage rep78 {bind:"Repair Record"})}.
+
+{p 4 8 2}
+{cmd:notes} prints notes at the end of the table explaining the
+significance symbols and the type of displayed statistics. This is
+the default. Specify {cmd:nonotes} to suppress the notes.
+
+{p 4 8 2}
+{cmd:addnotes(}{it:list}{cmd:)} may be used to add further lines of
+text at the bottom of the table. Lines containing blanks must be
+enclosed in double quotes,
+e.g. {cmd:addnotes({bind:"Line 1"} {bind:"Line 2"})}.
+
+{marker format}
+{dlgtab:Document format}
+
+{p 4 8 2}
+{cmd:smcl}, {cmd:fixed}, {cmd:tab}, {cmd:csv},  {cmd:scsv}, {cmd:rtf},
+{cmd:html}, {cmd:tex}, {cmd:booktabs}, and {cmd:md} choose the table's basic
+output format. The default format is {cmd:smcl} unless
+{cmd:using} is specified, in which case the default format
+depends on the filename's suffix ({cmd:smcl} for ".smcl", {cmd:csv}
+for ".csv", {cmd:rtf} for ".rtf",
+{cmd:html} for ".htm" or ".html", {cmd:tex} for ".tex", {cmd:md} for ".md" or ".mmd",
+and {cmd:fixed} for all other filenames). To override the default behavior, specify one of the
+following format options.
+
+{p 8 8 2}
+{cmd:smcl} produces a {help SMCL} formatted table to be displayed in the
+Stata results window or the Stata viewer.
+
+{p 8 8 2}
+{cmd:fixed} produces a fixed-format ASCII table. This is suitable,
+for example, if the table be displayed in a text editor.
+
+{p 8 8 2}
+{cmd:tab} produces a tab-delimited ASCII table.
+{p_end}
+{marker csv}
+{p 8 8 2}
+{cmd:csv} produces a CSV ({ul:C}omma {ul:S}eparated {ul:V}alue
+format) table for use with Microsoft Excel. Delimiter is a comma. In
+order to prevent Excel from interpreting the contents of the table
+cells, they are enclosed double quotes preceded by an equal sign
+(i.e. ="..."). However, if the {cmd:plain} option is specified, the
+table cells are enclosed in double quotes without the leading equal
+sign. The first method is appropriate if you want to preserve the
+table's formatting. The second method is appropriate if you want to
+use the table's contents for further computations in Excel.
+{p_end}
+{marker scsv}
+{p 8 8 2}
+{cmd:scsv} is a variant on the CSV format that uses a semicolon as
+the delimiter. This is appropriate for some non-English versions of
+Excel (e.g. the German version).
+{p_end}
+{marker rtf}
+{p 8 8 2}
+{cmd:rtf} produces a Rich Text Format table for use with word
+processors.
+
+{p 8 8 2}
+{cmd:html} produces a simple HTML formatted table.
+
+{p 8 8 2}
+{cmd:tex} produces a LaTeX formatted table.
+{p_end}
+{marker booktabs}
+{p 8 8 2}
+{cmd:booktabs} produces a LaTeX formatted table for use with LaTeX's
+{it:booktabs} package.
+
+{p 8 8 2}
+{cmd:md} produces a Markdown formatted table. Native
+{browse "http://daringfireball.net/projects/markdown/":Markdown} has no specific
+support for tables, but for example {browse "http://github.github.com/gfm/":GitHub Flavored Markdown}
+and {browse "http://fletcherpenney.net/multimarkdown/":MultiMarkdown} do. Option {cmd:mmd}
+can be used as a synonym for {cmd:md} (the default file suffix will be ".mmd" in this case).
+{p_end}
+{marker fragment}
+{p 4 8 2}
+{cmd:fragment} causes the table's opening and closing specifications
+to be suppressed. This is relevant primarily in LaTeX and HTML mode.
+
+{p 4 8 2}
+{cmd:float} causes the table to be set up as a floating object in LaTeX mode
+(table environment). Providing a {cmd:title()} implies {cmd:float}. Specify
+{cmd:nofloat} to omit the float environment in this case (this is useful, e.g.,
+for LyX users).
+
+{p 4 8 2}
+{cmd:page}[{cmd:(}{it:packages}{cmd:)}] adds opening and closing code
+to define a whole LaTeX or HTML document. The default is to produce a
+raw table that can then be included into an existing LaTeX or HTML
+document. Specifying {it:packages} in parentheses causes
+{cmd:\usepackage{c -(}}{it:packages}{cmd:{c )-}} to be added to the
+preamble of the LaTeX document (note that the {it:booktabs} package
+is automatically loaded if {cmd:booktabs} is specified).
+
+{p 4 8 2}
+{cmd:standalone}[{cmd:(}{it:opts}{cmd:)}] implies {cmd:page} 
+and uses {cmd:\documentclass[}{it:opts}{cmd:]{c -(}standlone{c )-}}
+instead of {cmd:\documentclass{c -(}article{c )-}} in the LaTeX header (see 
+{browse "http://ctan.org/pkg/standalone"}). The default for {it:opts}
+is {cmd:varwidth}; type {cmd:standalone("")} to suppress {cmd:[}{it:opts}{cmd:]}.
+
+{p 4 8 2}
+{cmd:alignment(}{it:string}{cmd:)} may be used to specify the
+alignment of the models' columns in LaTeX, HTML, or RTF mode.
+
+{p 8 8 2}
+In LaTeX mode {it:string} should be a LaTeX column specifier. The
+default is to center the columns. To produce right-aligned columns,
+for example, type {cmd:alignment(r)}. If the table contains multiple
+columns per model/equation, the alignment specification should define
+all columns. For example, if the {cmd:wide} option is specified, you
+could type {cmd:alignment(cr)} to, say, center the point estimates
+and right-align the t-statistics. Note that more sophisticated column
+definitions are often needed to produce appealing results. In
+particular, LaTeX's {it:dcolumn} package proves useful to align
+columns on the decimal point.
+
+{p 8 8 2}
+In HTML mode {it:string} should be a HTML alignment specifier. The
+default is to omit alignment specification, which results in left
+aligned columns. To center the columns in HTML, for example, specify
+{cmd:alignment(center)}. Other than in LaTeX mode, the same alignment
+is used for all columns if the table contains multiple columns per
+model/equation in the HTML mode.
+
+{p 8 8 2}
+In RTF mode {it:string} should be one of {cmd:l}, {cmd:c}, {cmd:r},
+and {cmd:j}. The default is to center the columns. To produce
+right-aligned columns, for example, type {cmd:alignment(r)}. The same
+alignment is used for all columns if the table contains multiple
+columns per model/equation in the RTF mode.
+
+{p 8 8 2}
+Note that {cmd:alignment()} does not change the alignment of the
+variable names/labels in the left stub of the table. They are always
+left-aligned.
+
+{p 4 8 2}
+{cmd:width(}{it:string}{cmd:)} sets the overall width of the table in
+LaTeX or HTML. {it:string} should be LaTeX or HTML literal. For
+example, specify {cmd:width(\hsize)} in LaTeX or {cmd:width(100%)} in
+HTML to span the whole page. The table columns will spread regularly
+over the specified width. Note that in RTF mode {helpb estout}'s
+{cmd:varwidth()} and {cmd:modelwidth()} options may be used to change
+the width of the table columns.
+
+{p 4 8 2}
+{cmdab:longtable} causes the {it:longtable} environment to be used in
+LaTeX. Use {cmdab:longtable} for tables that are too
+long to fit on a single page. {cmdab:longtable} cannot be combined
+with {cmd:width()}. Make sure to load the {it:longtable} package
+in the LaTeX document, i.e. include {cmd:\usepackage{longtable}} in the
+document's preamble.
+
+{p 4 8 2}
+{cmd:fonttbl(}{it:string}{cmd:)} defines a custom font table in RTF. The
+default is "{cmd:\f0\fnil Times New Roman;}". For example, typing
+
+            {com}. esttab using example.rtf, ti("\f1 The Auto Data") ///
+                fonttbl(\f0\fnil Times New Roman;\f1\fnil Arial;){txt}
+
+{p 8 8 2}
+would add a title in Arial.
+
+{p 4 8 2}
+{cmd:nortfencode} prevents the translation of non-ASCII characters in RTF
+mode (a translated character is encoded as {cmd:\u}#{cmd:?}, where
+# is the base 10 character code). This is only relevant in Stata 14 or newer;
+no translation is applied in Stata 13 or older.
+
+{marker output}
+{dlgtab:Output}
+
+{p 4 8 2}
+{cmd:replace} permits {cmd:esttab} to overwrite an existing file.
+
+{p 4 8 2}
+{cmd:append} specifies that the output be appended to an existing
+file. It may be used even if the file does not yet exist. Specifying
+{cmd:append} together with {cmd:page} in TeX or HTML mode causes the
+new table to be inserted at the end of the body of an existing
+document ({cmd:esttab} seeks a line reading "\end{document}" or
+"</body>", respectively, and starts appending from there;
+contents after this line will be overwritten). In RTF mode, existing
+documents are assumed to end with a line containing a single "}".
+
+{p 4 8 2}
+{cmd:type} specifies that the assembled table be printed in the
+results window and the log file. This is the default unless
+{cmd:using} is specified.
+
+{p 4 8 2}
+{cmd:noisily} displays the executed {helpb estout} command.
+
+{marker advanced}
+{dlgtab:Advanced}
+
+{p 4 8 2}
+{cmd:drop(}{it:droplist}{cmd:)} identifies the coefficients to be
+dropped from the table. A {it:droplist} comprises one or more
+specifications, separated by white space. A specification can be
+either a parameter name (e.g. {cmd:price}), an equation name followed
+by a colon (e.g. {cmd:mean:}), or a full name
+(e.g. {cmd:mean:price}). You may use the {cmd:*} and {cmd:?} wildcards
+in equation names and parameter names. Be sure to refer to the matched
+equation names, and not to the original equation names in the models,
+when using the {cmd:equations()} option to match equations.
+
+{p 4 8 2}
+{cmd:noomitted} drops omitted coefficients (only relevant in Stata 11 or
+newer).
+
+{p 4 8 2}
+{cmd:nobaselevels} drops base levels of factor variables (only relevant
+in Stata 11 or newer).
+
+{p 4 8 2}
+{cmd:keep(}{it:keeplist}{cmd:)} selects the coefficients to be
+included in the table. {it:keeplist} is specified analogous to
+{it:droplist} in {cmd:drop()} (see above).
+
+{p 4 8 2}
+{cmd:order(}{it:orderlist}{cmd:)} changes the order of the
+coefficients and equations within the table. {it:orderlist} is
+specified analogous to {it:droplist} in {cmd:drop()} (see above).
+Coefficients and equations that do not appear in {it:orderlist} are
+placed last (in their original order).
+
+{p 4 8 2}
+{cmd:equations(}{it:eqmatchlist}{cmd:)} specifies how the models'
+equations are to be matched. This option is passed to the internal
+call of {cmd:estimates table}. See help {helpb estimates} on how to
+specify this option. The most common usage is {cmd:equations(1)} to
+match all the first equations in the models.
+
+{p 4 8 2}
+{cmd:eform} displays the regression table in exponentiated form. The
+exponent of a coefficient is displayed in lieu of the untransformed
+coefficient; standard errors and confidence intervals are transformed
+as well. Note that the intercept is dropped in eform-mode, unless
+{cmd:constant} is specified.
+
+{p 4 8 2}
+{cmd:unstack} specifies that the individual equations from
+multiple-equation models (e.g. {cmd:mlogit}, {cmd:reg3},
+{cmd:heckman}) be placed in separate columns. The default is to place
+the equations below one another in a single column.
+
+{p 4 8 2}
+{it:estout_options} are any other {cmd:estout} options (see help
+{helpb estout}). Note that {cmd:estout} options take precedence over
+{cmd:esttab} options. For example,
+
+{p 8 20 2}
+{cmd:cells()}{space 5}disables {cmd:b()}, {cmd:beta()}, {cmd:main()},
+{cmd:t()}, {cmd:abs}, {cmd:not}, {cmd:se()}, {cmd:p()}, {cmd:ci()},
+{cmd:aux()}, {cmd:star}, {cmd:staraux}, {cmd:wide}, {cmd:onecell},
+{cmd:parentheses}, and {cmd:brackets},
+
+{p 8 20 2}
+{cmd:stats()}{space 5}disables {cmd:r2()}, {cmd:ar2()}, {cmd:pr2()},
+{cmd:aic()}, {cmd:bic()}, {cmd:scalars()}, {cmd:sfmt()}, {cmd:noobs},
+and {cmd:obslast}.
+
+{p 8 8 2}
+Other {cmd:estout} options that should be used with care are
+{cmd:begin()}, {cmd:delimiter()}, {cmd:end()}, {cmd:prehead()},
+{cmd:posthead()}, {cmd:prefoot()}, {cmd:postfoot()}, {cmd:mlabels()},
+and {cmd:varlabels()}. Furthermore, note that {cmd:estout}'s {cmd:style()}
+option does not have much effect because most options that would be affected
+by {cmd:style()} are set explicitly by {cmd:esttab}.
+
+{marker fmt}
+{dlgtab:Numerical formats}
+
+{p 4 4 2}
+Numerical display formats may be specified in {cmd:esttab} as follows:
+
+{p 5 8 2}
+1. Official Stata's display formats: You may specify formats, such as
+{cmd:%9.0g} or {cmd:%8.2f}. See help {help format} for a list
+of available formats. {cmd:%g} or {cmd:g} may be used as a
+synonym for {cmd:%9.0g}.
+
+{p 5 8 2}
+2. Fixed format: You may specify an integer value such as {cmd:0},
+{cmd:1}, {cmd:2}, etc. to request a display format with a fixed number
+of decimal places. For example, {cmd:t(3)} would display t-statistics
+with three decimal places.
+
+{p 5 8 2}
+3. Automatic format: You may specify {cmd:a1}, {cmd:a2}, ..., or
+{cmd:a9} to cause {cmd:esttab} to choose a reasonable display format for
+each number depending on the number's value. {cmd:a} may be used as a
+synonym for {cmd:a3}. The {it:#} in
+{cmd:a}{it:#} determines the minimum precision according to the
+following rules:
+
+{p 10 12 2}
+o Absolute numbers smaller than 1 are displayed with {it:#}
+significant decimal places (i.e. with {it:#} decimal places ignoring
+any leading zeros after the decimal point). For example,
+{cmd:0.00123456} is displayed as {cmd:0.00123} if the format is
+{cmd:a3}.
+
+{p 10 12 2}
+o Absolute numbers greater than 1 are displayed with as many digits
+required to retain at least one decimal place and are displayed with
+a minimum of ({it:#} + 1) digits. For example, if the format is
+{cmd:a3}, {cmd:1.23456} is displayed as {cmd:1.235}, {cmd:12.3456} is
+displayed as {cmd:12.35}, and {cmd:1234.56} is displayed as
+{cmd:1234.6}.
+
+{p 10 12 2}
+o In any case, integers are displayed with zero decimal places, and
+very large or very small absolute numbers are displayed in
+exponential format.
+
+{marker exa}
+{title:Examples}
+
+{p 4 4 2}
+The following examples are intended to illustrate the basic usage of
+{cmd:esttab}.  Additional examples can be found at
+{browse "http://repec.sowi.unibe.ch/stata/estout/"}.
+
+{p 4 4 2} The procedure is to first fit and store some models (see {helpb eststo}) and then apply
+{cmd:esttab} to these stored estimates:
+
+        {com}. eststo clear
+        {txt}
+        {com}. sysuse auto
+        {txt}(1978 Automobile Data)
+
+        {com}. eststo: quietly regress price weight mpg
+        {txt}({res}est1{txt} stored)
+
+        {com}. eststo: quietly regress price weight mpg foreign
+        {txt}({res}est2{txt} stored)
+
+        {com}. esttab, ar2
+        {res}
+        {txt}{hline 44}
+        {txt}                      (1)             (2)
+        {txt}                    price           price
+        {txt}{hline 44}
+        {txt}weight      {res}        1.747**         3.465***{txt}
+                    {res} {ralign 12:{txt:(}2.72{txt:)}}    {ralign 12:{txt:(}5.49{txt:)}}   {txt}
+
+        {txt}mpg         {res}       -49.51           21.85   {txt}
+                    {res} {ralign 12:{txt:(}-0.57{txt:)}}    {ralign 12:{txt:(}0.29{txt:)}}   {txt}
+
+        {txt}foreign     {res}                       3673.1***{txt}
+                    {res}                 {ralign 12:{txt:(}5.37{txt:)}}   {txt}
+
+        {txt}_cons       {res}       1946.1         -5853.7   {txt}
+                    {res} {ralign 12:{txt:(}0.54{txt:)}}    {ralign 12:{txt:(}-1.73{txt:)}}   {txt}
+        {txt}{hline 44}
+        {txt}N           {res}           74              74   {txt}
+        {txt}adj. R-sq   {res}        0.273           0.478   {txt}
+        {txt}{hline 44}
+        {txt}t statistics in parentheses
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+
+
+{p 4 4 2}
+The same table using labels:
+
+        {com}. esttab, ar2 label
+        {res}
+        {txt}{hline 52}
+        {txt}                              (1)             (2)
+        {txt}                            Price           Price
+        {txt}{hline 52}
+        {txt}Weight (lbs.)       {res}        1.747**         3.465***{txt}
+                            {res} {ralign 12:{txt:(}2.72{txt:)}}    {ralign 12:{txt:(}5.49{txt:)}}   {txt}
+
+        {txt}Mileage (mpg)       {res}       -49.51           21.85   {txt}
+                            {res} {ralign 12:{txt:(}-0.57{txt:)}}    {ralign 12:{txt:(}0.29{txt:)}}   {txt}
+
+        {txt}Car type            {res}                       3673.1***{txt}
+                            {res}                 {ralign 12:{txt:(}5.37{txt:)}}   {txt}
+
+        {txt}Constant            {res}       1946.1         -5853.7   {txt}
+                            {res} {ralign 12:{txt:(}0.54{txt:)}}    {ralign 12:{txt:(}-1.73{txt:)}}   {txt}
+        {txt}{hline 52}
+        {txt}Observations        {res}           74              74   {txt}
+        {txt}Adjusted R-squared  {res}        0.273           0.478   {txt}
+        {txt}{hline 52}
+        {txt}t statistics in parentheses
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+
+
+{p 4 4 2}
+Plain table:
+
+        {com}. esttab, ar2 plain
+        {res}
+        {txt}                     est1         est2
+        {txt}                      b/t          b/t
+        {txt}weight      {res}     1.746559     3.464706{txt}
+                    {res}     2.723238     5.493003{txt}
+        {txt}mpg         {res}    -49.51222      21.8536{txt}
+                    {res}    -.5746808     .2944391{txt}
+        {txt}foreign     {res}                   3673.06{txt}
+                    {res}                  5.370142{txt}
+        {txt}_cons       {res}     1946.069    -5853.696{txt}
+                    {res}      .541018    -1.733408{txt}
+        {txt}N           {res}           74           74{txt}
+        {txt}adj. R-sq   {res}     .2734846     .4781119{txt}
+
+
+{p 4 4 2}
+Using standard errors in brackets and suppress significance stars:
+
+        {com}. esttab, se nostar brackets
+        {res}
+        {txt}{hline 38}
+        {txt}                      (1)          (2)
+        {txt}                    price        price
+        {txt}{hline 38}
+        {txt}weight      {res}        1.747        3.465{txt}
+                    {res} {ralign 12:{txt:[}0.641{txt:]}} {ralign 12:{txt:[}0.631{txt:]}}{txt}
+
+        {txt}mpg         {res}       -49.51        21.85{txt}
+                    {res} {ralign 12:{txt:[}86.16{txt:]}} {ralign 12:{txt:[}74.22{txt:]}}{txt}
+
+        {txt}foreign     {res}                    3673.1{txt}
+                    {res}              {ralign 12:{txt:[}684.0{txt:]}}{txt}
+
+        {txt}_cons       {res}       1946.1      -5853.7{txt}
+                    {res} {ralign 12:{txt:[}3597.0{txt:]}} {ralign 12:{txt:[}3377.0{txt:]}}{txt}
+        {txt}{hline 38}
+        {txt}N           {res}           74           74{txt}
+        {txt}{hline 38}
+        {txt}Standard errors in brackets
+
+
+{p 4 4 2}
+Printing beta coefficients:
+
+        {com}. esttab, beta
+        {res}
+        {txt}{hline 44}
+        {txt}                      (1)             (2)
+        {txt}                    price           price
+        {txt}{hline 44}
+        {txt}weight      {res}        0.460**         0.913***{txt}
+                    {res} {ralign 12:{txt:(}2.72{txt:)}}    {ralign 12:{txt:(}5.49{txt:)}}   {txt}
+
+        {txt}mpg         {res}       -0.097           0.043   {txt}
+                    {res} {ralign 12:{txt:(}-0.57{txt:)}}    {ralign 12:{txt:(}0.29{txt:)}}   {txt}
+
+        {txt}foreign     {res}                        0.573***{txt}
+                    {res}                 {ralign 12:{txt:(}5.37{txt:)}}   {txt}
+        {txt}{hline 44}
+        {txt}N           {res}           74              74   {txt}
+        {txt}{hline 44}
+        {txt}Standardized beta coefficients; t statistics in parentheses
+        {txt}* p<0.05, ** p<0.01, *** p<0.001
+
+{marker aut}
+{title:Author}
+
+{p 4 4 2}
+Ben Jann, Institute of Sociology, University of Bern, jann@soz.unibe.ch
+
+{marker als}
+{title:Also see}
+
+    Manual:  {hi:[R] estimates}
+
+{p 4 13 2}Online:  help for
+ {helpb estimates},
+ {help estcom},
+ {helpb estout},
+ {helpb eststo},
+ {helpb estadd},
+ {helpb estpost}
+{p_end}

--- a/analysis/find_unconverged_models.R
+++ b/analysis/find_unconverged_models.R
@@ -1,0 +1,78 @@
+# find_unconverged_models.R - a script to identify models that have not converged based on their hazard ratios and confidence intervals.
+# from neurodegenerative repository: https://github.com/opensafely/post-covid-neurodegenerative/blob/post-release/analysis/post_release/find_unconverged_models.R
+
+# Load libraries ---------------------------------------------------------------
+print('Load libraries')
+
+library(magrittr)
+library(tidyverse)
+library(purrr)
+library(data.table)
+library(tidyverse)
+library(svglite)
+library(VennDiagram)
+library(grid)
+library(gridExtra)
+
+# Specify paths ----------------------------------------------------------------
+print('Specify paths')
+
+# NOTE:
+# This file is used to specify paths and is in the .gitignore to keep your information secret.
+# A file called specify_paths_example.R is provided for you to fill in.
+# Please remove "_example" from the file name and add your specific file paths before running this script.
+
+source("analysis/specify_paths.R")
+
+# Source functions -------------------------------------------------------------
+print('Source functions')
+
+source("analysis/utility.R")
+
+# Make post-release directory --------------------------------------------------
+print('Make post-release directory')
+
+dir.create("output/post_release/", recursive = TRUE, showWarnings = FALSE)
+output_folder <- "output/post_release/"
+
+# Find all model files ---------------------------------------------------------
+print('Collecting list of models')
+file_list <- list.files(
+  path = path_release,
+  pattern = "^model_output-.*-midpoint6\\.csv$",
+  full.names = TRUE
+)
+
+# Read and combine all CSV files into one data frame---------------------------
+print('Loading and combining models')
+df <- file_list %>%
+  lapply(read_csv, show_col_types = FALSE) %>%
+  bind_rows()
+
+# Define bounds for checking --------------------------------------------------
+lb <- 0.25
+ub <- 32
+
+# Find relevant rows ----------------------------------------------------------
+print('Filtering dataframe')
+df <- df[df$hr < lb | df$hr > ub | df$conf_low < lb | df$conf_high > ub, ] # HR range restriction
+df <- df[!(df$term %in% c("days_pre", "days0_1")), ] # Term restriction
+df <- df[!is.na(df$name), ] #NA filtering
+
+unconverged_list <- sprintf('"%s"', unique(df$name))
+
+# Save list of models ---------------------------------------------------------
+print("Saving .txt list of models")
+writeLines(
+  paste(unconverged_list, collapse = ",\n"),
+  "output/post_release/unconverged_models.txt"
+)
+
+# Save related dataframe -------------------------------------------------------
+print("Save dataframe of unconverged models")
+
+readr::write_csv(
+  df,
+  paste0(output_folder, "/unconverged_models.csv"),
+  na = "-"
+)

--- a/analysis/make_output/make_model_output.R
+++ b/analysis/make_output/make_model_output.R
@@ -74,9 +74,12 @@ for (i in files_R) {
   } else {
     tmp$error <- ""
   }
-
+  
   ## Add source file name
-  tmp$name <- gsub("model_output-", "", gsub(".csv", "", i))
+  tmp$name <- gsub("^(stata_)?model_output-", "", gsub("\\.csv", "", i))
+  
+  ## Add source column (R vs Stata)
+  tmp$source <- ifelse(grepl("^stata_model_output", i), "Stata", "R")
 
   ## Append to master dataframe
   df <- plyr::rbind.fill(df, tmp)
@@ -95,8 +98,6 @@ df <- merge(
 )
 
 df$outcome <- gsub("out_date_", "", df$outcome)
-
-df$source <- "R"
 
 # Save model output ------------------------------------------------------------
 print('Save model output')

--- a/analysis/model/cox_model.do
+++ b/analysis/model/cox_model.do
@@ -1,0 +1,326 @@
+* ==============================================================================
+*  Setup and input
+* ==============================================================================
+
+* Specify parameters
+
+local name "`1'"
+local cutpoints "`2'"
+local study_start "`3'"
+
+/*
+* Specify parameters locally
+
+local name "cohort_prevax-main_preex_FALSE-asthma"
+local cutpoints "1;28;183;365;730;1095;1460;1825;1979"
+local study_start "2020-01-01"
+*/
+
+* Set Ado file path
+
+adopath + "analysis/extra_ados"
+
+* Read and describe data
+
+use "./output/model/ready-`name'.dta", clear
+describe
+
+* ==============================================================================
+*  Convert args for use by Stata
+* ==============================================================================
+
+local cutpoints = subinstr("0;`cutpoints'", ";", " ", .)
+di "`cutpoints'"
+
+local cutpoints_last = word("`cutpoints'", wordcount("`cutpoints'"))
+di "`cutpoints_last'"
+
+* ==============================================================================
+*  Data preparation (matches R preprocessing)
+* ==============================================================================
+
+* Generate cox_weight = 1 if sampling was turned off
+
+capture confirm variable cox_weight
+if _rc {
+    di "Variable cox_weight not found: generating with value 1"
+    gen cox_weight = 1
+}
+else {
+    di "Variable cox_weight already exists: keeping existing values"
+}
+
+* Filter data
+
+keep patient_id exposure outcome fup_start fup_stop cox_weight cov_cat* strat* cov_num* cov_bin* 
+drop cov_num_age_sq
+duplicates drop
+
+* Rename variables
+
+rename cov_num_age age
+rename strat_cat_region region
+
+* Generate sex indicator
+
+local sub_sex = regexm("`name'", "sub_sex")
+display "`sub_sex'"
+
+* Replace NA with missing value that Stata recognises
+
+ds , has(type string)
+foreach var of varlist `r(varlist)' {
+	replace `var' = "" if `var' == "NA"
+}
+
+* Reformat date variables (already numeric)
+foreach var of varlist exposure outcome fup_start fup_stop {
+    format `var' %td
+}
+
+* Encode only string variables
+foreach var of varlist region cov_bin* cov_cat* {
+    di "Checking `var'..."
+    capture confirm string variable `var'
+    if !_rc {  // _rc = 0 means it's a string
+        di "Encoding `var'"
+        local var_short = substr("`var'", 1, length("`var'") - 1)
+        encode `var', generate(`var_short'1)
+        drop `var'
+        rename `var_short'1 `var'
+    }
+    else {
+        di "`var' is already numeric, skipping encode"
+    }
+}
+
+* ==============================================================================
+*  Summary checks
+* ==============================================================================
+
+misstable summarize
+
+* ==============================================================================
+*  Time-to-event setup (stset)
+* ==============================================================================
+
+* Update follow-up end
+
+replace fup_stop = fup_stop + 1
+format fup_stop %td
+
+* Make age spline
+
+centile age, centile(10 50 90)
+mkspline age_spline = age, cubic knots(`r(c_1)' `r(c_2)' `r(c_3)')
+
+* Make outcome status variable
+
+egen outcome_status = rownonmiss(outcome)
+
+* ==============================================================================
+*  Total number of patients and exposed patients
+* ==============================================================================
+
+egen N_total = count(patient_id)
+egen N_exposed = total(!missing(exposure))
+
+* Apply stset including IPW here as unsampled datasets will be provided with cox_weights set to 1
+
+gen origin_date = daily("`study_start'", "YMD")
+stset fup_stop [pweight=cox_weight], failure(outcome_status) id(patient_id) enter(fup_start) origin(origin_date)
+stsplit time, after(exposure) at(`cutpoints')
+replace time = `cutpoints_last' if time==-1
+	
+* ==============================================================================
+*  Person-time and events (matches R collapse step)
+* ==============================================================================
+
+gen fup = _t - _t0
+egen fup_total = total(fup)  
+
+* Person-time and events aggregated by time interval
+
+egen person_time_total = total(fup), by(time)
+egen N_events = total(outcome_status), by(time)
+
+* ==============================================================================
+* Median follow-up among those with the event
+* ==============================================================================
+
+gen tte = fup if outcome_status==1
+egen outcome_time_median_in_term = median(tte), by(time)
+
+* ==============================================================================
+*  Define indicator variables for each time period
+* ==============================================================================
+
+* Count the number of breakpoints
+local n : word count `cutpoints'
+
+* Loop over the breakpoints to generate interval variables
+forvalues i = 1/`=`n'-1' {
+    local start = word("`cutpoints'", `i')
+    local end   = word("`cutpoints'", `=`i'+1')
+    
+    * Generate variable name dynamically
+    local varname = "days`start'_`end'"
+    
+    * Generate the variable: 1 if time == start (or adjust to range if desired)
+    gen `varname' = (time == `start')
+    tab `varname'
+}
+
+* ==============================================================================
+*  Create term variable that indicates which days* the row refers to
+* ==============================================================================
+
+* Identify day variables
+ds days*, has(type numeric)
+local dayvars `r(varlist)'
+	
+* Generate empty variable
+gen str20 term = ""
+
+* Loop over each variable
+foreach var of local dayvars {
+    replace term = "`var'" if `var' == 1
+}
+
+* If all are 0, you can set "days_pre"
+replace term = "days_pre" if term == ""
+
+* ==============================================================================
+*  Based on term, add outcome time that has already passed
+* ==============================================================================
+preserve
+
+gen start_term = .
+gen match = regexs(1) if regexm(term, "days([0-9]+)_")
+replace start_term = real(match)
+drop match
+
+gen outcome_time_median = outcome_time_median_in_term
+replace outcome_time_median = outcome_time_median_in_term + start_term if term!="days_pre"
+
+order term N_total N_exposed N_events person_time_total outcome_time_median   
+keep term N_total N_exposed N_events person_time_total outcome_time_median 
+duplicates drop
+
+* ==============================================================================
+*  Save descriptive output (aligns with R's descriptive summary)
+* ==============================================================================
+
+save "./output/model/stata_tmp-`name'.dta", replace
+
+* ==============================================================================
+* Run models and save output [Note: cannot use efron method with weights]
+* ==============================================================================
+restore
+
+tab time outcome_status 
+
+di "Total follow-up in days: " fup_total
+bysort time: summarize(fup), detail
+
+if `sub_sex'==1 {
+	stcox days* age_spline1 age_spline2, strata(region) vce(r)
+	est store min, title(Age_Sex)
+	stcox days* age_spline1 age_spline2 i.cov_cat_* cov_num_* cov_bin_*, strata(region) vce(r)
+	est store max, title(Maximal)
+}
+else {
+	stcox days* i.cov_cat_sex age_spline1 age_spline2, strata(region) vce(r)
+	est store min, title(Age_Sex)
+	stcox days* age_spline1 age_spline2 i.cov_cat_* cov_num_* cov_bin_*, strata(region) vce(r)
+	est store max, title(Maximal)	
+}
+
+* Save coefficients with CIs
+estout * using "./output/model/stata_tmp_output-`name'.txt", cells("b se t ci_l ci_u p") stats(risk N_fail N_sub N N_clust) replace 
+
+* ==============================================================================
+* Format stata model output
+* ==============================================================================
+
+* Step 1. Import text file as raw
+
+import delimited using "./output/model/stata_tmp_output-`name'.txt", clear stringcols(_all)
+
+* Step 2. Rename columns properly
+
+rename v1 term
+rename v2 b_min
+rename v3 se_min
+rename v4 t_min
+rename v5 lci_min
+rename v6 uci_min
+rename v7 p_min
+rename v8 b_max
+rename v9 se_max
+rename v10 t_max
+rename v11 lci_max
+rename v12 uci_max
+rename v13 p_max
+drop in 1/2
+* Drop last 5 rows (risk, N_fail, etc.)
+count
+drop in `=`r(N)'-4'/`r(N)'
+drop p_* t_*
+
+* Step 3. Convert to numeric where possible
+destring b_min se_min lci_min uci_min ///
+         b_max se_max lci_max uci_max, replace force
+
+* Step 4. Calculate HRs from log-HR (b_min, b_max)
+gen hr_min = exp(b_min)
+gen conf_low_min = exp(lci_min)
+gen conf_high_min = exp(uci_min)
+
+gen hr_max = exp(b_max)
+gen conf_low_max = exp(lci_max)
+gen conf_high_max = exp(uci_max)
+
+* Step 5. Reshape to long form for model variable
+
+reshape long b_ se_ lci_ uci_ hr_ conf_low_ conf_high_, i(term) j(model) string
+
+* Label models
+replace model = "mdl_age_sex" if model=="min"
+replace model = "mdl_max_adj" if model=="max"
+
+* Rename for clarity
+rename b_ lnhr
+rename se_ se_lnhr
+rename hr_ hr
+rename conf_low_ conf_low
+rename conf_high_ conf_high
+
+*Relabel for readability
+replace term = "cov_cat_sex=Female" if term=="1.cov_cat_sex"
+replace term = "cov_cat_sex=Male" if term=="2.cov_cat_sex"
+replace term = "cov_cat_imd=1 (most deprived)" if term=="1.cov_cat_imd"
+replace term = "cov_cat_imd=2" if term=="2.cov_cat_imd"
+replace term = "cov_cat_imd=3" if term=="3.cov_cat_imd"
+replace term = "cov_cat_imd=4" if term=="4.cov_cat_imd"
+replace term = "cov_cat_imd=5 (least deprived)" if term=="5.cov_cat_imd"
+
+*tidy dataset by removing unnessary rows
+drop if model=="mdl_age_sex" & !(strpos(term,"age_spline") | strpos(term,"cov_cat_sex=Male") | strpos(term,"days"))
+drop if strpos(term,"cov_cat_sex=Female") | strpos(term,"cov_cat_imd=1 (most deprived)")
+
+*Step 6. Merge with survival information 
+
+merge m:1 term using "./output/model/stata_tmp-`name'.dta", nogen
+sort model term
+
+*Step 7. Add metadata fields
+
+gen strata_warning = ""
+gen surv_formula = ""
+replace surv_formula = "Surv(_t0, _t, _d) ~ days* + age_spline1 + age_spline2 + i.cov_cat_sex strata(region)" if model=="mdl_age_sex"
+replace surv_formula = "Surv(_t0, _t, _d) ~ days* + age_spline1 + age_spline2 + i.cov_cat_* + cov_num_* + cov_bin_* strata(region)" if model=="mdl_max_adj"
+
+*Step 8. Save final CSV
+
+export delimited using "./output/model/stata_model_output-`name'.csv", replace

--- a/analysis/model/cox_model.do
+++ b/analysis/model/cox_model.do
@@ -11,7 +11,7 @@ local study_start "`3'"
 /*
 * Specify parameters locally
 
-local name "cohort_prevax-main_preex_FALSE-asthma"
+local name "cohort_prevax-main_preex_FALSE-aki"
 local cutpoints "1;28;183;365;730;1095;1460;1825;1979"
 local study_start "2020-01-01"
 */

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '5.0'
 
 expectations:
 

--- a/project.yaml
+++ b/project.yaml
@@ -4079,7 +4079,7 @@ actions:
         ready: output/model/ready-cohort_prevax-main_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-main_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_FALSE-aki
@@ -4103,7 +4103,7 @@ actions:
         ready: output/model/ready-cohort_unvax-main_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-main_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_FALSE-aki
@@ -4127,7 +4127,7 @@ actions:
         ready: output/model/ready-cohort_unvax-main_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-main_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_FALSE-ckd
@@ -4151,8 +4151,8 @@ actions:
         ready: output/model/ready-cohort_vax-main_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-main_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-main_preex_FALSE-aki
-      1;28;183;365;730;1095;1460 2021-06-01
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-main_preex_FALSE-aki 1;28;183;365;730;1095;1460
+      2021-06-01
     needs:
     - ready-cohort_vax-main_preex_FALSE-aki
     outputs:
@@ -4175,7 +4175,7 @@ actions:
         ready: output/model/ready-cohort_prevax-main_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-main_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-main_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_TRUE-aki
@@ -4199,7 +4199,7 @@ actions:
         ready: output/model/ready-cohort_unvax-main_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-main_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_TRUE-aki
@@ -4223,7 +4223,7 @@ actions:
         ready: output/model/ready-cohort_unvax-main_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_unvax-main_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_TRUE-esrd
@@ -4247,8 +4247,8 @@ actions:
         ready: output/model/ready-cohort_vax-main_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-main_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-main_preex_TRUE-aki
-      1;28;183;365;730;1095;1460 2021-06-01
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-main_preex_TRUE-aki 1;28;183;365;730;1095;1460
+      2021-06-01
     needs:
     - ready-cohort_vax-main_preex_TRUE-aki
     outputs:
@@ -4271,7 +4271,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki
@@ -4295,7 +4295,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-ckd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd
@@ -4319,7 +4319,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki
@@ -4343,7 +4343,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd
@@ -4367,7 +4367,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_18_39_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_18_39_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_18_39_preex_FALSE-aki
@@ -4391,7 +4391,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki
@@ -4415,7 +4415,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-esrd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd
@@ -4439,7 +4439,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki
@@ -4463,7 +4463,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_18_39_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_18_39_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_18_39_preex_TRUE-aki
@@ -4487,7 +4487,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki
@@ -4511,7 +4511,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki
@@ -4535,7 +4535,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd
@@ -4559,7 +4559,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_40_59_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_40_59_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_40_59_preex_FALSE-aki
@@ -4583,7 +4583,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki
@@ -4607,7 +4607,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-esrd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd
@@ -4631,7 +4631,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki
@@ -4655,7 +4655,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_40_59_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_40_59_preex_TRUE-aki
@@ -4679,7 +4679,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd
@@ -4703,7 +4703,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki
@@ -4727,7 +4727,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki
@@ -4751,7 +4751,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_60_79_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_60_79_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_60_79_preex_FALSE-aki
@@ -4775,7 +4775,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki
@@ -4799,7 +4799,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki
@@ -4823,7 +4823,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_60_79_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_60_79_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_60_79_preex_TRUE-aki
@@ -4847,7 +4847,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki
@@ -4871,7 +4871,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki
@@ -4895,7 +4895,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd
@@ -4919,7 +4919,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_80_110_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_80_110_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_80_110_preex_FALSE-aki
@@ -4943,7 +4943,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki
@@ -4967,7 +4967,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki
@@ -4991,7 +4991,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_age_80_110_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_age_80_110_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_age_80_110_preex_TRUE-aki
@@ -5015,7 +5015,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki
@@ -5039,7 +5039,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
@@ -5063,7 +5063,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhistory_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhistory_preex_FALSE-aki
@@ -5087,7 +5087,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd
@@ -5111,7 +5111,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki
@@ -5135,7 +5135,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd
@@ -5159,7 +5159,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhistory_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhistory_preex_TRUE-aki
@@ -5183,7 +5183,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd
@@ -5207,7 +5207,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
@@ -5231,7 +5231,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
@@ -5255,7 +5255,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
@@ -5279,7 +5279,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
@@ -5303,7 +5303,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
@@ -5327,7 +5327,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
@@ -5351,7 +5351,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
@@ -5375,7 +5375,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
@@ -5399,7 +5399,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
@@ -5423,7 +5423,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
@@ -5447,7 +5447,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
@@ -5471,7 +5471,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
@@ -5495,7 +5495,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
@@ -5519,7 +5519,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
@@ -5543,7 +5543,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
@@ -5567,7 +5567,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
@@ -5591,7 +5591,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
@@ -5615,7 +5615,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
@@ -5639,7 +5639,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
@@ -5663,7 +5663,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
@@ -5687,7 +5687,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
@@ -5711,7 +5711,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
@@ -5735,7 +5735,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
@@ -5759,7 +5759,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
@@ -5783,7 +5783,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
@@ -5807,7 +5807,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
@@ -5831,7 +5831,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
@@ -5855,7 +5855,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
@@ -5879,7 +5879,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
@@ -5903,7 +5903,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki
@@ -5927,7 +5927,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
@@ -5951,7 +5951,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
@@ -5975,7 +5975,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
@@ -5999,7 +5999,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
@@ -6023,7 +6023,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki
@@ -6047,7 +6047,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
@@ -6071,7 +6071,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
@@ -6095,7 +6095,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
@@ -6119,7 +6119,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
@@ -6143,7 +6143,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
@@ -6167,7 +6167,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
@@ -6191,7 +6191,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
@@ -6215,7 +6215,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
@@ -6239,7 +6239,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
@@ -6263,7 +6263,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
@@ -6287,7 +6287,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki
@@ -6311,7 +6311,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
@@ -6335,7 +6335,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
@@ -6359,7 +6359,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki
@@ -6383,7 +6383,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
@@ -6407,7 +6407,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
@@ -6431,7 +6431,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
@@ -6455,7 +6455,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki
@@ -6479,7 +6479,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
@@ -6503,7 +6503,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
@@ -6527,7 +6527,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki
@@ -6551,7 +6551,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_sex_female_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_sex_female_preex_FALSE-aki
@@ -6575,7 +6575,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_sex_female_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_sex_female_preex_FALSE-aki
@@ -6599,7 +6599,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_sex_female_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_sex_female_preex_FALSE-aki
@@ -6623,7 +6623,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_sex_female_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_sex_female_preex_TRUE-aki
@@ -6647,7 +6647,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_sex_female_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_sex_female_preex_TRUE-aki
@@ -6671,7 +6671,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_sex_female_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_sex_female_preex_TRUE-aki
@@ -6695,7 +6695,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_sex_male_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_FALSE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_sex_male_preex_FALSE-aki
@@ -6719,7 +6719,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_sex_male_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_sex_male_preex_FALSE-aki
@@ -6743,7 +6743,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd.dta
 
   stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-ckd:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-ckd
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-ckd
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd
@@ -6767,7 +6767,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_sex_male_preex_FALSE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_sex_male_preex_FALSE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_FALSE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_FALSE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_sex_male_preex_FALSE-aki
@@ -6791,7 +6791,7 @@ actions:
         ready: output/model/ready-cohort_prevax-sub_sex_male_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_prevax-sub_sex_male_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_TRUE-aki
       1;28;183;365;730;1095;1460;1979 2020-01-01
     needs:
     - ready-cohort_prevax-sub_sex_male_preex_TRUE-aki
@@ -6815,7 +6815,7 @@ actions:
         ready: output/model/ready-cohort_unvax-sub_sex_male_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_unvax-sub_sex_male_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-sub_sex_male_preex_TRUE-aki
@@ -6839,7 +6839,7 @@ actions:
         ready: output/model/ready-cohort_vax-sub_sex_male_preex_TRUE-aki.dta
 
   stata_cox_ipw-cohort_vax-sub_sex_male_preex_TRUE-aki:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_TRUE-aki
+    run: stata-mp:v1 analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_TRUE-aki
       1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_vax-sub_sex_male_preex_TRUE-aki

--- a/project.yaml
+++ b/project.yaml
@@ -4063,6 +4063,2790 @@ actions:
       moderately_sensitive:
         model_output: output/model/model_output-cohort_vax-sub_sex_male_preex_TRUE-esrd.csv
 
+  ready-cohort_prevax-main_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-main_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-main_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-main_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-main_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-main_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-main_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-main_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-main_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-main_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-main_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-main_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-main_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-main_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-main_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-main_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-main_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-main_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-main_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-main_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-main_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-main_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-main_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-main_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-main_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-main_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-main_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-main_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-main_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-main_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-main_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-main_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-main_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-main_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-main_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-main_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-main_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-main_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-main_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-main_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-main_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-main_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-main_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-main_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-main_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-main_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-main_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-main_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-main_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-main_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-main_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-main_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-main_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-main_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-main_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-main_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-main_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-main_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-main_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_unvax-main_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-main_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_unvax-main_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-main_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-main_preex_TRUE-esrd.csv
+
+  ready-cohort_vax-main_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-main_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-main_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-main_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-main_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-main_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-main_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-main_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-main_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-main_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_18_39_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_18_39_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_18_39_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_18_39_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_18_39_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_18_39_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_18_39_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_18_39_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_18_39_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_18_39_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_18_39_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_18_39_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_age_18_39_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_18_39_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_18_39_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_18_39_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_18_39_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_18_39_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_18_39_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_18_39_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_18_39_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_18_39_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_18_39_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_18_39_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_18_39_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_18_39_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_18_39_preex_TRUE-esrd.csv
+
+  ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_18_39_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_18_39_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_18_39_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_18_39_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_age_18_39_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_18_39_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_18_39_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_18_39_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_18_39_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_18_39_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_18_39_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_18_39_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_18_39_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_40_59_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_40_59_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_40_59_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_40_59_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_40_59_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_40_59_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_40_59_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_40_59_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_40_59_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_age_40_59_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_40_59_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_40_59_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_40_59_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_40_59_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_40_59_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_40_59_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_40_59_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_40_59_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_40_59_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_40_59_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_40_59_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_40_59_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_40_59_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_40_59_preex_TRUE-esrd.csv
+
+  ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_40_59_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_40_59_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_40_59_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_40_59_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_age_40_59_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_40_59_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_40_59_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_40_59_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_40_59_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_40_59_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_40_59_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_40_59_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_40_59_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_40_59_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_40_59_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_40_59_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_40_59_preex_TRUE-esrd.csv
+
+  ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_60_79_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_60_79_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_60_79_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_60_79_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_60_79_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_60_79_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_age_60_79_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_60_79_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_60_79_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_60_79_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_60_79_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_60_79_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_60_79_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_60_79_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_60_79_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_60_79_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_60_79_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_60_79_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_60_79_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_60_79_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_60_79_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_60_79_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_age_60_79_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_60_79_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_60_79_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_60_79_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_60_79_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_60_79_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_60_79_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_60_79_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_60_79_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_80_110_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_80_110_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_80_110_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_80_110_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_80_110_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_80_110_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_80_110_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_80_110_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_80_110_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_age_80_110_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_80_110_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_80_110_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_80_110_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_80_110_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_80_110_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_80_110_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_80_110_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_age_80_110_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_age_80_110_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_age_80_110_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_age_80_110_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_age_80_110_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_age_80_110_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_age_80_110_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_age_80_110_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_age_80_110_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_age_80_110_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=FALSE --save_analysis_ready=model/ready-cohort_vax-sub_age_80_110_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_age_80_110_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_age_80_110_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_age_80_110_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_age_80_110_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_age_80_110_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_age_80_110_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhistory_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhistory_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhistory_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhistory_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhistory_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhistory_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_covidhistory_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhistory_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhistory_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhistory_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhistory_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhistory_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhistory_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhistory_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhistory_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhistory_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhistory_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhistory_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhistory_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhistory_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhistory_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhistory_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhistory_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhistory_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhistory_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhistory_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhistory_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhistory_preex_TRUE-esrd.csv
+
+  ready-cohort_vax-sub_covidhistory_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhistory_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhistory_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhistory_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhistory_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhistory_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhistory_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhistory_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhistory_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhistory_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhistory_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhistory_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhistory_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhistory_preex_TRUE-esrd.csv
+
+  ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+
+  ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+
+  ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd.csv
+
+  ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_black_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_black_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd.csv
+
+  ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd.csv
+
+  ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_black_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_black_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_black_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd.csv
+
+  ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_other_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_other_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_other_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_other_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd.csv
+
+  ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_white_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_white_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_white_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_ethnicity_white_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_white_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_sex_female_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_female_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_sex_female_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_sex_female_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_sex_female_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_sex_female_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_sex_female_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_sex_female_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_sex_female_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_sex_female_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_sex_female_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_sex_female_preex_FALSE-aki.csv
+
+  ready-cohort_vax-sub_sex_female_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_female_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_female_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_female_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_sex_female_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_sex_female_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_sex_female_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_sex_female_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_female_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_sex_female_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_sex_female_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_sex_female_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_female_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_sex_female_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_sex_female_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_sex_female_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_sex_female_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_sex_female_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_sex_female_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_female_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_sex_female_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_sex_female_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_female_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_female_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_female_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_sex_female_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_sex_female_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_sex_female_preex_TRUE-aki.csv
+
+  ready-cohort_prevax-sub_sex_male_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_male_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_sex_male_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_sex_male_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_sex_male_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_FALSE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_sex_male_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_sex_male_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_sex_male_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_sex_male_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_sex_male_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_sex_male_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_sex_male_preex_FALSE-aki.csv
+
+  ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_sex_male_preex_FALSE-ckd.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_sex_male_preex_FALSE-ckd.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_sex_male_preex_FALSE-ckd
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd.dta
+
+  stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-ckd:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_FALSE-ckd
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_sex_male_preex_FALSE-ckd
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_sex_male_preex_FALSE-ckd.csv
+
+  ready-cohort_vax-sub_sex_male_preex_FALSE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_male_preex_FALSE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_male_preex_FALSE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_male_preex_FALSE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_sex_male_preex_FALSE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_sex_male_preex_FALSE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_FALSE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_sex_male_preex_FALSE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_sex_male_preex_FALSE-aki.csv
+
+  ready-cohort_prevax-sub_sex_male_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_male_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2020-01-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460;1979 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_prevax-sub_sex_male_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_prevax-sub_sex_male_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_prevax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_prevax-sub_sex_male_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_prevax-sub_sex_male_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-sub_sex_male_preex_TRUE-aki
+      1;28;183;365;730;1095;1460;1979 2020-01-01
+    needs:
+    - ready-cohort_prevax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_prevax-sub_sex_male_preex_TRUE-aki.csv
+
+  ready-cohort_unvax-sub_sex_male_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_sex_male_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_sex_male_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_sex_male_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_unvax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_unvax-sub_sex_male_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_unvax-sub_sex_male_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_sex_male_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_unvax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_unvax-sub_sex_male_preex_TRUE-aki.csv
+
+  ready-cohort_vax-sub_sex_male_preex_TRUE-aki:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_male_preex_TRUE-aki.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_copd;cov_bin_stroke_isch;cov_bin_aki
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_male_preex_TRUE-aki.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_male_preex_TRUE-aki.csv
+    needs:
+    - make_model_input-cohort_vax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_sex_male_preex_TRUE-aki.dta
+
+  stata_cox_ipw-cohort_vax-sub_sex_male_preex_TRUE-aki:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_male_preex_TRUE-aki
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_sex_male_preex_TRUE-aki
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_sex_male_preex_TRUE-aki.csv
+
   ## Generate make-flow-output 
 
   make-flow-output:
@@ -4215,18 +6999,18 @@ actions:
   make_model_output-main:
     run: r:v2 analysis/make_output/make_model_output.R main
     needs:
-    - cox_ipw-cohort_prevax-main_preex_FALSE-aki
     - cox_ipw-cohort_prevax-main_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-main_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-main_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-main_preex_FALSE-aki
     - cox_ipw-cohort_vax-main_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-main_preex_TRUE-aki
     - cox_ipw-cohort_prevax-main_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-main_preex_TRUE-aki
-    - cox_ipw-cohort_unvax-main_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-main_preex_TRUE-aki
     - cox_ipw-cohort_vax-main_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-main_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-main_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-main_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-main_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-main_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-main_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-main_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_vax-main_preex_TRUE-aki
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-main.csv
@@ -4237,54 +7021,54 @@ actions:
   make_model_output-sub_age:
     run: r:v2 analysis/make_output/make_model_output.R sub_age
     needs:
-    - cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-aki
-    - cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_age_18_39_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_age_18_39_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-aki
-    - cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_age_18_39_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_age_18_39_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_age_18_39_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_age_18_39_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_age_40_59_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_age_40_59_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_age_40_59_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_age_40_59_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-aki
-    - cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_age_40_59_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_age_40_59_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-aki
-    - cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_age_60_79_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_age_60_79_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_age_60_79_preex_FALSE-aki
     - cox_ipw-cohort_unvax-sub_age_60_79_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_age_60_79_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_age_60_79_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_age_60_79_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_age_60_79_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_age_60_79_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_age_60_79_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_age_60_79_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_age_60_79_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_age_80_110_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_age_80_110_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_age_80_110_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_age_80_110_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_age_80_110_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_age_80_110_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_age_80_110_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_age_80_110_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_age_80_110_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_age_80_110_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_age_18_39_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_18_39_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_unvax-sub_age_18_39_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_18_39_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_age_40_59_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_40_59_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_unvax-sub_age_40_59_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_40_59_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_60_79_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_60_79_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_60_79_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_60_79_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_age_80_110_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_age_80_110_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_age_80_110_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_age_80_110_preex_TRUE-aki
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-sub_age.csv
@@ -4295,14 +7079,15 @@ actions:
   make_model_output-sub_covidhistory:
     run: r:v2 analysis/make_output/make_model_output.R sub_covidhistory
     needs:
-    - cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-aki
-    - cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-aki
-    - cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-aki
-    - cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-esrd
+    - cox_ipw-
+    - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_covidhistory_preex_TRUE-esrd
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-sub_covidhistory.csv
@@ -4313,30 +7098,30 @@ actions:
   make_model_output-sub_covidhospital:
     run: r:v2 analysis/make_output/make_model_output.R sub_covidhospital
     needs:
-    - cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
-    - cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
-    - cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
-    - cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
-    - cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_FALSE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_FALSE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_covidhospital_FALSE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_covidhospital_TRUE_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_covidhospital_TRUE_preex_TRUE-esrd
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-sub_covidhospital.csv
@@ -4347,66 +7132,66 @@ actions:
   make_model_output-sub_ethnicity:
     run: r:v2 analysis/make_output/make_model_output.R sub_ethnicity
     needs:
-    - cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_asian_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_asian_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
-    - cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-aki
-    - cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
-    - cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_black_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_ethnicity_black_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_black_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
-    - cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
-    - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
-    - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_ethnicity_white_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_white_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_ethnicity_white_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_ethnicity_white_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_ethnicity_white_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_asian_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_asian_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_asian_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_black_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_black_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_black_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_ethnicity_white_preex_TRUE-aki
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-sub_ethnicity.csv
@@ -4417,30 +7202,30 @@ actions:
   make_model_output-sub_sex:
     run: r:v2 analysis/make_output/make_model_output.R sub_sex
     needs:
-    - cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-aki
     - cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-esrd
-    - cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-aki
     - cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-ckd
-    - cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-aki
-    - cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-ckd
-    - cox_ipw-cohort_vax-sub_sex_male_preex_FALSE-aki
     - cox_ipw-cohort_vax-sub_sex_male_preex_FALSE-ckd
-    - cox_ipw-cohort_prevax-sub_sex_male_preex_TRUE-aki
     - cox_ipw-cohort_prevax-sub_sex_male_preex_TRUE-esrd
-    - cox_ipw-cohort_unvax-sub_sex_male_preex_TRUE-aki
     - cox_ipw-cohort_unvax-sub_sex_male_preex_TRUE-esrd
-    - cox_ipw-cohort_vax-sub_sex_male_preex_TRUE-aki
     - cox_ipw-cohort_vax-sub_sex_male_preex_TRUE-esrd
+    - stata_cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-aki
+    - stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-aki
+    - stata_cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-aki
+    - stata_cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-ckd
+    - stata_cox_ipw-cohort_vax-sub_sex_male_preex_FALSE-aki
+    - stata_cox_ipw-cohort_prevax-sub_sex_male_preex_TRUE-aki
+    - stata_cox_ipw-cohort_unvax-sub_sex_male_preex_TRUE-aki
+    - stata_cox_ipw-cohort_vax-sub_sex_male_preex_TRUE-aki
     outputs:
       moderately_sensitive:
         model_output: output/make_output/model_output-sub_sex.csv

--- a/project.yaml
+++ b/project.yaml
@@ -1,9 +1,5 @@
 version: '5.0'
 
-expectations:
-
-  population_size: 5000
-
 actions:
 
   ## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
@@ -7079,7 +7075,6 @@ actions:
   make_model_output-sub_covidhistory:
     run: r:v2 analysis/make_output/make_model_output.R sub_covidhistory
     needs:
-    - cox_ipw-
     - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-aki
     - stata_cox_ipw-cohort_unvax-sub_covidhistory_preex_FALSE-ckd
     - stata_cox_ipw-cohort_vax-sub_covidhistory_preex_FALSE-aki


### PR DESCRIPTION
Added in workflow to identify via code (find_unconverged_models.R) unconverged models, and also to add in models identified on examination of results to potentially run via Stata. Includes the code necessary to run Stata models, and identifies them via create_project_actions.R. Includes the extra ados needed to run the models in Stata. This includes a fix for when all models of a subgroup are Stata models - otherwise the 'needs' do not work and it creates an empty cox-ipw need.  (see this [commit](https://github.com/opensafely/post-covid-renal/commit/152165b39d62b7e839be75b35095b9a8f43c40bf)) 